### PR TITLE
docs: AI team onboarding architecture profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# BexioApiNet
+
+BexioApiNet is a .NET client library for the Bexio REST API (v3.0.0). It provides strongly-typed abstractions, domain models, and connector services to interact with Bexio's accounting, banking, and tax endpoints. The library simplifies API consumption by handling authentication, raw HTTP request execution, automatic pagination, and error serialization. It also includes an ASP.NET Core integration package to easily register the client via dependency injection.
+
+## Tech Stack
+- **Language**: C# 13
+- **Framework**: .NET 9.0
+- **Testing**: NUnit 4, Coverlet
+- **Core Dependencies**: `Microsoft.Extensions.DependencyInjection` (for the AspNetCore package), `System.Text.Json`
+
+## Solution Structure
+The solution `BexioApiNet.sln` is organized into four projects:
+- `src/BexioApiNet.Abstractions`: Contains the domain models (DTOs), interfaces, exceptions, and enums. It holds no implementation logic.
+- `src/BexioApiNet`: The core implementation library. Contains `BexioApiClient`, `BexioConnectionHandler`, and the various connector services (e.g., `ManualEntryService`).
+- `src/BexioApiNet.AspNetCore`: Provides `IServiceCollection` extension methods to register BexioApiNet in ASP.NET Core applications.
+- `src/BexioApiNet.Tests`: Integration tests utilizing NUnit.
+
+## Build Commands
+- **Restore**: `dotnet restore`
+- **Build**: `dotnet build`
+- **Test**: `dotnet test` (Note: Tests require actual API credentials. See 'Constraints & Gotchas')
+- **Pack**: `dotnet pack` (NuGet packages are automatically generated on build via `GeneratePackageOnBuild`)
+
+## Key Conventions
+- **ApiResult Wrapper**: All API calls return an `ApiResult<T>` (or `ApiResult`) instead of throwing exceptions on non-2xx status codes. This wrapper contains the `IsSuccess` boolean, `StatusCode`, `ApiError` details, `Data`, and extracted `ResponseHeaders`.
+- **Connector Pattern**: API endpoints are grouped logically into namespaces (e.g., `Accounting`, `Banking`) and implemented as individual connector services inheriting from `ConnectorService`.
+- **Dependency Injection**: The core `BexioApiClient` aggregates all connector services and is designed to be injected via `IBexioApiClient`.
+- **Query Parameters**: Optional query parameters are wrapped in domain-specific parameter objects extending `QueryParameter` (e.g., `QueryParameterManualEntry`).
+
+## Important File Locations
+- **Entry Point (DI)**: `src/BexioApiNet.AspNetCore/BexioServiceCollection.cs`
+- **Main Client Interface**: `src/BexioApiNet/Interfaces/IBexioApiClient.cs`
+- **Connection Handler**: `src/BexioApiNet/Services/BexioConnectionHandler.cs` (Handles HTTP execution and pagination)
+- **Domain Models**: `src/BexioApiNet.Abstractions/Models/` (Grouped by domain, e.g., `Accounting/ManualEntries/`)
+
+## Constraints & Gotchas
+- **Testing Requirements**: The `BexioApiNet.Tests` project does not mock the API. It makes live calls to Bexio. To run tests, you MUST set the environment variables `BexioApiNet__BaseUri` and `BexioApiNet__JwtToken`.
+- **Pagination**: The `BexioConnectionHandler.FetchAll<T>` method automatically handles Bexio's offset-based pagination to retrieve all available records when requested.
+- **HTTP Client Lifecycle**: `BexioConnectionHandler` manages its own `HttpClient` instance. Ensure proper disposal of `IBexioApiClient` or rely on the DI container's scoped lifecycle management.

--- a/doc/ai-readiness.md
+++ b/doc/ai-readiness.md
@@ -1,0 +1,66 @@
+---
+title: AI Readiness Assessment
+tags: [readiness, ai, assessment]
+---
+
+# AI Readiness Assessment
+
+## Section 1: Documentation Quality
+The documentation landscape for this project is well-structured but lacks formal AI-specific instructions.
+
+- **What exists and is useful**:
+  - A `CLAUDE.md` file exists in the repository root, providing high-level tech stack details, key conventions, and important file locations.
+  - Comprehensive C4 architecture models and ADRs are located in `doc/architecture/` (`README.md`, `context.md`, `containers.md`, `components/library.md`, `glossary.md`).
+  - The `README.md` clearly states the purpose of the project and its discontinuation status.
+- **What is missing or insufficient**:
+  - There is no standard `ai_instructions.md` file in the root.
+  - The API docs link in `README.md` points to Bexio's v3 API, but it would be beneficial for AI agents to have local OpenAPI specifications to generate models from.
+- **What needs improvement**:
+  - The project needs an `ai_instructions.md` to formally instruct AI agents (replacing or complementing the existing `CLAUDE.md`).
+- **Rate**: Ready
+
+## Section 2: Test Coverage
+The testing approach is integration-heavy and relies entirely on live API connectivity.
+
+- **Test frameworks in use**: 
+  - NUnit 4 and Coverlet, configured in `src/BexioApiNet.Tests/BexioApiNet.Tests.csproj`.
+  - **Run command**: `dotnet test src/BexioApiNet.Tests/BexioApiNet.Tests.csproj`
+- **What IS covered**: 
+  - `Accounting/Accounts/GetAll`
+  - `Accounting/Currencies/GetAll`
+  - `Accounting/ManualEntries` (Create, CreateAndAddFile, CreateAndAddFileFromStream, GetAll, GetAllAndDelete)
+  - `Accounting/Taxes/GetAll`
+  - `Banking/BankAccount/GetAll`
+  - *(See `src/BexioApiNet.Tests/Tests/` directory for full list)*
+- **What is NOT covered**: 
+  - There are no unit tests using a mocked `HttpMessageHandler`.
+  - Significant portions of the Bexio API (e.g., Contacts, Invoices, Items) are missing both library implementation and tests.
+- **Test quality assessment**: 
+  - Tests are high-fidelity integration tests but are **brittle** and impossible to run without live credentials. As seen in `src/BexioApiNet.Tests/TestBase.cs` lines 42-43, tests will throw `InvalidOperationException` if `BexioApiNet__BaseUri` and `BexioApiNet__JwtToken` environment variables are missing.
+- **Rate**: Partial Coverage
+
+## Section 3: Technical Debt & Danger Zones
+
+### 1. Live Integration Testing (Danger Zone)
+- **Location**: `src/BexioApiNet.Tests/TestBase.cs` lines 42-43
+- **Why it's dangerous**: Running `dotnet test` requires real Bexio API credentials. If an AI agent attempts to run tests during code changes without these credentials, the test suite will instantly fail. AI agents cannot verify their changes properly.
+- **Precautions**: Agents must avoid running `dotnet test` unless specifically provided with environment credentials. Instead, agents should rely on building (`dotnet build`) to check for compilation errors, and mock components where possible.
+
+### 2. HttpClient Lifecycle Management (Technical Debt)
+- **Location**: `src/BexioApiNet/Services/BexioConnectionHandler.cs` line 36
+- **Why it's dangerous**: `BexioConnectionHandler` instantiates and manages its own `HttpClient` (`_client = new(new HttpClientHandler...)`). In ASP.NET Core applications, this can lead to socket exhaustion under heavy load. It does not use `IHttpClientFactory`.
+- **Precautions**: Any AI agent modifying the HTTP pipeline must be careful not to introduce more manual `HttpClient` instantiations. A refactoring to `IHttpClientFactory` should be planned.
+
+### 3. Incomplete API Coverage (Known Debt)
+- **Location**: `README.md` and `src/BexioApiNet/Interfaces/Connectors/`
+- **Why it's dangerous**: The `README.md` notes the project is temporarily discontinued due to a lack of free test accounts. Many Bexio domains (Contacts, Projects, Invoices) are not implemented. 
+- **Precautions**: When an AI is asked to implement a new Bexio endpoint, it will have to create new Connector Services, Models, and Interfaces from scratch following the existing pattern.
+
+## Section 4: Backlog Ideas
+
+| Title | Description | Complexity | Priority |
+|-------|-------------|------------|----------|
+| Refactor to `IHttpClientFactory` | Modify `BexioConnectionHandler` and `BexioApiNet.AspNetCore` to utilize `IHttpClientFactory` instead of manual `HttpClient` instantiation to prevent socket exhaustion. | M | High |
+| Add Offline Unit Tests | Create a suite of unit tests utilizing a mocked `HttpMessageHandler` to allow testing API parsing and logic without live Bexio credentials. | M | High |
+| Create `ai_instructions.md` | Standardize AI instructions by migrating rules from `CLAUDE.md` to `ai_instructions.md` and adding explicit notes about testing constraints. | S | Low |
+| Expand API Connectors | Implement missing Bexio API endpoints such as Contacts, Invoices, and Projects based on the existing `ConnectorService` pattern. | L | Medium |

--- a/doc/architecture/README.md
+++ b/doc/architecture/README.md
@@ -1,0 +1,15 @@
+# BexioApiNet Architecture Documentation
+
+Welcome to the architecture documentation for BexioApiNet. This project uses the C4 model for structural diagrams and Architecture Decision Records (ADRs) to capture design constraints.
+
+## C4 Models
+1. [System Context](context.md) - High-level context and external actors.
+2. [Container Architecture](containers.md) - NuGet packages and deployable units.
+3. [Library Components](components/library.md) - Internal library mechanics and request flows.
+
+## Architecture Decision Records
+- [ADR-001: ApiResult Wrapper Pattern](decisions/001-apiresult-wrapper.md)
+- [ADR-002: Service Connector Partitioning](decisions/002-service-connector-pattern.md)
+
+## Reference
+- [Domain Glossary](glossary.md)

--- a/doc/architecture/components/library.md
+++ b/doc/architecture/components/library.md
@@ -1,0 +1,45 @@
+---
+title: Library Components
+tags: [architecture, c4, components]
+---
+
+# Internal Library Components: BexioApiNet Core
+
+This diagram details the internal structure of the `BexioApiNet` implementation project and how requests are processed.
+
+## C4 Component Diagram
+
+```mermaid
+C4Component
+  title Component diagram for BexioApiNet Core
+
+  Container_Boundary(core, "BexioApiNet") {
+    Component(bexioApiClient, "BexioApiClient", "Facade", "Aggregates all connector services. Main entry point for developers.")
+    
+    Component(accountingConnectors, "Accounting Services", "ConnectorService", "Handles ManualEntries, Accounts, Currencies, Taxes.")
+    Component(bankingConnectors, "Banking Services", "ConnectorService", "Handles BankAccounts.")
+    
+    Component(connectionHandler, "BexioConnectionHandler", "HTTP execution", "Manages HttpClient, Bearer token injection, request building, pagination, and response deserialization.")
+  }
+
+  Container(abstractions, "BexioApiNet.Abstractions", "Domain Models", "ApiResult<T>, QueryParameters, etc.")
+  System_Ext(bexioApi, "Bexio REST API", "Upstream API")
+
+  Rel(bexioApiClient, accountingConnectors, "Delegates to")
+  Rel(bexioApiClient, bankingConnectors, "Delegates to")
+  
+  Rel(accountingConnectors, connectionHandler, "Uses for HTTP")
+  Rel(bankingConnectors, connectionHandler, "Uses for HTTP")
+  
+  Rel(connectionHandler, bexioApi, "Executes HTTP requests")
+  Rel(connectionHandler, abstractions, "Deserializes into models")
+```
+
+## Component Breakdown
+
+| Component | Responsibility | Path |
+|-----------|----------------|------|
+| **BexioApiClient** | Facade implementing `IBexioApiClient`. Provides convenient properties (e.g., `AccountingManualEntries`, `BankingBankAccounts`) to access specific service areas. | `src/BexioApiNet/Services/BexioApiClient.cs` |
+| **Connector Services** | Concrete services inheriting from `ConnectorService` (e.g., `ManualEntryService`, `BankAccountService`). They construct specific API paths (using structures like `ManualEntryConfiguration`) and define typed methods for GET, POST, DELETE. | `src/BexioApiNet/Services/Connectors/` |
+| **BexioConnectionHandler** | Implements `IBexioConnectionHandler`. Wraps `HttpClient`. Applies authorization and accept headers. Contains robust methods for fetching single objects, executing multipart file uploads, and auto-paginating through collection endpoints. | `src/BexioApiNet/Services/BexioConnectionHandler.cs` |
+| **Query Parameters** | Wrappers for dictionary-based optional URL queries. Handled systematically by the `BexioConnectionHandler` during URL construction. | `src/BexioApiNet/Models/` |

--- a/doc/architecture/containers.md
+++ b/doc/architecture/containers.md
@@ -1,0 +1,44 @@
+---
+title: Container Architecture
+tags: [architecture, c4, containers]
+---
+
+# Container Architecture: BexioApiNet
+
+The BexioApiNet solution is partitioned into separate NuGet packages to minimize dependencies and strictly separate domain definitions from ASP.NET Core integrations.
+
+## C4 Container Diagram
+
+```mermaid
+C4Container
+  title Container diagram for BexioApiNet
+
+  Person(developer, "Developer / .NET App", "Consumes the library")
+
+  System_Boundary(bexioApiNet, "BexioApiNet SDK") {
+    Container(abstractions, "BexioApiNet.Abstractions", "NuGet Package (.NET 9)", "Provides interfaces, domain models (DTOs), and enums. No external dependencies.")
+    Container(core, "BexioApiNet", "NuGet Package (.NET 9)", "Provides core API client implementation, connectors, and HTTP handling.")
+    Container(aspnetcore, "BexioApiNet.AspNetCore", "NuGet Package (.NET 9)", "Provides IServiceCollection extensions for Microsoft.Extensions.DependencyInjection.")
+  }
+
+  System_Ext(bexioApi, "Bexio REST API", "Upstream API")
+
+  Rel(developer, aspnetcore, "Registers services via", "C#")
+  Rel(developer, abstractions, "Uses models from", "C#")
+  Rel(developer, core, "Injects IBexioApiClient from", "C#")
+
+  Rel(aspnetcore, core, "References")
+  Rel(aspnetcore, abstractions, "References")
+  Rel(core, abstractions, "References")
+
+  Rel(core, bexioApi, "Makes REST requests", "HTTPS/JSON")
+```
+
+## Deployable Units
+
+| Container | Path | Responsibility |
+|-----------|------|----------------|
+| **BexioApiNet.Abstractions** | `src/BexioApiNet.Abstractions/` | Defines the contract. Contains all domain models mapped to the Bexio API schema, enums (like `ApiResponseCodes`), exceptions, and connector interfaces. |
+| **BexioApiNet** | `src/BexioApiNet/` | The actual implementation. Contains the `BexioConnectionHandler` (HTTP client logic) and service implementations (e.g., `ManualEntryService`, `AccountService`). |
+| **BexioApiNet.AspNetCore** | `src/BexioApiNet.AspNetCore/` | A lightweight wrapper adding ASP.NET Core dependency injection compatibility (`AddBexioServices()`). |
+| **BexioApiNet.Tests** | `src/BexioApiNet.Tests/` | *Not deployed.* NUnit integration tests validating real API calls against Bexio. |

--- a/doc/architecture/context.md
+++ b/doc/architecture/context.md
@@ -1,0 +1,35 @@
+---
+title: System Context
+tags: [architecture, c4, context]
+---
+
+# System Context: BexioApiNet
+
+BexioApiNet acts as a bridge between .NET applications and the Bexio REST API, encapsulating HTTP communication, authentication, and error handling.
+
+## C4 System Context Diagram
+
+```mermaid
+C4Context
+  title System Context diagram for BexioApiNet
+
+  Person(developer, "Developer / .NET App", "A developer or a .NET application consuming the Bexio API")
+  
+  System(bexioApiNet, "BexioApiNet", ".NET SDK for Bexio API")
+  System_Ext(bexioApi, "Bexio REST API", "The official Bexio REST API (v3.0.0) providing access to accounting, banking, contacts, etc.")
+
+  Rel(developer, bexioApiNet, "Uses", "C# / .NET")
+  Rel(bexioApiNet, bexioApi, "Makes API calls to", "HTTPS / JSON")
+```
+
+## Actors
+
+| Actor | Description |
+|-------|-------------|
+| Developer / .NET App | Any third-party application or developer that needs to integrate with Bexio to manage accounting, taxes, or banking data. |
+
+## External Systems
+
+| System | Description |
+|--------|-------------|
+| Bexio REST API | The upstream SaaS platform API that manages the actual business data. |

--- a/doc/architecture/decisions/001-apiresult-wrapper.md
+++ b/doc/architecture/decisions/001-apiresult-wrapper.md
@@ -1,0 +1,18 @@
+# ADR-001: ApiResult Wrapper Pattern
+
+## Context
+When interacting with the Bexio REST API, HTTP calls can fail for various reasons (404 Not Found, 400 Bad Request, 429 Too Many Requests, etc.). Bexio typically returns a structured JSON error body. Traditional .NET libraries might throw an `HttpRequestException` or custom exceptions upon encountering non-2xx status codes. However, exception-based flow control for expected HTTP states can be costly and requires developers to implement wide `try-catch` blocks. Furthermore, Bexio provides valuable rate-limiting and pagination headers with responses.
+
+## Decision
+All connector methods in the `BexioApiNet` SDK return an `ApiResult<T>` (or non-generic `ApiResult`) instead of throwing exceptions for API errors.
+
+The `ApiResult<T>` record encapsulates:
+- `IsSuccess` boolean mapping to the HTTP status.
+- `StatusCode` containing the exact HTTP code.
+- `Data` containing the deserialized generic model (if successful).
+- `ApiError` containing the deserialized Bexio error model (if unsuccessful).
+- `ResponseHeaders` containing extracted meta-information like `RequestLimit`, `AppliedOffset`, and `TotalResults`.
+
+## Consequences
+- **Pros:** Safer error handling without try-catch blocks. Easy access to rate-limit headers. Unified mechanism for both successful requests and structured error decoding.
+- **Cons:** Developers must explicitly check `.IsSuccess` before accessing `.Data`, requiring slightly more boilerplate at the call site.

--- a/doc/architecture/decisions/002-service-connector-pattern.md
+++ b/doc/architecture/decisions/002-service-connector-pattern.md
@@ -1,0 +1,15 @@
+# ADR-002: Service Connector Partitioning
+
+## Context
+The Bexio REST API covers a vast domain including Accounting, Banking, Contacts, Invoices, Orders, Projects, and more. Creating a single monolithic client class (e.g., `BexioClient`) with hundreds of methods would lead to an unmaintainable "God class" that violates the Single Responsibility Principle and is difficult to test.
+
+## Decision
+We implemented a Service Connector pattern. The API is divided into logical namespaces (e.g., `Accounting`, `Banking`) mirroring Bexio's own domain structure. 
+
+- An abstract base class `ConnectorService` holds common dependencies (like the `BexioConnectionHandler`).
+- Each logical endpoint gets its own dedicated service implementation (e.g., `ManualEntryService`, `AccountService`).
+- A central facade `BexioApiClient` aggregates these services into a single discoverable interface (`IBexioApiClient`) for easy consumer access (e.g., `bexio.AccountingManualEntries.Create(...)`).
+
+## Consequences
+- **Pros:** High cohesion. Easy to scale and maintain as the Bexio API grows. Logical grouping makes it easier for consumers via IntelliSense. Separation of concerns.
+- **Cons:** Increased class count. Dependency Injection registration (in `BexioServiceCollection`) requires adding every new connector explicitly.

--- a/doc/architecture/glossary.md
+++ b/doc/architecture/glossary.md
@@ -1,0 +1,15 @@
+---
+title: Glossary
+tags: [architecture, glossary]
+---
+
+# Domain Glossary
+
+This glossary defines terms specific to the BexioApiNet domain and the Bexio API.
+
+| Term | Definition |
+|------|------------|
+| **Manual Entry** | A journal entry in accounting (`Accounting/ManualEntries`). Represents an explicit booking against accounts, containing multiple sub-entries. |
+| **ApiResult** | The wrapper class used consistently across BexioApiNet to encapsulate API responses, errors, HTTP status codes, and rate-limit headers. |
+| **Connector** | A localized service class (e.g., `ManualEntryService`) dedicated to a specific set of endpoints within the Bexio API, responsible for defining the routes and strongly-typed request/response models. |
+| **BexioConnectionHandler** | The internal component in the library responsible for processing raw HTTP requests, injecting authentication, handling offset-based auto-pagination (`FetchAll`), and executing multi-part form uploads. |


### PR DESCRIPTION
## AI Team Onboarding: BexioApiNet

Automated onboarding documentation for `AMANDA-Technology/BexioApiNet`.
Mode: **Standard** | Projects: **4** | Stack: **.NET 9 / C# 13**

### Deliverables
- `CLAUDE.md` — Project description, build commands, conventions, ApiResult pattern, DI entry points, live-credential test warning
- `doc/architecture/` — 8 files: context (C4 L1), containers (C4 L2), component deep-dive, 2 ADRs, glossary, README
- `doc/ai-readiness.md` — **Partial Coverage** (integration tests require live Bexio credentials)

### Key Findings
- **Danger zone — `dotnet test`**: Tests hit the live Bexio API. Agents must not run `dotnet test` without `BexioApiNet__BaseUri` + `BexioApiNet__JwtToken` env vars; use `dotnet build` to verify compilation instead.
- **HttpClient debt**: `BexioConnectionHandler` instantiates `HttpClient` directly (no `IHttpClientFactory`) — socket exhaustion risk under load; agents should not introduce more manual instantiations.
- **Incomplete API coverage**: Many Bexio domains (Contacts, Invoices, Projects) are not yet implemented — new connectors must be scaffolded from scratch following the existing `ConnectorService` pattern.

### Backlog Ideas (in `doc/ai-readiness.md`)
| Title | Complexity | Priority |
|-------|-----------|----------|
| Refactor to `IHttpClientFactory` | M | High |
| Add offline unit tests (mocked `HttpMessageHandler`) | M | High |
| Expand API connectors (Contacts, Invoices, Projects) | L | Medium |

### Ready for Review
All onboarding documentation has been committed. Please review and merge when satisfied.

Closes #1