### PR TITLE
ci(issue-6): add PR build + offline unit-test workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,32 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    name: Build and test (offline)
+    runs-on: ubuntu-latest
+
+    env:
+      BUILD_CONFIG: Release
+      SOLUTION: BexioApiNet.sln
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.x
+
+      - name: Restore
+        run: dotnet restore ${{ env.SOLUTION }}
+
+      - name: Build (warnings as errors)
+        run: dotnet build ${{ env.SOLUTION }} --configuration ${{ env.BUILD_CONFIG }} --no-restore /warnaserror
+
+      - name: Test (offline, skip E2E)
+        run: dotnet test ${{ env.SOLUTION }} --configuration ${{ env.BUILD_CONFIG }} --no-build --filter TestCategory!=E2E

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ See [Bexio website](https://www.bexio.com/).
 
 [![BuildNuGetAndPublish](https://github.com/AMANDA-Technology/BexioApiNet/actions/workflows/main.yml/badge.svg)](https://github.com/AMANDA-Technology/BexioApiNet/actions/workflows/main.yml)
 
+[![PR CI](https://github.com/AMANDA-Technology/BexioApiNet/actions/workflows/pr.yml/badge.svg)](https://github.com/AMANDA-Technology/BexioApiNet/actions/workflows/pr.yml)
+
 [![CodeQL](https://github.com/AMANDA-Technology/BexioApiNet/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/AMANDA-Technology/BexioApiNet/actions/workflows/codeql-analysis.yml)
 
 [![SonarCloud](https://github.com/AMANDA-Technology/BexioApiNet/actions/workflows/sonar-analysis.yml/badge.svg)](https://github.com/AMANDA-Technology/BexioApiNet/actions/workflows/sonar-analysis.yml)
+
+### Branch protection
+
+The `PR CI` check (build + offline unit tests) is intended to be **required** on `main`. Configure under *Settings → Branches → Branch protection rules → main*: require status check `Build and test (offline)`. E2E tests are never invoked in CI — they need Bexio credentials and run only locally.


### PR DESCRIPTION
Closes #6.

## Summary

Adds `.github/workflows/pr.yml` — a PR-time build and test gate that runs on every pull request targeting `main`.

Steps:
1. `actions/checkout@v4`
2. `actions/setup-dotnet@v4` with `dotnet-version: 9.x` (aligned with the current `net9.0` target framework)
3. `dotnet restore BexioApiNet.sln`
4. `dotnet build --configuration Release --no-restore /warnaserror` — fails on any warning or error
5. `dotnet test --configuration Release --no-build --filter TestCategory!=E2E` — runs offline unit tests, skips anything tagged `E2E`

E2E tests are **never** invoked: all current live tests inherit `TestBase` which is decorated with `[Category("E2E")]`, and the filter `TestCategory!=E2E` excludes them. No Bexio credentials are needed in CI.

Existing workflows (`main.yml`, `codeql-analysis.yml`, `sonar-analysis.yml`) are untouched.

## Acceptance criteria

- [x] New workflow runs on `pull_request` (any branch → `main`)
- [x] Workflow fails if build has any warnings/errors (`/warnaserror`)
- [x] Workflow fails if any non-E2E test fails
- [x] E2E tests are never invoked (`--filter TestCategory!=E2E`)
- [x] Branch protection guidance documented in `README.md`
- [x] `main.yml`, `codeql-analysis.yml`, `sonar-analysis.yml` untouched

## Local verification

```
$ dotnet restore BexioApiNet.sln
$ dotnet build BexioApiNet.sln --configuration Release --no-restore /warnaserror
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet test BexioApiNet.sln --configuration Release --no-build --filter TestCategory!=E2E
No test matches the given testcase filter `TestCategory!=E2E`  # exit 0 — clean until unit tests land
```

## Follow-ups (out of scope)

- Once offline unit tests are added, extend this workflow with `--collect "XPlat Code Coverage"` and upload the coverlet report as an artifact (noted in the issue).
- Configure *Settings → Branches → main → Require status check "Build and test (offline)"* after the workflow is green on this PR.

## Test plan

- [ ] GitHub Actions runs `PR CI` on this PR
- [ ] `Build and test (offline)` job reports green
- [ ] Check that `main.yml` did **not** trigger (it is tag-only)
- [ ] SonarCloud + CodeQL still run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)