### PR TITLE
docs(openapi): vendor Bexio v3 OpenAPI spec under doc/openapi/

### DIFF
--- a/ai_instructions.md
+++ b/ai_instructions.md
@@ -17,6 +17,8 @@ If anything here conflicts with `CLAUDE.md`, **this file wins for agent behavior
 ## 1. Mission & Source of Truth
 
 1. This library is a 1:1 typed .NET client for the **Bexio REST API v3.0.0**. Source of truth: <https://docs.bexio.com/>.
+   - **Vendored spec (primary reference for AI agents):** [`doc/openapi/bexio-v3.json`](./doc/openapi/bexio-v3.json) — OpenAPI 3.0.2, API v3.0.0, 355 paths, retrieved 2026-04-18. Use this for offline, deterministic model generation. See [`doc/openapi/README.md`](./doc/openapi/README.md) for the refresh procedure.
+   - **Human-readable mirror:** <https://docs.bexio.com/> — use for browsing documentation and for verifying context not captured in the JSON spec.
 2. **Every** endpoint, DTO field, status code and query parameter must match the Bexio docs exactly. If the docs and the code disagree, **the docs are right** — open a change.
 3. Never invent endpoints, fields or behavior that the Bexio docs do not describe. If the docs are ambiguous, stop and ask rather than guessing.
 

--- a/doc/ai-readiness.md
+++ b/doc/ai-readiness.md
@@ -5,7 +5,7 @@ tags: [readiness, ai, assessment]
 
 # AI Readiness Assessment
 
-_Last updated: 2026-04-18 (Issue #3 "get steroids" hardening pass)_
+_Last updated: 2026-04-18 (Issue #8 — vendor Bexio OpenAPI spec)_
 
 ## Section 1: Documentation Quality
 The documentation landscape for this project is formal and AI-aware.
@@ -18,7 +18,7 @@ The documentation landscape for this project is formal and AI-aware.
   - Comprehensive C4 architecture models and ADRs under `doc/architecture/` (`README.md`, `context.md`, `containers.md`, `components/library.md`, `glossary.md`).
   - `README.md` clearly states the purpose and status of the project.
 - **What is missing or insufficient**:
-  - A locally vendored copy of the Bexio OpenAPI spec would further reduce the risk of drift against <https://docs.bexio.com/>. Backlog candidate, not a blocker.
+  - Nothing critical. A locally vendored OpenAPI spec is now committed at `doc/openapi/bexio-v3.json` (Issue #8).
 - **Rate**: Ready
 
 ## Section 2: Test Coverage
@@ -73,10 +73,9 @@ Two-layer strategy now in place: offline unit tests (mandatory for new code) and
 |-------|-------------|------------|----------|
 | Add Offline Unit Test Suite | Populate `src/BexioApiNet.Tests/UnitTests/` with NSubstitute- and WireMock.Net-based tests covering every existing connector method. Today the folder is scaffolded but empty. | M | High |
 | Expand API Connectors | Implement missing Bexio domains (Contacts, Projects, Invoices, Items, ...) per the feature-addition guide. | L | Medium |
-| Vendor Bexio OpenAPI Spec | Check a local copy of the Bexio OpenAPI spec into `doc/` so AI agents can generate models deterministically without relying on docs.bexio.com uptime. | M | Medium |
 | Wire Unit Tests into CI | Add a GitHub Actions job that runs `dotnet test --filter TestCategory=Unit` on every PR (independently of E2E credentials availability). | S | Medium |
 
-## Section 5: Completed (Issue #3)
+## Section 5: Completed
 
 | Title | Resolved In |
 |-------|-------------|
@@ -86,3 +85,4 @@ Two-layer strategy now in place: offline unit tests (mandatory for new code) and
 | Refactor to `IHttpClientFactory` | Issue #3 — dual constructor on `BexioConnectionHandler` + `AddHttpClient<>` in DI registration. |
 | Tests skip gracefully without credentials | Issue #3 — `TestBase.Setup` uses `Assert.Ignore`; base class `[Category("E2E")]`. |
 | Harmonize `CLAUDE.md` with agent docs | Issue #3 — cross-links added, redundant rules moved to `ai_instructions.md`. |
+| Vendor Bexio OpenAPI Spec | Issue #8 — `doc/openapi/bexio-v3.json` committed (OpenAPI 3.0.2, API v3.0.0, 355 paths, retrieved 2026-04-18). Refresh procedure in `doc/openapi/README.md`. |

--- a/doc/development/feature-addition-guide.md
+++ b/doc/development/feature-addition-guide.md
@@ -7,7 +7,7 @@ tags: [development, guide, how-to, contributing]
 
 This guide defines the **strict, reproducible, 5-step process** for adding a new Bexio API endpoint to BexioApiNet. Every new endpoint must follow this process so the library remains 1:1 with the Bexio REST API documentation.
 
-**Source of truth for every endpoint, field and parameter:** <https://docs.bexio.com/>.
+**Source of truth for every endpoint, field and parameter:** [`doc/openapi/bexio-v3.json`](../openapi/bexio-v3.json) (vendored OpenAPI spec — primary reference for AI agents). Human-readable mirror: <https://docs.bexio.com/>.
 
 Before starting, make sure you have read:
 - [`ai_instructions.md`](../../ai_instructions.md) — agent rules.

--- a/doc/openapi/README.md
+++ b/doc/openapi/README.md
@@ -1,0 +1,76 @@
+---
+title: Vendored Bexio OpenAPI Spec
+tags: [openapi, bexio, spec, ai]
+---
+
+# Vendored Bexio OpenAPI Spec
+
+This directory contains a local copy of the Bexio REST API OpenAPI specification for use by AI agents and offline tooling.
+
+## Spec Details
+
+| Field | Value |
+|-------|-------|
+| **File** | `bexio-v3.json` |
+| **API Version** | 3.0.0 |
+| **OpenAPI Version** | 3.0.2 |
+| **Paths** | 355 |
+| **Retrieval Source** | <https://docs.bexio.com/> (spec embedded in Redoc HTML at `__redoc_state.spec.data`) |
+| **Retrieval Date** | 2026-04-18 |
+| **Human-readable mirror** | <https://docs.bexio.com/> |
+
+## Usage by AI Agents
+
+AI agents working in this repository should consult `doc/openapi/bexio-v3.json` as the **primary reference** for endpoint definitions, request/response shapes, field names, types, and status codes. This enables deterministic, offline model generation without depending on external uptime.
+
+The human-readable documentation at <https://docs.bexio.com/> remains the canonical mirror for browsing.
+
+## Refresh Procedure
+
+### When to refresh
+
+- A Bexio API changelog entry on <https://docs.bexio.com/> describes new endpoints, changed fields, or deprecated operations that affect this library.
+- A developer notices a mismatch between the vendored spec and the live API behavior.
+- Routine maintenance: at most once per quarter unless a change warrants an earlier update.
+
+### How to refresh
+
+1. Download the latest spec:
+   ```bash
+   curl -s "https://docs.bexio.com/" | python3 -c "
+   import sys, json
+   html = sys.stdin.read()
+   idx = html.find('__redoc_state = {')
+   start = idx + len('__redoc_state = ')
+   depth, in_string, escape_next = 0, False, False
+   for i, c in enumerate(html[start:], start=start):
+       if escape_next: escape_next = False; continue
+       if c == '\\\\' and in_string: escape_next = True; continue
+       if c == '\"' and not escape_next: in_string = not in_string; continue
+       if in_string: continue
+       if c == '{': depth += 1
+       elif c == '}':
+           depth -= 1
+           if depth == 0: end = i + 1; break
+   spec = json.loads(html[start:end])['spec']['data']
+   print(json.dumps(spec, indent=2, ensure_ascii=False))
+   " > doc/openapi/bexio-v3.json
+   ```
+
+2. Verify the new spec looks correct:
+   ```bash
+   python3 -c "import json; s=json.load(open('doc/openapi/bexio-v3.json')); print('version:', s['info']['version'], '| paths:', len(s['paths']))"
+   ```
+
+3. Diff the new spec against the previous version to understand what changed:
+   ```bash
+   git diff doc/openapi/bexio-v3.json
+   ```
+
+4. Re-verify `ai_instructions.md` and `doc/development/feature-addition-guide.md`:
+   - If new endpoints were added, update the "not yet implemented" lists in these files.
+   - If existing endpoints changed (new required fields, changed types, deprecated parameters), note them as "watch points" in the relevant ADR or open a new issue.
+
+5. Update the **Retrieval Date** in this README to today's date.
+
+6. Commit with message: `chore(openapi): refresh vendored Bexio v3 spec (YYYY-MM-DD)`


### PR DESCRIPTION
## Summary

- Commits the Bexio REST API v3 OpenAPI spec (`doc/openapi/bexio-v3.json`) — OpenAPI 3.0.2, API v3.0.0, 355 paths, retrieved 2026-04-18 from <https://docs.bexio.com/>
- Adds `doc/openapi/README.md` with spec metadata, usage guidance, and a Python-based refresh procedure
- Updates `ai_instructions.md` §1 to cross-link the vendored spec as the primary reference for AI agents
- Updates `doc/development/feature-addition-guide.md` to point Step 1 at the vendored spec
- Moves "Vendor Bexio OpenAPI Spec" from `doc/ai-readiness.md` § 4 (Backlog) to § 5 (Completed)

## Phase Outcome

| Phase | Scope | Verdict |
|-------|-------|---------|
| 1 of 1 | Vendor spec + update cross-links | Doc-writer verified — all cross-links correct, no fixes needed |

## Acceptance Criteria

- [x] Spec file(s) committed under `doc/openapi/`
- [x] `doc/openapi/README.md` records spec version, retrieval source URL, retrieval date, and refresh procedure
- [x] `ai_instructions.md` and `feature-addition-guide.md` updated to point agents at the vendored copy
- [x] `doc/ai-readiness.md` § 4 row moved to § 5 (Completed)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)