### PR TITLE
feat: Wave 1 API coverage — 13 new connector services + 68 endpoints (#24)

### DIFF
--- a/doc/analysis/api-completeness-audit.md
+++ b/doc/analysis/api-completeness-audit.md
@@ -10,8 +10,8 @@ status: tracking
 Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implementation status. Source of truth: vendored OpenAPI spec at `doc/openapi/bexio-v3.json`.
 
 **Total endpoint methods:** 309  
-**Implemented:** 15 (4.8%)  
-**Remaining:** 294 (95.2%)
+**Implemented:** 83 (26.9%)  
+**Remaining:** 226 (73.1%)
 
 ---
 
@@ -19,9 +19,9 @@ Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implement
 
 | # | Domain Group | Tags | Endpoints | Done | Remaining | Wave |
 |---|---|---|---|---|---|---|
-| 1 | Accounting (Extended) | 8 | 35 | 10 | 25 | 1 |
-| 2 | Banking & Payments | 4 | 15 | 1 | 14 | 1 |
-| 3 | Contacts & CRM | 5 | 28 | 0 | 28 | 1 |
+| 1 | Accounting (Extended) | 8 | 35 | 35 | 0 | 1 |
+| 2 | Banking & Payments | 4 | 15 | 15 | 0 | 1 |
+| 3 | Contacts & CRM | 5 | 28 | 28 | 0 | 1 |
 | 4 | Sales — Invoices | 1 | 26 | 0 | 26 | 2 |
 | 5 | Sales — Quotes | 1 | 17 | 0 | 17 | 2 |
 | 6 | Sales — Orders & Deliveries | 2 | 15 | 0 | 15 | 2 |
@@ -33,11 +33,11 @@ Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implement
 | 12 | Payroll | 3 | 10 | 0 | 10 | 5 |
 | 13 | Files & Documents | 3 | 11 | 0 | 11 | 6 |
 | 14 | Master Data & Settings | 9 | 42 | 0 | 42 | 6 |
-| | **TOTAL** | **56** | **309** | **15** | **294** | |
+| | **TOTAL** | **56** | **309** | **83** | **226** | |
 
 ---
 
-## Domain Group 1: Accounting (Extended) — Wave 1
+## Domain Group 1: Accounting (Extended) — Wave 1 — DONE
 
 ### Tag: Accounts (2 endpoints) — DONE
 
@@ -46,174 +46,174 @@ Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implement
 | GET | `/2.0/accounts` | DONE | AccountService |
 | POST | `/2.0/accounts/search` | DONE | AccountService |
 
-### Tag: Account Groups (1 endpoint)
+### Tag: Account Groups (1 endpoint) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/2.0/account_groups` | TODO | AccountGroupService |
+| GET | `/2.0/account_groups` | DONE | AccountGroupService |
 
-### Tag: Currencies (7 endpoints) — PARTIAL (1/7)
+### Tag: Currencies (7 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
 | GET | `/3.0/currencies` | DONE | CurrencyService |
-| GET | `/3.0/currencies/codes` | TODO | CurrencyService |
-| GET | `/3.0/currencies/{currency_id}` | TODO | CurrencyService |
-| GET | `/3.0/currencies/{currency_id}/exchange_rates` | TODO | CurrencyService |
-| POST | `/3.0/currencies` | TODO | CurrencyService |
-| PATCH | `/3.0/currencies/{currency_id}` | TODO | CurrencyService |
-| DELETE | `/3.0/currencies/{currency_id}` | TODO | CurrencyService |
+| GET | `/3.0/currencies/codes` | DONE | CurrencyService |
+| GET | `/3.0/currencies/{currency_id}` | DONE | CurrencyService |
+| GET | `/3.0/currencies/{currency_id}/exchange_rates` | DONE | CurrencyService |
+| POST | `/3.0/currencies` | DONE | CurrencyService |
+| PATCH | `/3.0/currencies/{currency_id}` | DONE | CurrencyService |
+| DELETE | `/3.0/currencies/{currency_id}` | DONE | CurrencyService |
 
-### Tag: Manual Entries (13 endpoints) — PARTIAL (5/13)
+### Tag: Manual Entries (13 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
 | GET | `/3.0/accounting/manual_entries` | DONE | ManualEntryService |
-| GET | `/3.0/accounting/manual_entries/next_ref_nr` | TODO | ManualEntryService |
-| GET | `/3.0/accounting/manual_entries/{id}/entries/{entry_id}/files` | TODO | ManualEntryService |
-| GET | `/3.0/accounting/manual_entries/{id}/entries/{entry_id}/files/{file_id}` | TODO | ManualEntryService |
-| GET | `/3.0/accounting/manual_entries/{id}/files` | TODO | ManualEntryService |
-| GET | `/3.0/accounting/manual_entries/{id}/files/{file_id}` | TODO | ManualEntryService |
+| GET | `/3.0/accounting/manual_entries/next_ref_nr` | DONE | ManualEntryService |
+| GET | `/3.0/accounting/manual_entries/{id}/entries/{entry_id}/files` | DONE | ManualEntryService |
+| GET | `/3.0/accounting/manual_entries/{id}/entries/{entry_id}/files/{file_id}` | DONE | ManualEntryService |
+| GET | `/3.0/accounting/manual_entries/{id}/files` | DONE | ManualEntryService |
+| GET | `/3.0/accounting/manual_entries/{id}/files/{file_id}` | DONE | ManualEntryService |
 | POST | `/3.0/accounting/manual_entries` | DONE | ManualEntryService |
 | POST | `/3.0/accounting/manual_entries/{id}/entries/{entry_id}/files` | DONE | ManualEntryService |
 | POST | `/3.0/accounting/manual_entries/{id}/files` | DONE | ManualEntryService |
-| PUT | `/3.0/accounting/manual_entries/{id}` | TODO | ManualEntryService |
+| PUT | `/3.0/accounting/manual_entries/{id}` | DONE | ManualEntryService |
 | DELETE | `/3.0/accounting/manual_entries/{id}` | DONE | ManualEntryService |
-| DELETE | `/3.0/accounting/manual_entries/{id}/entries/{entry_id}/files/{file_id}` | TODO | ManualEntryService |
-| DELETE | `/3.0/accounting/manual_entries/{id}/files/{file_id}` | TODO | ManualEntryService |
+| DELETE | `/3.0/accounting/manual_entries/{id}/entries/{entry_id}/files/{file_id}` | DONE | ManualEntryService |
+| DELETE | `/3.0/accounting/manual_entries/{id}/files/{file_id}` | DONE | ManualEntryService |
 
-### Tag: Taxes (3 endpoints) — PARTIAL (1/3)
+### Tag: Taxes (3 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
 | GET | `/3.0/taxes` | DONE | TaxService |
-| GET | `/3.0/taxes/{tax_id}` | TODO | TaxService |
-| DELETE | `/3.0/taxes/{tax_id}` | TODO | TaxService |
+| GET | `/3.0/taxes/{tax_id}` | DONE | TaxService |
+| DELETE | `/3.0/taxes/{tax_id}` | DONE | TaxService |
 
-### Tag: Business Years (2 endpoints)
-
-| Method | Path | Status | Service |
-|--------|------|--------|---------|
-| GET | `/3.0/accounting/business_years` | TODO | BusinessYearService |
-| GET | `/3.0/accounting/business_years/{id}` | TODO | BusinessYearService |
-
-### Tag: Calendar Years (4 endpoints)
+### Tag: Business Years (2 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/3.0/accounting/calendar_years` | TODO | CalendarYearService |
-| GET | `/3.0/accounting/calendar_years/{id}` | TODO | CalendarYearService |
-| POST | `/3.0/accounting/calendar_years` | TODO | CalendarYearService |
-| POST | `/3.0/accounting/calendar_years/search` | TODO | CalendarYearService |
+| GET | `/3.0/accounting/business_years` | DONE | BusinessYearService |
+| GET | `/3.0/accounting/business_years/{id}` | DONE | BusinessYearService |
 
-### Tag: Reports (1 endpoint)
+### Tag: Calendar Years (4 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/3.0/accounting/journal` | TODO | ReportService |
+| GET | `/3.0/accounting/calendar_years` | DONE | CalendarYearService |
+| GET | `/3.0/accounting/calendar_years/{id}` | DONE | CalendarYearService |
+| POST | `/3.0/accounting/calendar_years` | DONE | CalendarYearService |
+| POST | `/3.0/accounting/calendar_years/search` | DONE | CalendarYearService |
 
-### Tag: Vat Periods (2 endpoints)
+### Tag: Reports (1 endpoint) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/3.0/accounting/vat_periods` | TODO | VatPeriodService |
-| GET | `/3.0/accounting/vat_periods/{id}` | TODO | VatPeriodService |
+| GET | `/3.0/accounting/journal` | DONE | ReportService |
+
+### Tag: Vat Periods (2 endpoints) — DONE
+
+| Method | Path | Status | Service |
+|--------|------|--------|---------|
+| GET | `/3.0/accounting/vat_periods` | DONE | VatPeriodService |
+| GET | `/3.0/accounting/vat_periods/{id}` | DONE | VatPeriodService |
 
 ---
 
-## Domain Group 2: Banking & Payments — Wave 1
+## Domain Group 2: Banking & Payments — Wave 1 — DONE
 
-### Tag: Bank Accounts (2 endpoints) — PARTIAL (1/2)
+### Tag: Bank Accounts (2 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
 | GET | `/3.0/banking/accounts` | DONE | BankAccountService |
-| GET | `/3.0/banking/accounts/{bank_account_id}` | TODO | BankAccountService |
+| GET | `/3.0/banking/accounts/{bank_account_id}` | DONE | BankAccountService |
 
-### Tag: Payment Types (2 endpoints)
-
-| Method | Path | Status | Service |
-|--------|------|--------|---------|
-| GET | `/2.0/payment_type` | TODO | PaymentTypeService |
-| POST | `/2.0/payment_type/search` | TODO | PaymentTypeService |
-
-### Tag: Payments (6 endpoints)
+### Tag: Payment Types (2 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/4.0/banking/payments` | TODO | PaymentService |
-| GET | `/4.0/banking/payments/{payment_id}` | TODO | PaymentService |
-| POST | `/4.0/banking/payments` | TODO | PaymentService |
-| POST | `/4.0/banking/payments/{payment_id}/cancel` | TODO | PaymentService |
-| PUT | `/4.0/banking/payments/{payment_id}` | TODO | PaymentService |
-| DELETE | `/4.0/banking/payments/{payment_id}` | TODO | PaymentService |
+| GET | `/2.0/payment_type` | DONE | PaymentTypeService |
+| POST | `/2.0/payment_type/search` | DONE | PaymentTypeService |
 
-### Tag: Outgoing Payments (5 endpoints)
+### Tag: Payments (6 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/4.0/purchase/outgoing-payments` | TODO | OutgoingPaymentService |
-| GET | `/4.0/purchase/outgoing-payments/{id}` | TODO | OutgoingPaymentService |
-| POST | `/4.0/purchase/outgoing-payments` | TODO | OutgoingPaymentService |
-| PUT | `/4.0/purchase/outgoing-payments` | TODO | OutgoingPaymentService |
-| DELETE | `/4.0/purchase/outgoing-payments/{id}` | TODO | OutgoingPaymentService |
+| GET | `/4.0/banking/payments` | DONE | PaymentService |
+| GET | `/4.0/banking/payments/{payment_id}` | DONE | PaymentService |
+| POST | `/4.0/banking/payments` | DONE | PaymentService |
+| POST | `/4.0/banking/payments/{payment_id}/cancel` | DONE | PaymentService |
+| PUT | `/4.0/banking/payments/{payment_id}` | DONE | PaymentService |
+| DELETE | `/4.0/banking/payments/{payment_id}` | DONE | PaymentService |
+
+### Tag: Outgoing Payments (5 endpoints) — DONE
+
+| Method | Path | Status | Service |
+|--------|------|--------|---------|
+| GET | `/4.0/purchase/outgoing-payments` | DONE | OutgoingPaymentService |
+| GET | `/4.0/purchase/outgoing-payments/{id}` | DONE | OutgoingPaymentService |
+| POST | `/4.0/purchase/outgoing-payments` | DONE | OutgoingPaymentService |
+| PUT | `/4.0/purchase/outgoing-payments` | DONE | OutgoingPaymentService |
+| DELETE | `/4.0/purchase/outgoing-payments/{id}` | DONE | OutgoingPaymentService |
 
 ---
 
-## Domain Group 3: Contacts & CRM — Wave 1
+## Domain Group 3: Contacts & CRM — Wave 1 — DONE
 
-### Tag: Contacts (8 endpoints)
-
-| Method | Path | Status | Service |
-|--------|------|--------|---------|
-| GET | `/2.0/contact` | TODO | ContactService |
-| GET | `/2.0/contact/{contact_id}` | TODO | ContactService |
-| POST | `/2.0/contact` | TODO | ContactService |
-| POST | `/2.0/contact/_bulk_create` | TODO | ContactService |
-| POST | `/2.0/contact/search` | TODO | ContactService |
-| POST | `/2.0/contact/{contact_id}` | TODO | ContactService |
-| PATCH | `/2.0/contact/{contact_id}/restore` | TODO | ContactService |
-| DELETE | `/2.0/contact/{contact_id}` | TODO | ContactService |
-
-### Tag: Contact Groups (6 endpoints)
+### Tag: Contacts (8 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/2.0/contact_group` | TODO | ContactGroupService |
-| GET | `/2.0/contact_group/{id}` | TODO | ContactGroupService |
-| POST | `/2.0/contact_group` | TODO | ContactGroupService |
-| POST | `/2.0/contact_group/search` | TODO | ContactGroupService |
-| POST | `/2.0/contact_group/{id}` | TODO | ContactGroupService |
-| DELETE | `/2.0/contact_group/{id}` | TODO | ContactGroupService |
+| GET | `/2.0/contact` | DONE | ContactService |
+| GET | `/2.0/contact/{contact_id}` | DONE | ContactService |
+| POST | `/2.0/contact` | DONE | ContactService |
+| POST | `/2.0/contact/_bulk_create` | DONE | ContactService |
+| POST | `/2.0/contact/search` | DONE | ContactService |
+| POST | `/2.0/contact/{contact_id}` | DONE | ContactService |
+| PATCH | `/2.0/contact/{contact_id}/restore` | DONE | ContactService |
+| DELETE | `/2.0/contact/{contact_id}` | DONE | ContactService |
 
-### Tag: Contact Relations (6 endpoints)
-
-| Method | Path | Status | Service |
-|--------|------|--------|---------|
-| GET | `/2.0/contact_relation` | TODO | ContactRelationService |
-| GET | `/2.0/contact_relation/{id}` | TODO | ContactRelationService |
-| POST | `/2.0/contact_relation` | TODO | ContactRelationService |
-| POST | `/2.0/contact_relation/search` | TODO | ContactRelationService |
-| POST | `/2.0/contact_relation/{id}` | TODO | ContactRelationService |
-| DELETE | `/2.0/contact_relation/{id}` | TODO | ContactRelationService |
-
-### Tag: Contact Sectors (2 endpoints)
+### Tag: Contact Groups (6 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/2.0/contact_branch` | TODO | ContactSectorService |
-| POST | `/2.0/contact_branch/search` | TODO | ContactSectorService |
+| GET | `/2.0/contact_group` | DONE | ContactGroupService |
+| GET | `/2.0/contact_group/{id}` | DONE | ContactGroupService |
+| POST | `/2.0/contact_group` | DONE | ContactGroupService |
+| POST | `/2.0/contact_group/search` | DONE | ContactGroupService |
+| POST | `/2.0/contact_group/{id}` | DONE | ContactGroupService |
+| DELETE | `/2.0/contact_group/{id}` | DONE | ContactGroupService |
 
-### Tag: Additional Addresses (6 endpoints)
+### Tag: Contact Relations (6 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/2.0/contact/{contact_id}/additional_address` | TODO | AdditionalAddressService |
-| GET | `/2.0/contact/{contact_id}/additional_address/{id}` | TODO | AdditionalAddressService |
-| POST | `/2.0/contact/{contact_id}/additional_address` | TODO | AdditionalAddressService |
-| POST | `/2.0/contact/{contact_id}/additional_address/search` | TODO | AdditionalAddressService |
-| POST | `/2.0/contact/{contact_id}/additional_address/{id}` | TODO | AdditionalAddressService |
-| DELETE | `/2.0/contact/{contact_id}/additional_address/{id}` | TODO | AdditionalAddressService |
+| GET | `/2.0/contact_relation` | DONE | ContactRelationService |
+| GET | `/2.0/contact_relation/{id}` | DONE | ContactRelationService |
+| POST | `/2.0/contact_relation` | DONE | ContactRelationService |
+| POST | `/2.0/contact_relation/search` | DONE | ContactRelationService |
+| POST | `/2.0/contact_relation/{id}` | DONE | ContactRelationService |
+| DELETE | `/2.0/contact_relation/{id}` | DONE | ContactRelationService |
+
+### Tag: Contact Sectors (2 endpoints) — DONE
+
+| Method | Path | Status | Service |
+|--------|------|--------|---------|
+| GET | `/2.0/contact_branch` | DONE | ContactSectorService |
+| POST | `/2.0/contact_branch/search` | DONE | ContactSectorService |
+
+### Tag: Additional Addresses (6 endpoints) — DONE
+
+| Method | Path | Status | Service |
+|--------|------|--------|---------|
+| GET | `/2.0/contact/{contact_id}/additional_address` | DONE | AdditionalAddressService |
+| GET | `/2.0/contact/{contact_id}/additional_address/{id}` | DONE | AdditionalAddressService |
+| POST | `/2.0/contact/{contact_id}/additional_address` | DONE | AdditionalAddressService |
+| POST | `/2.0/contact/{contact_id}/additional_address/search` | DONE | AdditionalAddressService |
+| POST | `/2.0/contact/{contact_id}/additional_address/{id}` | DONE | AdditionalAddressService |
+| DELETE | `/2.0/contact/{contact_id}/additional_address/{id}` | DONE | AdditionalAddressService |
 
 ---
 

--- a/src/BexioApiNet.Abstractions/Models/Accounting/AccountGroups/AccountGroup.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/AccountGroups/AccountGroup.cs
@@ -1,0 +1,46 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Accounting.AccountGroups;
+
+/// <summary>
+/// Account group object. <see href="https://docs.bexio.com/#tag/Account-Groups/operation/v2ListAccountGroups"/>
+/// </summary>
+/// <param name="Id"></param>
+/// <param name="Uuid"></param>
+/// <param name="AccountNo"></param>
+/// <param name="Name"></param>
+/// <param name="ParentFibuAccountGroupId"></param>
+/// <param name="IsActive"></param>
+/// <param name="IsLocked"></param>
+public sealed record AccountGroup(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("account_no")] string AccountNo,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("parent_fibu_account_group_id")] int? ParentFibuAccountGroupId,
+    [property: JsonPropertyName("is_active")] bool IsActive,
+    [property: JsonPropertyName("is_locked")] bool IsLocked
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/BusinessYears/BusinessYear.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/BusinessYears/BusinessYear.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.BusinessYears.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Accounting.BusinessYears;
+
+/// <summary>
+///     Business year object. <see href="https://docs.bexio.com/#tag/Business-Years" />
+/// </summary>
+/// <param name="Id"></param>
+/// <param name="Start"></param>
+/// <param name="End"></param>
+/// <param name="Status"></param>
+/// <param name="ClosedAt"></param>
+public sealed record BusinessYear(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("start")] DateOnly Start,
+    [property: JsonPropertyName("end")] DateOnly End,
+    [property: JsonPropertyName("status")] BusinessYearStatus Status,
+    [property: JsonPropertyName("closed_at")]
+    DateOnly? ClosedAt
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/BusinessYears/Enums/BusinessYearStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/BusinessYears/Enums/BusinessYearStatus.cs
@@ -1,0 +1,50 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+
+namespace BexioApiNet.Abstractions.Models.Accounting.BusinessYears.Enums;
+
+/// <summary>
+///     Status of a business year. <see href="https://docs.bexio.com/#tag/Business-Years" />
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum BusinessYearStatus
+{
+    /// <summary>
+    ///     The business year period is open for new bookings.
+    /// </summary>
+    open,
+
+    /// <summary>
+    ///     The business year period is closed for new bookings, but without an ordinary year end closing.
+    /// </summary>
+    locked,
+
+    /// <summary>
+    ///     The business year period is closed for new bookings, but with an ordinary year end closing.
+    /// </summary>
+    closed
+}

--- a/src/BexioApiNet.Abstractions/Models/Accounting/CalendarYears/CalendarYear.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/CalendarYears/CalendarYear.cs
@@ -1,0 +1,52 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Accounting.CalendarYears;
+
+/// <summary>
+/// Calendar year returned by the Bexio accounting endpoint. <see href="https://docs.bexio.com/#tag/Calendar-Years/operation/ListCalendarYears">List Calendar Years</see>
+/// </summary>
+/// <param name="Id"></param>
+/// <param name="Start"></param>
+/// <param name="End"></param>
+/// <param name="IsVatSubject"></param>
+/// <param name="IsAnnualReporting"></param>
+/// <param name="CreatedAt"></param>
+/// <param name="UpdatedAt"></param>
+/// <param name="VatAccountingMethod"></param>
+/// <param name="VatAccountingType"></param>
+public sealed record CalendarYear(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("start")] DateOnly Start,
+    [property: JsonPropertyName("end")] DateOnly End,
+    [property: JsonPropertyName("is_vat_subject")] bool IsVatSubject,
+    [property: JsonPropertyName("is_annual_reporting")] bool IsAnnualReporting,
+    [property: JsonPropertyName("created_at")] DateTime CreatedAt,
+    [property: JsonPropertyName("updated_at")] DateTime UpdatedAt,
+    [property: JsonPropertyName("vat_accounting_method")] VatAccountingMethod VatAccountingMethod,
+    [property: JsonPropertyName("vat_accounting_type")] VatAccountingType VatAccountingType
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/CalendarYears/Enums/VatAccountingMethod.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/CalendarYears/Enums/VatAccountingMethod.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Enums;
+
+/// <summary>
+/// VAT accounting method used by a calendar year. <see href="https://docs.bexio.com/#tag/Calendar-Years"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum VatAccountingMethod
+{
+    /// <summary>
+    /// Effective VAT accounting method.
+    /// </summary>
+    effective,
+
+    /// <summary>
+    /// Net tax (flat rate) VAT accounting method.
+    /// </summary>
+    net_tax
+}

--- a/src/BexioApiNet.Abstractions/Models/Accounting/CalendarYears/Enums/VatAccountingType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/CalendarYears/Enums/VatAccountingType.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Enums;
+
+/// <summary>
+/// VAT accounting type used by a calendar year. <see href="https://docs.bexio.com/#tag/Calendar-Years"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum VatAccountingType
+{
+    /// <summary>
+    /// Agreed VAT accounting type.
+    /// </summary>
+    agreed,
+
+    /// <summary>
+    /// Collected VAT accounting type.
+    /// </summary>
+    collected
+}

--- a/src/BexioApiNet.Abstractions/Models/Accounting/CalendarYears/Views/CalendarYearCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/CalendarYears/Views/CalendarYearCreate.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Views;
+
+/// <summary>
+/// Create view for a calendar year. <see href="https://docs.bexio.com/#tag/Calendar-Years/operation/CreateCalendarYear">Create Calendar Year</see>
+/// </summary>
+/// <param name="Year"></param>
+/// <param name="IsVatSubject"></param>
+/// <param name="IsAnnualReporting"></param>
+/// <param name="VatAccountingMethod"></param>
+/// <param name="VatAccountingType"></param>
+/// <param name="DefaultTaxIncomeId"></param>
+/// <param name="DefaultTaxExpenseId"></param>
+public sealed record CalendarYearCreate(
+    [property: JsonPropertyName("year")] string Year,
+    [property: JsonPropertyName("is_vat_subject")] bool? IsVatSubject,
+    [property: JsonPropertyName("is_annual_reporting")] bool? IsAnnualReporting,
+    [property: JsonPropertyName("vat_accounting_method")] VatAccountingMethod? VatAccountingMethod,
+    [property: JsonPropertyName("vat_accounting_type")] VatAccountingType? VatAccountingType,
+    [property: JsonPropertyName("default_tax_income_id")] int? DefaultTaxIncomeId,
+    [property: JsonPropertyName("default_tax_expense_id")] int? DefaultTaxExpenseId
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/ExchangeRate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/ExchangeRate.cs
@@ -1,0 +1,61 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Accounting.Currencies;
+
+/// <summary>
+///     Exchange rate for a currency.
+///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ListExchangeRatesForCurrency">
+///         List Exchange Rates For
+///         Currency
+///     </see>
+/// </summary>
+/// <param name="FactorNr">
+///     The exchange rate of the currency in comparison with the currency listed in
+///     <paramref name="ExchangeCurrency" />.
+/// </param>
+/// <param name="ExchangeCurrency">The currency that the exchange rate is compared against.</param>
+/// <param name="Ratio">The ratio representing how much of the base currency equals one unit of the quote currency.</param>
+/// <param name="ExchangeRateToRatio">The exchange rate of the currency multiplied by the ratio.</param>
+/// <param name="Source">The source where the exchange rate is fetched from (<c>custom</c>, <c>monthly_average</c>).</param>
+/// <param name="SourceReason">
+///     The reason why the source of the exchange rate was chosen (<c>monthly_average_provided</c>,
+///     <c>monthly_average_unavailable</c>, <c>monthly_average_unreachable</c>, <c>source_custom</c>).
+/// </param>
+/// <param name="ExchangeRateDate">The validity date of the exchange rate.</param>
+public sealed record ExchangeRate(
+    [property: JsonPropertyName("factor_nr")]
+    decimal FactorNr,
+    [property: JsonPropertyName("exchange_currency")]
+    Currency ExchangeCurrency,
+    [property: JsonPropertyName("ratio")] decimal? Ratio,
+    [property: JsonPropertyName("exchange_rate_to_ratio")]
+    decimal? ExchangeRateToRatio,
+    [property: JsonPropertyName("source")] string? Source,
+    [property: JsonPropertyName("source_reason")]
+    string? SourceReason,
+    [property: JsonPropertyName("exchange_rate_date")]
+    string? ExchangeRateDate
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/Views/CurrencyCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/Views/CurrencyCreate.cs
@@ -1,0 +1,41 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
+
+/// <summary>
+///     Create view for a currency.
+///     <see href="https://docs.bexio.com/#tag/Currencies/operation/CreateCurrency">Create Currency</see>
+/// </summary>
+/// <param name="Name">A name of the currency. Must be in the format "ISO 4217" and must be unique. Maximum 80 characters.</param>
+/// <param name="RoundFactor">
+///     The round factor of the currency. E.g.: In order to round CHF to 5 Rp. the round_factor must
+///     be set to 0.05.
+/// </param>
+public sealed record CurrencyCreate(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("round_factor")]
+    double RoundFactor
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/Views/CurrencyPatch.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/Views/CurrencyPatch.cs
@@ -1,0 +1,40 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
+
+/// <summary>
+///     Patch view for a currency.
+///     <see href="https://docs.bexio.com/#tag/Currencies/operation/UpdateCurrency">Update Currency</see>
+/// </summary>
+/// <param name="RoundFactor">
+///     The round factor of the currency. E.g.: In order to round CHF to 5 Rp. the round_factor must
+///     be set to 0.05.
+/// </param>
+public sealed record CurrencyPatch(
+    [property: JsonPropertyName("round_factor")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    double? RoundFactor
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/Enums/ManualEntryFileSourceType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/Enums/ManualEntryFileSourceType.cs
@@ -1,0 +1,50 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+
+/// <summary>
+/// Source type of a manual entry file, indicating where it was uploaded from.
+/// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/ListManualCompoundEntryFiles"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ManualEntryFileSourceType
+{
+    /// <summary>
+    /// File uploaded via the Bexio web application.
+    /// </summary>
+    web,
+
+    /// <summary>
+    /// File received via email.
+    /// </summary>
+    email,
+
+    /// <summary>
+    /// File uploaded via the Bexio mobile application.
+    /// </summary>
+    mobile
+}

--- a/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/ManualEntryFile.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/ManualEntryFile.cs
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Accounting.ManualEntries;
+
+/// <summary>
+/// File metadata returned by the Bexio manual entry file listing endpoints.
+/// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/ListManualCompoundEntryFiles"/>
+/// </summary>
+/// <param name="Id"></param>
+/// <param name="Uuid"></param>
+/// <param name="Name"></param>
+/// <param name="SizeInBytes"></param>
+/// <param name="Extension"></param>
+/// <param name="MimeType"></param>
+/// <param name="UploaderEmail"></param>
+/// <param name="UserId"></param>
+/// <param name="IsArchived"></param>
+/// <param name="SourceType"></param>
+/// <param name="IsReferenced"></param>
+/// <param name="CreatedAt"></param>
+public sealed record ManualEntryFile(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("size_in_bytes")] long SizeInBytes,
+    [property: JsonPropertyName("extension")] string Extension,
+    [property: JsonPropertyName("mime_type")] string MimeType,
+    [property: JsonPropertyName("uploader_email")] string? UploaderEmail,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("is_archived")] bool IsArchived,
+    [property: JsonPropertyName("source_type")] ManualEntryFileSourceType? SourceType,
+    [property: JsonPropertyName("is_referenced")] bool IsReferenced,
+    [property: JsonPropertyName("created_at")] DateTime CreatedAt
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/ManualEntryFileDetail.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/ManualEntryFileDetail.cs
@@ -1,0 +1,61 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Accounting.ManualEntries;
+
+/// <summary>
+/// File detail including base64-encoded binary content, returned by the Bexio manual entry file fetch endpoints.
+/// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/ShowManualCompoundEntryFile"/>
+/// </summary>
+/// <param name="Id"></param>
+/// <param name="Uuid"></param>
+/// <param name="Name"></param>
+/// <param name="SizeInBytes"></param>
+/// <param name="Extension"></param>
+/// <param name="MimeType"></param>
+/// <param name="UploaderEmail"></param>
+/// <param name="UserId"></param>
+/// <param name="IsArchived"></param>
+/// <param name="SourceType"></param>
+/// <param name="IsReferenced"></param>
+/// <param name="CreatedAt"></param>
+/// <param name="Data"></param>
+public sealed record ManualEntryFileDetail(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("size_in_bytes")] long SizeInBytes,
+    [property: JsonPropertyName("extension")] string Extension,
+    [property: JsonPropertyName("mime_type")] string MimeType,
+    [property: JsonPropertyName("uploader_email")] string? UploaderEmail,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("is_archived")] bool IsArchived,
+    [property: JsonPropertyName("source_type")] ManualEntryFileSourceType? SourceType,
+    [property: JsonPropertyName("is_referenced")] bool IsReferenced,
+    [property: JsonPropertyName("created_at")] DateTime CreatedAt,
+    [property: JsonPropertyName("data")] string Data
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/ManualEntryNextRefNr.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/ManualEntryNextRefNr.cs
@@ -1,0 +1,35 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Accounting.ManualEntries;
+
+/// <summary>
+/// Suggested next reference number for a manual entry.
+/// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/GetNextReferenceNumber"/>
+/// </summary>
+/// <param name="NextRefNr">The reference number which is suggested for the next manual entry.</param>
+public sealed record ManualEntryNextRefNr(
+    [property: JsonPropertyName("next_ref_nr")] string? NextRefNr
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/Views/ManualEntryUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/ManualEntries/Views/ManualEntryUpdate.cs
@@ -1,0 +1,70 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Views;
+
+/// <summary>
+/// Update view for a single manual entry line inside a <see cref="ManualEntryUpdate"/> payload.
+/// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/UpdateManualEntry">Update Manual Entry</see>
+/// </summary>
+/// <param name="DebitAccountId"></param>
+/// <param name="CreditAccountId"></param>
+/// <param name="TaxId"></param>
+/// <param name="TaxAccountId"></param>
+/// <param name="Description"></param>
+/// <param name="Amount"></param>
+/// <param name="CurrencyId"></param>
+/// <param name="CurrencyFactor"></param>
+/// <param name="Id"></param>
+public sealed record ManualEntryEntryUpdate(
+    [property: JsonPropertyName("debit_account_id")] int? DebitAccountId,
+    [property: JsonPropertyName("credit_account_id")] int? CreditAccountId,
+    [property: JsonPropertyName("tax_id")] int? TaxId,
+    [property: JsonPropertyName("tax_account_id")] int? TaxAccountId,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("amount")] decimal? Amount,
+    [property: JsonPropertyName("currency_id")] int? CurrencyId,
+    [property: JsonPropertyName("currency_factor")] decimal? CurrencyFactor,
+    [property: JsonPropertyName("id")] int? Id
+);
+
+/// <summary>
+/// Update view for a manual entry. Sent as the JSON body of a PUT request.
+/// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/UpdateManualEntry">Update Manual Entry</see>
+/// </summary>
+/// <param name="Type"></param>
+/// <param name="Date"></param>
+/// <param name="ReferenceNr"></param>
+/// <param name="Entries"></param>
+/// <param name="Id"></param>
+public sealed record ManualEntryUpdate(
+    [property: JsonPropertyName("type")] ManualEntryType Type,
+    [property: JsonPropertyName("date")] DateOnly Date,
+    [property: JsonPropertyName("reference_nr")] string? ReferenceNr,
+    [property: JsonPropertyName("entries")] IReadOnlyList<ManualEntryEntryUpdate> Entries,
+    [property: JsonPropertyName("id")] int? Id
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/Reports/Journal.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/Reports/Journal.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Accounting.Reports;
+
+/// <summary>
+/// Journal entry as returned by the Bexio accounting journal endpoint. <see href="https://docs.bexio.com/#tag/Reports/operation/ListJournalEntries"/>
+/// </summary>
+/// <param name="Id">The id of the journal entry.</param>
+/// <param name="RefId">Referenced id of the entry.</param>
+/// <param name="RefUuid">Referenced uuid of the entry.</param>
+/// <param name="RefClass">Referenced class of the entry.</param>
+/// <param name="Date">Entry date for the entry.</param>
+/// <param name="DebitAccountId">The id of the debit account.</param>
+/// <param name="CreditAccountId">The id of the credit account.</param>
+/// <param name="Description">A description for the entry.</param>
+/// <param name="Amount">The total amount of the entry.</param>
+/// <param name="CurrencyId">The id of the referenced currency.</param>
+/// <param name="CurrencyFactor">The exchange factor of the currency_id and base_currency_id.</param>
+/// <param name="BaseCurrencyId">The id of the currency used in the general ledger.</param>
+/// <param name="BaseCurrencyAmount">The total amount of the entry in the currency of the general ledger.</param>
+public sealed record Journal(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("ref_id")] int? RefId,
+    [property: JsonPropertyName("ref_uuid")] string? RefUuid,
+    [property: JsonPropertyName("ref_class")] string? RefClass,
+    [property: JsonPropertyName("date")] DateTime Date,
+    [property: JsonPropertyName("debit_account_id")] int? DebitAccountId,
+    [property: JsonPropertyName("credit_account_id")] int? CreditAccountId,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("currency_id")] int? CurrencyId,
+    [property: JsonPropertyName("currency_factor")] decimal? CurrencyFactor,
+    [property: JsonPropertyName("base_currency_id")] int? BaseCurrencyId,
+    [property: JsonPropertyName("base_currency_amount")] decimal BaseCurrencyAmount
+);

--- a/src/BexioApiNet.Abstractions/Models/Accounting/VatPeriods/Enums/VatPeriodStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/VatPeriods/Enums/VatPeriodStatus.cs
@@ -1,0 +1,49 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Accounting.VatPeriods.Enums;
+
+/// <summary>
+/// Status of a vat period. <see href="https://docs.bexio.com/#tag/Vat-Periods"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum VatPeriodStatus
+{
+    /// <summary>
+    /// The period is open.
+    /// </summary>
+    open,
+
+    /// <summary>
+    /// The period is closed.
+    /// </summary>
+    closed,
+
+    /// <summary>
+    /// The period is closed and message was acknowledged.
+    /// </summary>
+    closed_with_message
+}

--- a/src/BexioApiNet.Abstractions/Models/Accounting/VatPeriods/Enums/VatPeriodType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/VatPeriods/Enums/VatPeriodType.cs
@@ -1,0 +1,49 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Accounting.VatPeriods.Enums;
+
+/// <summary>
+/// Duration of a vat period. <see href="https://docs.bexio.com/#tag/Vat-Periods"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum VatPeriodType
+{
+    /// <summary>
+    /// The vat period has the duration of a quarter.
+    /// </summary>
+    quarter,
+
+    /// <summary>
+    /// The vat period has the duration of a semester.
+    /// </summary>
+    semester,
+
+    /// <summary>
+    /// The vat period has the duration of a year.
+    /// </summary>
+    annual
+}

--- a/src/BexioApiNet.Abstractions/Models/Accounting/VatPeriods/VatPeriod.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/VatPeriods/VatPeriod.cs
@@ -1,0 +1,46 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.VatPeriods.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Accounting.VatPeriods;
+
+/// <summary>
+/// Vat period object. <see href="https://docs.bexio.com/#tag/Vat-Periods"/>
+/// </summary>
+/// <param name="Id">The id of the vat period.</param>
+/// <param name="Start">Start date of the vat period.</param>
+/// <param name="End">End date of the vat period.</param>
+/// <param name="Type">Duration of the vat period (quarter, semester, annual).</param>
+/// <param name="Status">Status of the vat period (open, closed, closed_with_message).</param>
+/// <param name="ClosedAt">Closed date of the vat period; <see langword="null"/> while the period is still open.</param>
+public sealed record VatPeriod(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("start")] DateOnly Start,
+    [property: JsonPropertyName("end")] DateOnly End,
+    [property: JsonPropertyName("type")] VatPeriodType Type,
+    [property: JsonPropertyName("status")] VatPeriodStatus Status,
+    [property: JsonPropertyName("closed_at")] DateOnly? ClosedAt
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Enums/OutgoingPaymentFeeType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Enums/OutgoingPaymentFeeType.cs
@@ -1,0 +1,55 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+
+/// <summary>
+/// Outgoing payment fee type — required for <c>IBAN</c>, disallowed for <c>QR</c>, <c>MANUAL</c> and <c>CASH_DISCOUNT</c>.
+/// <see href="https://docs.bexio.com/#tag/Outgoing-Payment">Outgoing Payment</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum OutgoingPaymentFeeType
+{
+    /// <summary>
+    /// Sender of the payment pays all fees.
+    /// </summary>
+    BY_SENDER,
+
+    /// <summary>
+    /// Receiver of the payment pays all fees.
+    /// </summary>
+    BY_RECEIVER,
+
+    /// <summary>
+    /// Fees are split between sender and receiver.
+    /// </summary>
+    BREAKDOWN,
+
+    /// <summary>
+    /// No fees — only allowed for domestic IBAN payments (same country as the sender bank account IBAN).
+    /// </summary>
+    NO_FEE
+}

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Enums/OutgoingPaymentStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Enums/OutgoingPaymentStatus.cs
@@ -1,0 +1,64 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+
+/// <summary>
+/// Outgoing payment status. <see href="https://docs.bexio.com/#tag/Outgoing-Payment">Outgoing Payment</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum OutgoingPaymentStatus
+{
+    /// <summary>
+    /// Payment is pending and has not been transferred yet.
+    /// </summary>
+    PENDING,
+
+    /// <summary>
+    /// Payment has been transferred to the bank.
+    /// </summary>
+    TRANSFERRED,
+
+    /// <summary>
+    /// Payment has been downloaded.
+    /// </summary>
+    DOWNLOADED,
+
+    /// <summary>
+    /// Payment processing resulted in an error.
+    /// </summary>
+    ERROR,
+
+    /// <summary>
+    /// Payment has been fully paid.
+    /// </summary>
+    PAID,
+
+    /// <summary>
+    /// Payment is a cash discount (<c>CASH_DISCOUNT</c>) adjustment.
+    /// </summary>
+    DISCOUNTED
+}

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Enums/OutgoingPaymentType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Enums/OutgoingPaymentType.cs
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+
+/// <summary>
+/// Outgoing payment type. <see href="https://docs.bexio.com/#tag/Outgoing-Payment">Outgoing Payment</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum OutgoingPaymentType
+{
+    /// <summary>
+    /// IBAN bank transfer payment.
+    /// </summary>
+    IBAN,
+
+    /// <summary>
+    /// Manually recorded payment (e.g. cash).
+    /// </summary>
+    MANUAL,
+
+    /// <summary>
+    /// Cash discount applied against the bill.
+    /// </summary>
+    CASH_DISCOUNT,
+
+    /// <summary>
+    /// Payment has been reconciled from a banking transaction. Cannot be created via this API.
+    /// </summary>
+    RECONCILED,
+
+    /// <summary>
+    /// QR-bill payment.
+    /// </summary>
+    QR
+}

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/OutgoingPayment.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/OutgoingPayment.cs
@@ -1,0 +1,115 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments;
+
+/// <summary>
+/// Outgoing payment returned by the Bexio <c>/4.0/purchase/outgoing-payments</c> endpoints
+/// (GET by id, POST create, PUT update). <see href="https://docs.bexio.com/#tag/Outgoing-Payment">Outgoing Payment</see>
+/// </summary>
+/// <param name="Id">Unique outgoing payment identifier.</param>
+/// <param name="Status">Payment status (<c>PENDING</c>, <c>TRANSFERRED</c>, ...).</param>
+/// <param name="CreatedAt">Timestamp when the payment was created.</param>
+/// <param name="BillId">Identifier of the bill the payment belongs to.</param>
+/// <param name="PaymentType">Payment type (<c>IBAN</c>, <c>MANUAL</c>, <c>CASH_DISCOUNT</c>, <c>RECONCILED</c>, <c>QR</c>).</param>
+/// <param name="ExecutionDate">Execution date of the payment.</param>
+/// <param name="Amount">Payment amount.</param>
+/// <param name="CurrencyCode">ISO currency code of the payment.</param>
+/// <param name="ExchangeRate">Exchange rate used for the payment.</param>
+/// <param name="Note">Optional note — not allowed for <c>IBAN</c> or <c>QR</c> payments.</param>
+/// <param name="SenderBankAccountId">Bexio bank account identifier of the sender.</param>
+/// <param name="SenderIban">IBAN of the sender.</param>
+/// <param name="SenderName">Name of the sender.</param>
+/// <param name="SenderStreet">Street of the sender.</param>
+/// <param name="SenderHouseNo">House number of the sender.</param>
+/// <param name="SenderCity">City of the sender.</param>
+/// <param name="SenderPostcode">Postcode of the sender.</param>
+/// <param name="SenderCountryCode">Country code of the sender.</param>
+/// <param name="SenderBcNo">Bank clearing number of the sender bank.</param>
+/// <param name="SenderBankNo">Bank number of the sender bank.</param>
+/// <param name="SenderBankName">Name of the sender bank.</param>
+/// <param name="ReceiverAccountNo">Deprecated — receiver account number.</param>
+/// <param name="ReceiverIban">IBAN of the receiver.</param>
+/// <param name="ReceiverName">Name of the receiver.</param>
+/// <param name="ReceiverStreet">Street of the receiver.</param>
+/// <param name="ReceiverHouseNo">House number of the receiver.</param>
+/// <param name="ReceiverCity">City of the receiver.</param>
+/// <param name="ReceiverPostcode">Postcode of the receiver.</param>
+/// <param name="ReceiverCountryCode">Country code of the receiver.</param>
+/// <param name="ReceiverBcNo">Bank clearing number of the receiver bank.</param>
+/// <param name="ReceiverBankNo">Bank number of the receiver bank.</param>
+/// <param name="ReceiverBankName">Name of the receiver bank.</param>
+/// <param name="FeeType">Fee allocation (<c>BY_SENDER</c>, <c>BY_RECEIVER</c>, <c>BREAKDOWN</c>, <c>NO_FEE</c>).</param>
+/// <param name="IsSalaryPayment">True if this is a salary payment. Only allowed for <c>IBAN</c>.</param>
+/// <param name="ReferenceNo">Reference number (for <c>QR</c> payments).</param>
+/// <param name="Message">Remittance message.</param>
+/// <param name="BookingText">Internal booking text.</param>
+/// <param name="BankingPaymentId">Reference to the banking payment order (for <c>IBAN</c>/<c>QR</c>).</param>
+/// <param name="BankingPaymentEntryId">Reference to the banking payment order entry.</param>
+/// <param name="TransactionId">Reconciled transaction id when the payment is <c>RECONCILED</c>.</param>
+public sealed record OutgoingPayment(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("status")] OutgoingPaymentStatus Status,
+    [property: JsonPropertyName("created_at")] DateTimeOffset CreatedAt,
+    [property: JsonPropertyName("bill_id")] Guid BillId,
+    [property: JsonPropertyName("payment_type")] OutgoingPaymentType PaymentType,
+    [property: JsonPropertyName("execution_date")] DateOnly ExecutionDate,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("currency_code")] string CurrencyCode,
+    [property: JsonPropertyName("exchange_rate")] decimal ExchangeRate,
+    [property: JsonPropertyName("note")] string? Note,
+    [property: JsonPropertyName("sender_bank_account_id")] int SenderBankAccountId,
+    [property: JsonPropertyName("sender_iban")] string? SenderIban,
+    [property: JsonPropertyName("sender_name")] string? SenderName,
+    [property: JsonPropertyName("sender_street")] string? SenderStreet,
+    [property: JsonPropertyName("sender_house_no")] string? SenderHouseNo,
+    [property: JsonPropertyName("sender_city")] string? SenderCity,
+    [property: JsonPropertyName("sender_postcode")] string? SenderPostcode,
+    [property: JsonPropertyName("sender_country_code")] string? SenderCountryCode,
+    [property: JsonPropertyName("sender_bc_no")] string? SenderBcNo,
+    [property: JsonPropertyName("sender_bank_no")] string? SenderBankNo,
+    [property: JsonPropertyName("sender_bank_name")] string? SenderBankName,
+    [property: JsonPropertyName("receiver_account_no")] string? ReceiverAccountNo,
+    [property: JsonPropertyName("receiver_iban")] string? ReceiverIban,
+    [property: JsonPropertyName("receiver_name")] string? ReceiverName,
+    [property: JsonPropertyName("receiver_street")] string? ReceiverStreet,
+    [property: JsonPropertyName("receiver_house_no")] string? ReceiverHouseNo,
+    [property: JsonPropertyName("receiver_city")] string? ReceiverCity,
+    [property: JsonPropertyName("receiver_postcode")] string? ReceiverPostcode,
+    [property: JsonPropertyName("receiver_country_code")] string? ReceiverCountryCode,
+    [property: JsonPropertyName("receiver_bc_no")] string? ReceiverBcNo,
+    [property: JsonPropertyName("receiver_bank_no")] string? ReceiverBankNo,
+    [property: JsonPropertyName("receiver_bank_name")] string? ReceiverBankName,
+    [property: JsonPropertyName("fee_type")] OutgoingPaymentFeeType? FeeType,
+    [property: JsonPropertyName("is_salary_payment")] bool IsSalaryPayment,
+    [property: JsonPropertyName("reference_no")] string? ReferenceNo,
+    [property: JsonPropertyName("message")] string? Message,
+    [property: JsonPropertyName("booking_text")] string? BookingText,
+    [property: JsonPropertyName("banking_payment_id")] Guid? BankingPaymentId,
+    [property: JsonPropertyName("banking_payment_entry_id")] Guid? BankingPaymentEntryId,
+    [property: JsonPropertyName("transaction_id")] Guid? TransactionId
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/OutgoingPaymentListItem.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/OutgoingPaymentListItem.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments;
+
+/// <summary>
+/// Condensed outgoing payment entry returned by the list endpoint
+/// <c>GET /4.0/purchase/outgoing-payments</c>. See <see cref="OutgoingPayment"/> for the full model.
+/// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPaymentList_GET">List Outgoing Payments</see>
+/// </summary>
+/// <param name="Id">Unique outgoing payment identifier.</param>
+/// <param name="BillId">Identifier of the bill the payment belongs to.</param>
+/// <param name="PaymentType">Payment type.</param>
+/// <param name="Status">Payment status.</param>
+/// <param name="ExecutionDate">Execution date of the payment.</param>
+/// <param name="Amount">Payment amount.</param>
+/// <param name="SenderBankAccountId">Bexio bank account identifier of the sender.</param>
+/// <param name="ReceiverAccountNo">Deprecated — receiver account number.</param>
+/// <param name="ReceiverIban">IBAN of the receiver.</param>
+/// <param name="BankingPaymentId">Reference to the banking payment order (for <c>IBAN</c>/<c>QR</c>).</param>
+/// <param name="TransactionId">Reconciled transaction id when the payment is <c>RECONCILED</c>.</param>
+public sealed record OutgoingPaymentListItem(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("bill_id")] Guid BillId,
+    [property: JsonPropertyName("payment_type")] OutgoingPaymentType PaymentType,
+    [property: JsonPropertyName("status")] OutgoingPaymentStatus Status,
+    [property: JsonPropertyName("execution_date")] DateOnly ExecutionDate,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("sender_bank_account_id")] int? SenderBankAccountId,
+    [property: JsonPropertyName("receiver_account_no")] string? ReceiverAccountNo,
+    [property: JsonPropertyName("receiver_iban")] string? ReceiverIban,
+    [property: JsonPropertyName("banking_payment_id")] Guid? BankingPaymentId,
+    [property: JsonPropertyName("transaction_id")] Guid? TransactionId
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/OutgoingPaymentListResponse.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/OutgoingPaymentListResponse.cs
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments;
+
+/// <summary>
+/// Envelope response returned by <c>GET /4.0/purchase/outgoing-payments</c>.
+/// The v4.0 list endpoints wrap results in a <c>{ data, paging }</c> object instead of
+/// returning a raw array (the convention used by v2.0 / v3.0 endpoints).
+/// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPaymentList_GET">List Outgoing Payments</see>
+/// </summary>
+/// <param name="Data">Outgoing payments matching the query.</param>
+/// <param name="Paging">Pagination metadata for the current page.</param>
+public sealed record OutgoingPaymentListResponse(
+    [property: JsonPropertyName("data")] IReadOnlyList<OutgoingPaymentListItem> Data,
+    [property: JsonPropertyName("paging")] OutgoingPaymentPaging Paging
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/OutgoingPaymentPaging.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/OutgoingPaymentPaging.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments;
+
+/// <summary>
+/// Paging envelope returned by the list endpoint
+/// <c>GET /4.0/purchase/outgoing-payments</c>. Bexio v4.0 list endpoints use
+/// page-based pagination (not offset-based).
+/// </summary>
+/// <param name="Page">Current 1-based page number.</param>
+/// <param name="PageSize">Number of items per page (<c>limit</c> query parameter).</param>
+/// <param name="PageCount">Total number of pages.</param>
+/// <param name="ItemCount">Total number of items across all pages.</param>
+public sealed record OutgoingPaymentPaging(
+    [property: JsonPropertyName("page")] int Page,
+    [property: JsonPropertyName("page_size")] int PageSize,
+    [property: JsonPropertyName("page_count")] int PageCount,
+    [property: JsonPropertyName("item_count")] int ItemCount
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Views/OutgoingPaymentCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Views/OutgoingPaymentCreate.cs
@@ -1,0 +1,103 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Views;
+
+/// <summary>
+/// Create view for <c>POST /4.0/purchase/outgoing-payments</c>.
+/// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPayment_POST">Create Outgoing Payment</see>
+/// </summary>
+/// <param name="BillId">Identifier of the bill. Payment can only be created for bills that are not in <c>DRAFT</c> status.</param>
+/// <param name="PaymentType">Payment type. Bill amounts cannot be covered by <c>CASH_DISCOUNT</c> payments only.</param>
+/// <param name="ExecutionDate">Execution date. Must be within an existing (non-closed, non-locked) business year; for <c>IBAN</c>/<c>QR</c> it must be in the present or future and not on a weekend.</param>
+/// <param name="Amount">Payment amount. Must be less or equal to the bill's pending amount; maximum 17 digits and 2 decimals.</param>
+/// <param name="CurrencyCode">Currency code. Must equal the bill's currency. Only <c>CHF</c> and <c>EUR</c> are allowed for <c>QR</c>.</param>
+/// <param name="ExchangeRate">Exchange rate. Maximum 5 digits and 10 decimals.</param>
+/// <param name="SenderBankAccountId">Bexio bank account identifier of the sender. Required for <c>IBAN</c>/<c>MANUAL</c>/<c>QR</c>; not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="IsSalaryPayment">Whether this is a salary payment. Only allowed to be <c>true</c> for <c>IBAN</c>.</param>
+/// <param name="Note">Optional note. Not allowed for <c>IBAN</c>/<c>QR</c>.</param>
+/// <param name="SenderIban">Sender IBAN. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderName">Sender name. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderStreet">Sender street. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderHouseNo">Sender house number. Not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderCity">Sender city. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderPostcode">Sender postcode. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderCountryCode">Sender country code. Not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderBcNo">Sender bank clearing number. Not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderBankNo">Sender bank number. Not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="SenderBankName">Sender bank name. Not allowed for <c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverAccountNo">Deprecated — receiver account number.</param>
+/// <param name="ReceiverIban">Receiver IBAN. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>. For <c>QR</c>, must be a valid QR IBAN.</param>
+/// <param name="ReceiverName">Receiver name. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverStreet">Receiver street. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverHouseNo">Receiver house number. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverCity">Receiver city. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverPostcode">Receiver postcode. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverCountryCode">Receiver country code. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverBcNo">Receiver bank clearing number. Not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverBankNo">Receiver bank number. Not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverBankName">Receiver bank name. Not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="FeeType">Fee allocation. Required for <c>IBAN</c>; not allowed for <c>QR</c>/<c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReferenceNo">Reference number (for <c>QR</c>).</param>
+/// <param name="Message">Remittance message. Not allowed for <c>QR</c>/<c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="BookingText">Internal booking text. Not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+public sealed record OutgoingPaymentCreate(
+    [property: JsonPropertyName("bill_id")] Guid BillId,
+    [property: JsonPropertyName("payment_type")] OutgoingPaymentType PaymentType,
+    [property: JsonPropertyName("execution_date")] DateOnly ExecutionDate,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("currency_code")] string CurrencyCode,
+    [property: JsonPropertyName("exchange_rate")] decimal ExchangeRate,
+    [property: JsonPropertyName("sender_bank_account_id")] int SenderBankAccountId,
+    [property: JsonPropertyName("is_salary_payment")] bool IsSalaryPayment,
+    [property: JsonPropertyName("note")] string? Note = null,
+    [property: JsonPropertyName("sender_iban")] string? SenderIban = null,
+    [property: JsonPropertyName("sender_name")] string? SenderName = null,
+    [property: JsonPropertyName("sender_street")] string? SenderStreet = null,
+    [property: JsonPropertyName("sender_house_no")] string? SenderHouseNo = null,
+    [property: JsonPropertyName("sender_city")] string? SenderCity = null,
+    [property: JsonPropertyName("sender_postcode")] string? SenderPostcode = null,
+    [property: JsonPropertyName("sender_country_code")] string? SenderCountryCode = null,
+    [property: JsonPropertyName("sender_bc_no")] string? SenderBcNo = null,
+    [property: JsonPropertyName("sender_bank_no")] string? SenderBankNo = null,
+    [property: JsonPropertyName("sender_bank_name")] string? SenderBankName = null,
+    [property: JsonPropertyName("receiver_account_no")] string? ReceiverAccountNo = null,
+    [property: JsonPropertyName("receiver_iban")] string? ReceiverIban = null,
+    [property: JsonPropertyName("receiver_name")] string? ReceiverName = null,
+    [property: JsonPropertyName("receiver_street")] string? ReceiverStreet = null,
+    [property: JsonPropertyName("receiver_house_no")] string? ReceiverHouseNo = null,
+    [property: JsonPropertyName("receiver_city")] string? ReceiverCity = null,
+    [property: JsonPropertyName("receiver_postcode")] string? ReceiverPostcode = null,
+    [property: JsonPropertyName("receiver_country_code")] string? ReceiverCountryCode = null,
+    [property: JsonPropertyName("receiver_bc_no")] string? ReceiverBcNo = null,
+    [property: JsonPropertyName("receiver_bank_no")] string? ReceiverBankNo = null,
+    [property: JsonPropertyName("receiver_bank_name")] string? ReceiverBankName = null,
+    [property: JsonPropertyName("fee_type")] OutgoingPaymentFeeType? FeeType = null,
+    [property: JsonPropertyName("reference_no")] string? ReferenceNo = null,
+    [property: JsonPropertyName("message")] string? Message = null,
+    [property: JsonPropertyName("booking_text")] string? BookingText = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Views/OutgoingPaymentUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/OutgoingPayments/Views/OutgoingPaymentUpdate.cs
@@ -1,0 +1,64 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Views;
+
+/// <summary>
+/// Update view for <c>PUT /4.0/purchase/outgoing-payments</c>. The target payment is identified by
+/// <see cref="PaymentId"/> in the body — the Bexio spec does not use <c>{id}</c> in the request path for this endpoint.
+/// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPayment_PUT">Edit Outgoing Payment</see>
+/// </summary>
+/// <param name="PaymentId">Identifier of the outgoing payment to update.</param>
+/// <param name="ExecutionDate">Execution date. Must be within an existing business year; for <c>IBAN</c>/<c>QR</c> it must be in the present or future and not on a weekend.</param>
+/// <param name="Amount">Payment amount. Must be less or equal to the bill's pending amount; maximum 17 digits and 2 decimals.</param>
+/// <param name="IsSalaryPayment">Whether this is a salary payment. Only allowed to be <c>true</c> for <c>IBAN</c>.</param>
+/// <param name="FeeType">Fee allocation. Required for <c>IBAN</c>; not allowed for <c>QR</c>/<c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReferenceNo">Reference number. For <c>QR</c> payments, must be a valid ISR account or creditor reference.</param>
+/// <param name="Message">Remittance message. Not allowed for <c>QR</c>/<c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverIban">Receiver IBAN. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverName">Receiver name. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverStreet">Receiver street. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverHouseNo">Receiver house number. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverCity">Receiver city. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverPostcode">Receiver postcode. Required for <c>IBAN</c>/<c>QR</c>; not allowed for <c>MANUAL</c>/<c>CASH_DISCOUNT</c>.</param>
+/// <param name="ReceiverCountryCode">Receiver country code.</param>
+public sealed record OutgoingPaymentUpdate(
+    [property: JsonPropertyName("payment_id")] Guid PaymentId,
+    [property: JsonPropertyName("execution_date")] DateOnly ExecutionDate,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("is_salary_payment")] bool IsSalaryPayment,
+    [property: JsonPropertyName("fee_type")] OutgoingPaymentFeeType? FeeType = null,
+    [property: JsonPropertyName("reference_no")] string? ReferenceNo = null,
+    [property: JsonPropertyName("message")] string? Message = null,
+    [property: JsonPropertyName("receiver_iban")] string? ReceiverIban = null,
+    [property: JsonPropertyName("receiver_name")] string? ReceiverName = null,
+    [property: JsonPropertyName("receiver_street")] string? ReceiverStreet = null,
+    [property: JsonPropertyName("receiver_house_no")] string? ReceiverHouseNo = null,
+    [property: JsonPropertyName("receiver_city")] string? ReceiverCity = null,
+    [property: JsonPropertyName("receiver_postcode")] string? ReceiverPostcode = null,
+    [property: JsonPropertyName("receiver_country_code")] string? ReceiverCountryCode = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/PaymentTypes/PaymentType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/PaymentTypes/PaymentType.cs
@@ -1,0 +1,36 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Banking.PaymentTypes;
+
+/// <summary>
+///     Bexio payment type. <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2ListPaymentTypes" />
+/// </summary>
+/// <param name="Id">Unique payment type identifier (read-only).</param>
+/// <param name="Name">Human-readable payment type name (e.g. <c>Cash</c>, <c>Bank</c>).</param>
+public sealed record PaymentType(
+    [property: JsonPropertyName("id")] int? Id,
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/Enums/PaymentAllowance.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/Enums/PaymentAllowance.cs
@@ -1,0 +1,56 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+
+/// <summary>
+/// Fee allowance mode for a payment. Controls how transaction fees are split between payer and payee,
+/// typically relevant for payments in a different currency or to a foreign country.
+/// <see href="https://docs.bexio.com/#tag/Payments"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PaymentAllowance
+{
+    /// <summary>
+    /// All transaction fees are paid by the payer.
+    /// </summary>
+    fee_paid_by_payer,
+
+    /// <summary>
+    /// All transaction fees are paid by the payee.
+    /// </summary>
+    fee_paid_by_payee,
+
+    /// <summary>
+    /// Transaction fees are split between payer and payee.
+    /// </summary>
+    fee_split,
+
+    /// <summary>
+    /// No transaction fees apply.
+    /// </summary>
+    no_fee
+}

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/Enums/PaymentStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/Enums/PaymentStatus.cs
@@ -1,0 +1,65 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+
+/// <summary>
+/// Lifecycle status of a payment returned by the Bexio banking API.
+/// <see href="https://docs.bexio.com/#tag/Payments"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PaymentStatus
+{
+    /// <summary>
+    /// Payment has been created but not yet transmitted to the bank.
+    /// </summary>
+    open,
+
+    /// <summary>
+    /// Payment instruction has been transmitted to the bank.
+    /// </summary>
+    transmitted,
+
+    /// <summary>
+    /// Payment file has been downloaded for manual bank upload.
+    /// </summary>
+    downloaded,
+
+    /// <summary>
+    /// Payment has been successfully paid by the bank.
+    /// </summary>
+    paid,
+
+    /// <summary>
+    /// Payment failed during processing.
+    /// </summary>
+    failed,
+
+    /// <summary>
+    /// Payment has been cancelled.
+    /// </summary>
+    cancelled
+}

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/Enums/PaymentType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/Enums/PaymentType.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+
+/// <summary>
+/// Type of a Bexio banking payment. Different types require different fields on the create payload.
+/// <see href="https://docs.bexio.com/#tag/Payments"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PaymentType
+{
+    /// <summary>
+    /// Payment by IBAN.
+    /// </summary>
+    iban,
+
+    /// <summary>
+    /// Payment using a Swiss QR invoice slip.
+    /// </summary>
+    qr
+}

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/Payment.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/Payment.cs
@@ -1,0 +1,73 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Banking.Payments;
+
+/// <summary>
+/// Payment as returned by the Bexio banking payments endpoints.
+/// <see href="https://docs.bexio.com/#tag/Payments/operation/NewFetchAllPayments"/>
+/// </summary>
+/// <param name="Id">Numeric identifier of the payment.</param>
+/// <param name="Uuid">Unique identifier (UUID) of the payment.</param>
+/// <param name="Sender">Sender account used for the payment.</param>
+/// <param name="Recipient">Recipient (beneficiary) of the payment.</param>
+/// <param name="Amount">Amount to send in the chosen currency.</param>
+/// <param name="Currency">ISO 4217 currency code (three uppercase letters).</param>
+/// <param name="ExecutionDate">Execution date of the payment (when it should be carried out by the bank).</param>
+/// <param name="Allowance">Fee allowance mode.</param>
+/// <param name="IsSalary">Whether this payment is a salary payment.</param>
+/// <param name="InstructionId">Optional instruction identifier assigned by the bank.</param>
+/// <param name="PurchaseReference">Reference to a purchase bill and its bill payment entry, if any.</param>
+/// <param name="DocumentNo">Document number of the linked purchase bill, or empty when there is no linked bill.</param>
+/// <param name="QrReferenceNumber">QR IBAN or SCOR reference number (required for QR invoice payments).</param>
+/// <param name="AdditionalInformation">Additional information for QR invoice payments.</param>
+/// <param name="Status">Lifecycle status of the payment.</param>
+/// <param name="Type">Type of the payment (iban or qr).</param>
+/// <param name="DueDate">Due date for the purchase payment.</param>
+/// <param name="CreatedAt">Timestamp when the payment was created.</param>
+/// <param name="IsEditingRestricted">If true, editing is restricted to the API client that created the payment.</param>
+public sealed record Payment(
+    [property: JsonPropertyName("id")] int? Id,
+    [property: JsonPropertyName("uuid")] string? Uuid,
+    [property: JsonPropertyName("sender")] PaymentSender? Sender,
+    [property: JsonPropertyName("recipient")] PaymentRecipient? Recipient,
+    [property: JsonPropertyName("amount")] decimal? Amount,
+    [property: JsonPropertyName("currency")] string? Currency,
+    [property: JsonPropertyName("execution_date")] DateOnly? ExecutionDate,
+    [property: JsonPropertyName("allowance")] PaymentAllowance? Allowance,
+    [property: JsonPropertyName("is_salary")] bool? IsSalary,
+    [property: JsonPropertyName("instruction_id")] string? InstructionId,
+    [property: JsonPropertyName("purchase_reference")] PaymentPurchaseReference? PurchaseReference,
+    [property: JsonPropertyName("document_no")] string? DocumentNo,
+    [property: JsonPropertyName("qr_reference_number")] string? QrReferenceNumber,
+    [property: JsonPropertyName("additional_information")] string? AdditionalInformation,
+    [property: JsonPropertyName("status")] PaymentStatus? Status,
+    [property: JsonPropertyName("type")] PaymentType? Type,
+    [property: JsonPropertyName("due_date")] DateOnly? DueDate,
+    [property: JsonPropertyName("created_at")] string? CreatedAt,
+    [property: JsonPropertyName("is_editing_restricted")] bool? IsEditingRestricted
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/PaymentAddress.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/PaymentAddress.cs
@@ -1,0 +1,43 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Banking.Payments;
+
+/// <summary>
+/// Postal address as used by the Bexio banking payments endpoint.
+/// <see href="https://docs.bexio.com/#tag/Payments"/>
+/// </summary>
+/// <param name="StreetName">Street name of the address.</param>
+/// <param name="HouseNumber">Optional house number of the address.</param>
+/// <param name="Zip">Postal code of the address.</param>
+/// <param name="City">City of the address.</param>
+/// <param name="CountryCode">ISO 3166-1 alpha-2 country code (two uppercase letters). Defaults to "CH" in the Bexio API.</param>
+public sealed record PaymentAddress(
+    [property: JsonPropertyName("street_name")] string StreetName,
+    [property: JsonPropertyName("house_number")] string? HouseNumber,
+    [property: JsonPropertyName("zip")] string Zip,
+    [property: JsonPropertyName("city")] string City,
+    [property: JsonPropertyName("country_code")] string CountryCode
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/PaymentPurchaseReference.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/PaymentPurchaseReference.cs
@@ -1,0 +1,37 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Banking.Payments;
+
+/// <summary>
+/// Reference linking a banking payment to a purchase bill and its related bill payment.
+/// <see href="https://docs.bexio.com/#tag/Payments"/>
+/// </summary>
+/// <param name="BillId">UUID of the purchase bill the payment is tied to.</param>
+/// <param name="BillPaymentId">UUID of the bill payment entry within the bill.</param>
+public sealed record PaymentPurchaseReference(
+    [property: JsonPropertyName("bill_id")] Guid? BillId,
+    [property: JsonPropertyName("bill_payment_id")] Guid? BillPaymentId
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/PaymentRecipient.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/PaymentRecipient.cs
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Banking.Payments;
+
+/// <summary>
+/// Recipient of a Bexio banking payment (the beneficiary/payee account holder).
+/// <see href="https://docs.bexio.com/#tag/Payments"/>
+/// </summary>
+/// <param name="Name">Name of the owner of the bank account (individual or legal entity).</param>
+/// <param name="Iban">IBAN according to ISO 13616.</param>
+/// <param name="Address">Postal address of the recipient.</param>
+public sealed record PaymentRecipient(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("iban")] string Iban,
+    [property: JsonPropertyName("address")] PaymentAddress Address
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/PaymentSender.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/PaymentSender.cs
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Banking.Payments;
+
+/// <summary>
+/// Sender information of a Bexio banking payment (the Bexio tenant's own account used as the source).
+/// <see href="https://docs.bexio.com/#tag/Payments"/>
+/// </summary>
+/// <param name="Id">Numeric sender account id.</param>
+/// <param name="Uuid">Unique identifier (UUID) of the sender account.</param>
+/// <param name="Iban">IBAN of the sender account according to ISO 13616.</param>
+public sealed record PaymentSender(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("iban")] string Iban
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/Views/PaymentCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/Views/PaymentCreate.cs
@@ -1,0 +1,61 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Banking.Payments.Views;
+
+/// <summary>
+/// Create view for a banking payment.
+/// <see href="https://docs.bexio.com/#tag/Payments/operation/NewCreatePayment"/>
+/// </summary>
+/// <param name="Type">Type of the payment (iban or qr).</param>
+/// <param name="AccountId">UUID of the Bexio sender bank account to debit.</param>
+/// <param name="Recipient">Recipient (beneficiary) of the payment.</param>
+/// <param name="Amount">Amount to send in the chosen currency (must be &gt; 0).</param>
+/// <param name="Currency">ISO 4217 currency code (three uppercase letters).</param>
+/// <param name="ExecutionDate">Execution date (should be at least the next working day).</param>
+/// <param name="IsSalary">Whether this is a salary payment.</param>
+/// <param name="Allowance">Fee allowance mode. Defaults to <see cref="PaymentAllowance.fee_split"/> server-side when omitted.</param>
+/// <param name="QrReferenceNr">QR reference number or creditor reference number (for QR invoice payments).</param>
+/// <param name="AdditionalInformation">Additional information on the payment slip.</param>
+/// <param name="PurchaseReference">Reference to a purchase bill and its bill payment entry.</param>
+/// <param name="IsEditingRestricted">If true, editing is restricted to the API client that created the payment.</param>
+/// <param name="Message">Multi-line description of the payment.</param>
+public sealed record PaymentCreate(
+    [property: JsonPropertyName("type")] PaymentType Type,
+    [property: JsonPropertyName("account_id")] Guid AccountId,
+    [property: JsonPropertyName("recipient")] PaymentRecipient Recipient,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("currency")] string Currency,
+    [property: JsonPropertyName("execution_date")] DateOnly ExecutionDate,
+    [property: JsonPropertyName("is_salary")] bool IsSalary,
+    [property: JsonPropertyName("allowance")] PaymentAllowance? Allowance = null,
+    [property: JsonPropertyName("qr_reference_nr")] string? QrReferenceNr = null,
+    [property: JsonPropertyName("additional_information")] string? AdditionalInformation = null,
+    [property: JsonPropertyName("purchase_reference")] PaymentPurchaseReference? PurchaseReference = null,
+    [property: JsonPropertyName("is_editing_restricted")] bool? IsEditingRestricted = null,
+    [property: JsonPropertyName("message")] string? Message = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Banking/Payments/Views/PaymentUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/Payments/Views/PaymentUpdate.cs
@@ -1,0 +1,56 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Banking.Payments.Views;
+
+/// <summary>
+/// Update view for a banking payment. Only the fields that should be changed need to be supplied;
+/// unspecified fields are omitted from the JSON payload.
+/// <see href="https://docs.bexio.com/#tag/Payments/operation/NewUpdatePayment"/>
+/// </summary>
+/// <param name="Allowance">Fee allowance mode.</param>
+/// <param name="Amount">Amount to send in the chosen currency (must be &gt; 0).</param>
+/// <param name="Currency">ISO 4217 currency code (three uppercase letters).</param>
+/// <param name="ExecutionDate">Execution date (should be at least the next working day).</param>
+/// <param name="IsSalary">Whether this is a salary payment.</param>
+/// <param name="Recipient">Recipient (beneficiary) of the payment.</param>
+/// <param name="QrReferenceNr">QR reference number or creditor reference number (for QR invoice payments).</param>
+/// <param name="AdditionalInformation">Additional information on the payment slip.</param>
+/// <param name="IsEditingRestricted">If true, editing is restricted to the API client that created the payment.</param>
+/// <param name="Message">Multi-line description of the payment.</param>
+public sealed record PaymentUpdate(
+    [property: JsonPropertyName("allowance")] PaymentAllowance? Allowance = null,
+    [property: JsonPropertyName("amount")] decimal? Amount = null,
+    [property: JsonPropertyName("currency")] string? Currency = null,
+    [property: JsonPropertyName("execution_date")] DateOnly? ExecutionDate = null,
+    [property: JsonPropertyName("is_salary")] bool? IsSalary = null,
+    [property: JsonPropertyName("recipient")] PaymentRecipient? Recipient = null,
+    [property: JsonPropertyName("qr_reference_nr")] string? QrReferenceNr = null,
+    [property: JsonPropertyName("additional_information")] string? AdditionalInformation = null,
+    [property: JsonPropertyName("is_editing_restricted")] bool? IsEditingRestricted = null,
+    [property: JsonPropertyName("message")] string? Message = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/AdditionalAddresses/AdditionalAddress.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/AdditionalAddresses/AdditionalAddress.cs
@@ -1,0 +1,56 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses;
+
+/// <summary>
+/// Additional address attached to a Bexio contact. <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2ListAdditionalAddresses"/>
+/// </summary>
+/// <param name="Id">Unique identifier of the additional address.</param>
+/// <param name="Name">Display name of the additional address.</param>
+/// <param name="NameAddition">Optional name addition / suffix.</param>
+/// <param name="Address">Combined address line returned by list/show responses (e.g. <c>"Walter Street 22"</c>).</param>
+/// <param name="StreetName">Street name of the additional address.</param>
+/// <param name="HouseNumber">House number of the additional address.</param>
+/// <param name="AddressAddition">Optional address addition (e.g. <c>"Building C"</c>).</param>
+/// <param name="Postcode">Postal code of the additional address.</param>
+/// <param name="City">City of the additional address.</param>
+/// <param name="CountryId">Country identifier. References a country object.</param>
+/// <param name="Subject">Subject line describing the additional address.</param>
+/// <param name="Description">Free-form internal description of the additional address.</param>
+public sealed record AdditionalAddress(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("name_addition")] string? NameAddition,
+    [property: JsonPropertyName("address")] string? Address,
+    [property: JsonPropertyName("street_name")] string? StreetName,
+    [property: JsonPropertyName("house_number")] string? HouseNumber,
+    [property: JsonPropertyName("address_addition")] string? AddressAddition,
+    [property: JsonPropertyName("postcode")] string? Postcode,
+    [property: JsonPropertyName("city")] string? City,
+    [property: JsonPropertyName("country_id")] int? CountryId,
+    [property: JsonPropertyName("subject")] string? Subject,
+    [property: JsonPropertyName("description")] string? Description
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/AdditionalAddresses/Views/AdditionalAddressCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/AdditionalAddresses/Views/AdditionalAddressCreate.cs
@@ -1,0 +1,52 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses.Views;
+
+/// <summary>
+/// Create view for an additional address. <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2CreateAdditionalAddress"/>
+/// </summary>
+/// <param name="Name">Display name of the additional address.</param>
+/// <param name="NameAddition">Optional name addition / suffix.</param>
+/// <param name="StreetName">Street name. Is required if <c>house_number</c> or <c>address_addition</c> are not <c>null</c>.</param>
+/// <param name="HouseNumber">House number. Requires <c>street_name</c> when not <c>null</c>.</param>
+/// <param name="AddressAddition">Optional address addition. Requires <c>street_name</c> when not <c>null</c>.</param>
+/// <param name="Postcode">Postal code of the additional address.</param>
+/// <param name="City">City of the additional address.</param>
+/// <param name="CountryId">Country identifier. References a country object.</param>
+/// <param name="Subject">Subject line describing the additional address.</param>
+/// <param name="Description">Free-form internal description of the additional address.</param>
+public sealed record AdditionalAddressCreate(
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("name_addition")] string? NameAddition,
+    [property: JsonPropertyName("street_name")] string? StreetName,
+    [property: JsonPropertyName("house_number")] string? HouseNumber,
+    [property: JsonPropertyName("address_addition")] string? AddressAddition,
+    [property: JsonPropertyName("postcode")] string? Postcode,
+    [property: JsonPropertyName("city")] string? City,
+    [property: JsonPropertyName("country_id")] int? CountryId,
+    [property: JsonPropertyName("subject")] string? Subject,
+    [property: JsonPropertyName("description")] string? Description
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/AdditionalAddresses/Views/AdditionalAddressUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/AdditionalAddresses/Views/AdditionalAddressUpdate.cs
@@ -1,0 +1,54 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses.Views;
+
+/// <summary>
+/// Update view for an additional address. The Bexio edit endpoint uses HTTP <c>POST</c>
+/// (not <c>PUT</c>) and accepts the same body shape as create.
+/// <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2EditAdditionalAddress"/>
+/// </summary>
+/// <param name="Name">Display name of the additional address.</param>
+/// <param name="NameAddition">Optional name addition / suffix.</param>
+/// <param name="StreetName">Street name. Is required if <c>house_number</c> or <c>address_addition</c> are not <c>null</c>.</param>
+/// <param name="HouseNumber">House number. Requires <c>street_name</c> when not <c>null</c>.</param>
+/// <param name="AddressAddition">Optional address addition. Requires <c>street_name</c> when not <c>null</c>.</param>
+/// <param name="Postcode">Postal code of the additional address.</param>
+/// <param name="City">City of the additional address.</param>
+/// <param name="CountryId">Country identifier. References a country object.</param>
+/// <param name="Subject">Subject line describing the additional address.</param>
+/// <param name="Description">Free-form internal description of the additional address.</param>
+public sealed record AdditionalAddressUpdate(
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("name_addition")] string? NameAddition,
+    [property: JsonPropertyName("street_name")] string? StreetName,
+    [property: JsonPropertyName("house_number")] string? HouseNumber,
+    [property: JsonPropertyName("address_addition")] string? AddressAddition,
+    [property: JsonPropertyName("postcode")] string? Postcode,
+    [property: JsonPropertyName("city")] string? City,
+    [property: JsonPropertyName("country_id")] int? CountryId,
+    [property: JsonPropertyName("subject")] string? Subject,
+    [property: JsonPropertyName("description")] string? Description
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/ContactGroups/ContactGroup.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/ContactGroups/ContactGroup.cs
@@ -1,0 +1,36 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.ContactGroups;
+
+/// <summary>
+/// Contact group object. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2ListContactGroups"/>
+/// </summary>
+/// <param name="Id"></param>
+/// <param name="Name"></param>
+public sealed record ContactGroup(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/ContactGroups/Views/ContactGroupCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/ContactGroups/Views/ContactGroupCreate.cs
@@ -1,0 +1,34 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.ContactGroups.Views;
+
+/// <summary>
+/// Create view for a contact group. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2CreateContactGroup"/>
+/// </summary>
+/// <param name="Name"></param>
+public sealed record ContactGroupCreate(
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/ContactGroups/Views/ContactGroupUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/ContactGroups/Views/ContactGroupUpdate.cs
@@ -1,0 +1,34 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.ContactGroups.Views;
+
+/// <summary>
+/// Edit view for a contact group. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2EditContactGroup"/>
+/// </summary>
+/// <param name="Name"></param>
+public sealed record ContactGroupUpdate(
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/ContactRelations/ContactRelation.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/ContactRelations/ContactRelation.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.ContactRelations;
+
+/// <summary>
+/// Contact relation linking two contacts. <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2ListContactRelations"/>
+/// </summary>
+/// <param name="Id">Unique identifier of the contact relation.</param>
+/// <param name="ContactId">Identifier of the primary contact.</param>
+/// <param name="ContactSubId">Identifier of the related contact.</param>
+/// <param name="Description">Free text description of the relation.</param>
+/// <param name="UpdatedAt">Timestamp of the last update (read-only, supplied by Bexio).</param>
+public sealed record ContactRelation(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("contact_id")] int? ContactId,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("updated_at")] string? UpdatedAt
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/ContactRelations/Views/ContactRelationCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/ContactRelations/Views/ContactRelationCreate.cs
@@ -1,0 +1,38 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.ContactRelations.Views;
+
+/// <summary>
+/// Create view for a contact relation. <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2CreateContactRelation">Create Contact Relation</see>
+/// </summary>
+/// <param name="ContactId">Identifier of the primary contact. References a contact object.</param>
+/// <param name="ContactSubId">Identifier of the related contact. References a contact object.</param>
+/// <param name="Description">Optional free text description of the relation.</param>
+public sealed record ContactRelationCreate(
+    [property: JsonPropertyName("contact_id")] int? ContactId,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId,
+    [property: JsonPropertyName("description")] string? Description
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/ContactRelations/Views/ContactRelationUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/ContactRelations/Views/ContactRelationUpdate.cs
@@ -1,0 +1,38 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.ContactRelations.Views;
+
+/// <summary>
+/// Update view for a contact relation. <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2EditContactRelation">Edit Contact Relation</see>
+/// </summary>
+/// <param name="ContactId">Identifier of the primary contact. References a contact object.</param>
+/// <param name="ContactSubId">Identifier of the related contact. References a contact object.</param>
+/// <param name="Description">Optional free text description of the relation.</param>
+public sealed record ContactRelationUpdate(
+    [property: JsonPropertyName("contact_id")] int? ContactId,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId,
+    [property: JsonPropertyName("description")] string? Description
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/ContactSectors/ContactSector.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/ContactSectors/ContactSector.cs
@@ -1,0 +1,37 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.ContactSectors;
+
+/// <summary>
+/// Contact sector object. Bexio exposes these under the <c>/2.0/contact_branch</c> route but the
+/// public concept is "contact sector". <see href="https://docs.bexio.com/#tag/Contact-Sectors"/>
+/// </summary>
+/// <param name="Id">Unique contact sector identifier.</param>
+/// <param name="Name">Display name of the contact sector (e.g. "Photography").</param>
+public sealed record ContactSector(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/Contacts/Contact.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/Contacts/Contact.cs
@@ -1,0 +1,100 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.Contacts;
+
+/// <summary>
+/// Contact as returned by the Bexio contacts endpoint. Covers both the plain <c>Contact</c>
+/// schema and the <c>ContactWithDetails</c> variant (which adds <c>profile_image</c>).
+/// <see href="https://docs.bexio.com/#tag/Contacts/operation/v2ListContacts"/>
+/// </summary>
+/// <param name="Id">Unique contact identifier (read-only).</param>
+/// <param name="Nr">Optional customer number (string of digits). Bexio assigns one automatically when <see langword="null"/>.</param>
+/// <param name="ContactTypeId"><c>1</c> for companies, <c>2</c> for persons.</param>
+/// <param name="Name1">Company name if <see cref="ContactTypeId"/> is <c>1</c>, otherwise the person's last name.</param>
+/// <param name="Name2">Company addition if <see cref="ContactTypeId"/> is <c>1</c>, otherwise the person's first name.</param>
+/// <param name="SalutationId">Reference to a salutation object.</param>
+/// <param name="SalutationForm">Salutation form id.</param>
+/// <param name="TitleId">Reference to a title object (read-only — use <c>titel_id</c> for writes).</param>
+/// <param name="Birthday">Birthday of the contact.</param>
+/// <param name="Address">Composed address string returned by Bexio (read-only).</param>
+/// <param name="StreetName">Street part of the postal address.</param>
+/// <param name="HouseNumber">House number part of the postal address.</param>
+/// <param name="AddressAddition">Additional address line (e.g. building, c/o).</param>
+/// <param name="Postcode">Postal code.</param>
+/// <param name="City">City or locality.</param>
+/// <param name="CountryId">Reference to a country object.</param>
+/// <param name="Mail">Primary email address.</param>
+/// <param name="MailSecond">Secondary email address.</param>
+/// <param name="PhoneFixed">Primary landline phone number.</param>
+/// <param name="PhoneFixedSecond">Secondary landline phone number.</param>
+/// <param name="PhoneMobile">Mobile phone number.</param>
+/// <param name="Fax">Fax number.</param>
+/// <param name="Url">Website URL.</param>
+/// <param name="SkypeName">Skype name.</param>
+/// <param name="Remarks">Free-text remarks.</param>
+/// <param name="LanguageId">Reference to a language object.</param>
+/// <param name="IsLead">Legacy lead flag (deprecated, read-only).</param>
+/// <param name="ContactGroupIds">Comma-separated references to one or more contact group objects.</param>
+/// <param name="ContactBranchIds">Comma-separated references to one or more contact sector objects.</param>
+/// <param name="UserId">Reference to the user that owns the contact.</param>
+/// <param name="OwnerId">Reference to the owner of the contact.</param>
+/// <param name="UpdatedAt">Timestamp of the last update in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format (read-only).</param>
+/// <param name="ProfileImage">Base64-encoded profile image. Only populated on the <c>ContactWithDetails</c> responses (show / create / update).</param>
+public sealed record Contact(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("nr")] string? Nr,
+    [property: JsonPropertyName("contact_type_id")] int ContactTypeId,
+    [property: JsonPropertyName("name_1")] string Name1,
+    [property: JsonPropertyName("name_2")] string? Name2,
+    [property: JsonPropertyName("salutation_id")] int? SalutationId,
+    [property: JsonPropertyName("salutation_form")] int? SalutationForm,
+    [property: JsonPropertyName("title_id")] int? TitleId,
+    [property: JsonPropertyName("birthday")] DateOnly? Birthday,
+    [property: JsonPropertyName("address")] string? Address,
+    [property: JsonPropertyName("street_name")] string? StreetName,
+    [property: JsonPropertyName("house_number")] string? HouseNumber,
+    [property: JsonPropertyName("address_addition")] string? AddressAddition,
+    [property: JsonPropertyName("postcode")] string? Postcode,
+    [property: JsonPropertyName("city")] string? City,
+    [property: JsonPropertyName("country_id")] int? CountryId,
+    [property: JsonPropertyName("mail")] string? Mail,
+    [property: JsonPropertyName("mail_second")] string? MailSecond,
+    [property: JsonPropertyName("phone_fixed")] string? PhoneFixed,
+    [property: JsonPropertyName("phone_fixed_second")] string? PhoneFixedSecond,
+    [property: JsonPropertyName("phone_mobile")] string? PhoneMobile,
+    [property: JsonPropertyName("fax")] string? Fax,
+    [property: JsonPropertyName("url")] string? Url,
+    [property: JsonPropertyName("skype_name")] string? SkypeName,
+    [property: JsonPropertyName("remarks")] string? Remarks,
+    [property: JsonPropertyName("language_id")] int? LanguageId,
+    [property: JsonPropertyName("is_lead")] bool? IsLead,
+    [property: JsonPropertyName("contact_group_ids")] string? ContactGroupIds,
+    [property: JsonPropertyName("contact_branch_ids")] string? ContactBranchIds,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("owner_id")] int OwnerId,
+    [property: JsonPropertyName("updated_at")] string? UpdatedAt,
+    [property: JsonPropertyName("profile_image")] string? ProfileImage
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/Contacts/Views/ContactCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/Contacts/Views/ContactCreate.cs
@@ -1,0 +1,93 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.Contacts.Views;
+
+/// <summary>
+/// Create view for a contact — body of <c>POST /2.0/contact</c> and items sent to
+/// <c>POST /2.0/contact/_bulk_create</c>. Read-only fields (<c>id</c>, <c>address</c>,
+/// <c>is_lead</c>, <c>updated_at</c>, <c>title_id</c>) are intentionally omitted.
+/// The write-only title field is called <c>titel_id</c> by Bexio — the typo is
+/// preserved to match the live API exactly.
+/// <see href="https://docs.bexio.com/#tag/Contacts/operation/v2CreateContact"/>
+/// </summary>
+/// <param name="ContactTypeId"><c>1</c> for companies, <c>2</c> for persons.</param>
+/// <param name="Name1">Company name if <see cref="ContactTypeId"/> is <c>1</c>, otherwise the person's last name.</param>
+/// <param name="UserId">Reference to the user that owns the contact.</param>
+/// <param name="OwnerId">Reference to the owner of the contact.</param>
+/// <param name="Nr">Optional customer number. Bexio assigns one automatically when <see langword="null"/>.</param>
+/// <param name="Name2">Company addition if <see cref="ContactTypeId"/> is <c>1</c>, otherwise the person's first name.</param>
+/// <param name="SalutationId">Reference to a salutation object.</param>
+/// <param name="SalutationForm">Salutation form id.</param>
+/// <param name="TitelId">Reference to a title object (write-only; Bexio uses the spelling <c>titel_id</c>).</param>
+/// <param name="Birthday">Birthday of the contact.</param>
+/// <param name="StreetName">Street part of the postal address. Required when <see cref="HouseNumber"/> or <see cref="AddressAddition"/> is provided.</param>
+/// <param name="HouseNumber">House number part of the postal address.</param>
+/// <param name="AddressAddition">Additional address line (e.g. building, c/o).</param>
+/// <param name="Postcode">Postal code.</param>
+/// <param name="City">City or locality.</param>
+/// <param name="CountryId">Reference to a country object.</param>
+/// <param name="Mail">Primary email address.</param>
+/// <param name="MailSecond">Secondary email address.</param>
+/// <param name="PhoneFixed">Primary landline phone number.</param>
+/// <param name="PhoneFixedSecond">Secondary landline phone number.</param>
+/// <param name="PhoneMobile">Mobile phone number.</param>
+/// <param name="Fax">Fax number.</param>
+/// <param name="Url">Website URL.</param>
+/// <param name="SkypeName">Skype name.</param>
+/// <param name="Remarks">Free-text remarks.</param>
+/// <param name="LanguageId">Reference to a language object.</param>
+/// <param name="ContactGroupIds">Comma-separated references to one or more contact group objects.</param>
+/// <param name="ContactBranchIds">Comma-separated references to one or more contact sector objects.</param>
+public sealed record ContactCreate(
+    [property: JsonPropertyName("contact_type_id")] int ContactTypeId,
+    [property: JsonPropertyName("name_1")] string Name1,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("owner_id")] int OwnerId,
+    [property: JsonPropertyName("nr")] string? Nr = null,
+    [property: JsonPropertyName("name_2")] string? Name2 = null,
+    [property: JsonPropertyName("salutation_id")] int? SalutationId = null,
+    [property: JsonPropertyName("salutation_form")] int? SalutationForm = null,
+    [property: JsonPropertyName("titel_id")] int? TitelId = null,
+    [property: JsonPropertyName("birthday")] DateOnly? Birthday = null,
+    [property: JsonPropertyName("street_name")] string? StreetName = null,
+    [property: JsonPropertyName("house_number")] string? HouseNumber = null,
+    [property: JsonPropertyName("address_addition")] string? AddressAddition = null,
+    [property: JsonPropertyName("postcode")] string? Postcode = null,
+    [property: JsonPropertyName("city")] string? City = null,
+    [property: JsonPropertyName("country_id")] int? CountryId = null,
+    [property: JsonPropertyName("mail")] string? Mail = null,
+    [property: JsonPropertyName("mail_second")] string? MailSecond = null,
+    [property: JsonPropertyName("phone_fixed")] string? PhoneFixed = null,
+    [property: JsonPropertyName("phone_fixed_second")] string? PhoneFixedSecond = null,
+    [property: JsonPropertyName("phone_mobile")] string? PhoneMobile = null,
+    [property: JsonPropertyName("fax")] string? Fax = null,
+    [property: JsonPropertyName("url")] string? Url = null,
+    [property: JsonPropertyName("skype_name")] string? SkypeName = null,
+    [property: JsonPropertyName("remarks")] string? Remarks = null,
+    [property: JsonPropertyName("language_id")] int? LanguageId = null,
+    [property: JsonPropertyName("contact_group_ids")] string? ContactGroupIds = null,
+    [property: JsonPropertyName("contact_branch_ids")] string? ContactBranchIds = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Contacts/Contacts/Views/ContactUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Contacts/Contacts/Views/ContactUpdate.cs
@@ -1,0 +1,91 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Contacts.Contacts.Views;
+
+/// <summary>
+/// Update view for a contact — body of <c>POST /2.0/contact/{id}</c>. The Bexio API uses
+/// <c>POST</c> (not <c>PUT</c>) for full-replacement edits on this resource and requires
+/// the same fields as <see cref="ContactCreate"/>.
+/// <see href="https://docs.bexio.com/#tag/Contacts/operation/v2EditContact"/>
+/// </summary>
+/// <param name="ContactTypeId"><c>1</c> for companies, <c>2</c> for persons.</param>
+/// <param name="Name1">Company name if <see cref="ContactTypeId"/> is <c>1</c>, otherwise the person's last name.</param>
+/// <param name="UserId">Reference to the user that owns the contact.</param>
+/// <param name="OwnerId">Reference to the owner of the contact.</param>
+/// <param name="Nr">Optional customer number. Bexio assigns one automatically when <see langword="null"/>.</param>
+/// <param name="Name2">Company addition if <see cref="ContactTypeId"/> is <c>1</c>, otherwise the person's first name.</param>
+/// <param name="SalutationId">Reference to a salutation object.</param>
+/// <param name="SalutationForm">Salutation form id.</param>
+/// <param name="TitelId">Reference to a title object (write-only; Bexio uses the spelling <c>titel_id</c>).</param>
+/// <param name="Birthday">Birthday of the contact.</param>
+/// <param name="StreetName">Street part of the postal address. Required when <see cref="HouseNumber"/> or <see cref="AddressAddition"/> is provided.</param>
+/// <param name="HouseNumber">House number part of the postal address.</param>
+/// <param name="AddressAddition">Additional address line (e.g. building, c/o).</param>
+/// <param name="Postcode">Postal code.</param>
+/// <param name="City">City or locality.</param>
+/// <param name="CountryId">Reference to a country object.</param>
+/// <param name="Mail">Primary email address.</param>
+/// <param name="MailSecond">Secondary email address.</param>
+/// <param name="PhoneFixed">Primary landline phone number.</param>
+/// <param name="PhoneFixedSecond">Secondary landline phone number.</param>
+/// <param name="PhoneMobile">Mobile phone number.</param>
+/// <param name="Fax">Fax number.</param>
+/// <param name="Url">Website URL.</param>
+/// <param name="SkypeName">Skype name.</param>
+/// <param name="Remarks">Free-text remarks.</param>
+/// <param name="LanguageId">Reference to a language object.</param>
+/// <param name="ContactGroupIds">Comma-separated references to one or more contact group objects.</param>
+/// <param name="ContactBranchIds">Comma-separated references to one or more contact sector objects.</param>
+public sealed record ContactUpdate(
+    [property: JsonPropertyName("contact_type_id")] int ContactTypeId,
+    [property: JsonPropertyName("name_1")] string Name1,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("owner_id")] int OwnerId,
+    [property: JsonPropertyName("nr")] string? Nr = null,
+    [property: JsonPropertyName("name_2")] string? Name2 = null,
+    [property: JsonPropertyName("salutation_id")] int? SalutationId = null,
+    [property: JsonPropertyName("salutation_form")] int? SalutationForm = null,
+    [property: JsonPropertyName("titel_id")] int? TitelId = null,
+    [property: JsonPropertyName("birthday")] DateOnly? Birthday = null,
+    [property: JsonPropertyName("street_name")] string? StreetName = null,
+    [property: JsonPropertyName("house_number")] string? HouseNumber = null,
+    [property: JsonPropertyName("address_addition")] string? AddressAddition = null,
+    [property: JsonPropertyName("postcode")] string? Postcode = null,
+    [property: JsonPropertyName("city")] string? City = null,
+    [property: JsonPropertyName("country_id")] int? CountryId = null,
+    [property: JsonPropertyName("mail")] string? Mail = null,
+    [property: JsonPropertyName("mail_second")] string? MailSecond = null,
+    [property: JsonPropertyName("phone_fixed")] string? PhoneFixed = null,
+    [property: JsonPropertyName("phone_fixed_second")] string? PhoneFixedSecond = null,
+    [property: JsonPropertyName("phone_mobile")] string? PhoneMobile = null,
+    [property: JsonPropertyName("fax")] string? Fax = null,
+    [property: JsonPropertyName("url")] string? Url = null,
+    [property: JsonPropertyName("skype_name")] string? SkypeName = null,
+    [property: JsonPropertyName("remarks")] string? Remarks = null,
+    [property: JsonPropertyName("language_id")] int? LanguageId = null,
+    [property: JsonPropertyName("contact_group_ids")] string? ContactGroupIds = null,
+    [property: JsonPropertyName("contact_branch_ids")] string? ContactBranchIds = null
+);

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -29,9 +29,11 @@ using Microsoft.Extensions.DependencyInjection;
 using BexioApiNet.Interfaces;
 using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Services;
 using BexioApiNet.Services.Connectors.Accounting;
 using BexioApiNet.Services.Connectors.Banking;
+using BexioApiNet.Services.Connectors.Contacts;
 
 namespace BexioApiNet.AspNetCore;
 
@@ -89,6 +91,19 @@ public static class BexioServiceCollection
         services.AddScoped<ICurrencyService, CurrencyService>();
         services.AddScoped<IManualEntryService, ManualEntryService>();
         services.AddScoped<ITaxService, TaxService>();
+        services.AddScoped<IAccountGroupService, AccountGroupService>();
+        services.AddScoped<IBusinessYearService, BusinessYearService>();
+        services.AddScoped<ICalendarYearService, CalendarYearService>();
+        services.AddScoped<IVatPeriodService, VatPeriodService>();
+        services.AddScoped<IReportService, ReportService>();
+        services.AddScoped<IPaymentTypeService, PaymentTypeService>();
+        services.AddScoped<IPaymentService, PaymentService>();
+        services.AddScoped<IOutgoingPaymentService, OutgoingPaymentService>();
+        services.AddScoped<IContactService, ContactService>();
+        services.AddScoped<IContactGroupService, ContactGroupService>();
+        services.AddScoped<IContactRelationService, ContactRelationService>();
+        services.AddScoped<IContactSectorService, ContactSectorService>();
+        services.AddScoped<IAdditionalAddressService, AdditionalAddressService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet/BexioApiNet.csproj
+++ b/src/BexioApiNet/BexioApiNet.csproj
@@ -22,4 +22,10 @@
       <ProjectReference Include="..\BexioApiNet.Abstractions\BexioApiNet.Abstractions.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <InternalsVisibleTo Include="BexioApiNet.UnitTests" />
+      <InternalsVisibleTo Include="BexioApiNet.IntegrationTests" />
+      <InternalsVisibleTo Include="BexioApiNet.E2eTests" />
+    </ItemGroup>
+
 </Project>

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/IAccountGroupService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/IAccountGroupService.cs
@@ -1,0 +1,46 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Accounting.AccountGroups;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Accounting;
+
+/// <summary>
+/// Service for getting account group entries in accounting namespace. <see href="https://docs.bexio.com/#tag/Account-Groups">Account Groups</see>
+/// </summary>
+public interface IAccountGroupService
+{
+    /// <summary>
+    /// Get a list of account groups. <see href="https://docs.bexio.com/#tag/Account-Groups/operation/v2ListAccountGroups">v2 List Account Groups</see>
+    /// </summary>
+    /// <param name="queryParameterAccountGroup">Query parameter specific for account groups</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<AccountGroup>>> Get([Optional] QueryParameterAccountGroup? queryParameterAccountGroup, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/IBusinessYearService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/IBusinessYearService.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Accounting.BusinessYears;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Accounting;
+
+/// <summary>
+///     Service for getting business year entries in accounting namespace.
+///     <see href="https://docs.bexio.com/#tag/Business-Years">Business Years</see>
+/// </summary>
+public interface IBusinessYearService
+{
+    /// <summary>
+    ///     Get a list of business years.
+    ///     <see href="https://docs.bexio.com/#tag/Business-Years/operation/ListBusinessYears">List Business Years</see>
+    /// </summary>
+    /// <param name="queryParameterBusinessYear">Query parameter specific for business years</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<BusinessYear>>> Get([Optional] QueryParameterBusinessYear? queryParameterBusinessYear,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Get a single business year by id.
+    ///     <see href="https://docs.bexio.com/#tag/Business-Years/operation/ShowBusinessYear">Show Business Year</see>
+    /// </summary>
+    /// <param name="id">The id of the business year</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<BusinessYear>> GetById(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/ICalendarYearService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/ICalendarYearService.cs
@@ -1,0 +1,72 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears;
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Views;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Accounting;
+
+/// <summary>
+/// Service for working with accounting calendar years. <see href="https://docs.bexio.com/#tag/Calendar-Years">Calendar Years</see>
+/// </summary>
+public interface ICalendarYearService
+{
+    /// <summary>
+    /// Fetch a list of calendar years. <see href="https://docs.bexio.com/#tag/Calendar-Years/operation/ListCalendarYears">List Calendar Years</see>
+    /// </summary>
+    /// <param name="queryParameterCalendarYear">Query parameter specific for calendar years</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<CalendarYear>?>> Get([Optional] QueryParameterCalendarYear? queryParameterCalendarYear, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single calendar year by id. <see href="https://docs.bexio.com/#tag/Calendar-Years/operation/ShowCalendarYear">Show Calendar Year</see>
+    /// </summary>
+    /// <param name="id">The calendar year id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<CalendarYear>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a calendar year. If a future year is passed, all years in between are generated using the provided settings. <see href="https://docs.bexio.com/#tag/Calendar-Years/operation/CreateCalendarYear">Create Calendar Year</see>
+    /// </summary>
+    /// <param name="calendarYearCreate">Create view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<CalendarYear>>> Create(CalendarYearCreate calendarYearCreate, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search calendar years matching the provided criteria. <see href="https://docs.bexio.com/#tag/Calendar-Years/operation/SearchCalendarYears">Search Calendar Years</see>
+    /// </summary>
+    /// <param name="searchCriteria">The search criteria sent as the JSON body</param>
+    /// <param name="queryParameterCalendarYear">Optional query parameter (e.g. limit / offset)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<CalendarYear>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterCalendarYear? queryParameterCalendarYear, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/ICurrencyService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/ICurrencyService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -25,22 +25,87 @@ SOFTWARE.
 
 using System.Runtime.InteropServices;
 using BexioApiNet.Abstractions.Models.Accounting.Currencies;
+using BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Models;
 
 namespace BexioApiNet.Interfaces.Connectors.Accounting;
 
 /// <summary>
-/// Service for getting currency entries in accounting namespace. <see href="https://docs.bexio.com/#tag/Currencies/operation/ListCurrencies">List Currencies</see>
+///     Service for managing currency entries in the accounting namespace.
+///     <see href="https://docs.bexio.com/#tag/Currencies">Currencies</see>
 /// </summary>
 public interface ICurrencyService
 {
     /// <summary>
-    /// Get a list of currencies. <see href="https://docs.bexio.com/#tag/Currencies/operation/ListCurrencies">List Currencies</see>
+    ///     Get a list of currencies.
+    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ListCurrencies">List Currencies</see>
     /// </summary>
-    /// <param name="queryParameterCurrency">Query parameter specific for accounts</param>
+    /// <param name="queryParameterCurrency">Query parameter specific for currencies</param>
     /// <param name="autoPage">Fetch all possible results</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
-    public Task<ApiResult<List<Currency>>> Get([Optional] QueryParameterCurrency? queryParameterCurrency, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+    public Task<ApiResult<List<Currency>>> Get([Optional] QueryParameterCurrency? queryParameterCurrency,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch all possible currency codes (in the format CHF, EUR, etc.).
+    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ListCurrenciesCodes">List Currencies Codes</see>
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<string>>> GetCodes([Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single currency by id.
+    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ShowCurrency">Show Currency</see>
+    /// </summary>
+    /// <param name="id">The id of the currency</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Currency>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch all configured exchange rates for a given currency.
+    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ListExchangeRatesForCurrency">
+    ///         List Exchange Rates For
+    ///         Currency
+    ///     </see>
+    /// </summary>
+    /// <param name="id">The id of the currency</param>
+    /// <param name="queryParameterExchangeRate">Optional query parameter (date filter)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ExchangeRate>>> GetExchangeRates(int id,
+        [Optional] QueryParameterExchangeRate? queryParameterExchangeRate,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create a new currency.
+    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/CreateCurrency">Create Currency</see>
+    /// </summary>
+    /// <param name="currency">Create view describing the new currency</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Currency>> Create(CurrencyCreate currency, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Partially update an existing currency.
+    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/UpdateCurrency">Update Currency</see>
+    /// </summary>
+    /// <param name="id">The id of the currency to update</param>
+    /// <param name="currency">Patch view describing the fields to update</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Currency>> Patch(int id, CurrencyPatch currency,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Permanently delete a currency by id. This cannot be undone.
+    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/DeleteCurrency">Delete Currency</see>
+    /// </summary>
+    /// <param name="id">The id of the currency to delete</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
 }

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/IManualEntryService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/IManualEntryService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -45,6 +45,15 @@ public interface IManualEntryService
     public Task<ApiResult<ManualEntry>> Create(ManualEntryEntryCreate manualEntryEntry, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
+    /// Update a manual entry. <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/UpdateManualEntry">Update Manual Entry</see>
+    /// </summary>
+    /// <param name="manualEntryId">The manual entry id</param>
+    /// <param name="payload">Update view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ManualEntry>> Put(int manualEntryId, ManualEntryUpdate payload, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
     /// Add one or more attachments to a manual entry. <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/UploadManualEntryFile">Upload Manual Entry File</see>
     /// </summary>
     /// <param name="manuelEntriesId">The manual entry root id</param>
@@ -74,10 +83,80 @@ public interface IManualEntryService
     public Task<ApiResult<List<ManualEntry>?>> Get([Optional] QueryParameterManualEntry? queryParameterManualEntry, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
+    /// Get the suggested next reference number for a manual entry. <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/GetNextReferenceNumber">Get Next Reference Number</see>
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ManualEntryNextRefNr>> GetNextRefNr([Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// List all files attached to a manual compound entry. <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/ListManualCompoundEntryFiles">List Manual Compound Entry Files</see>
+    /// </summary>
+    /// <param name="manualEntryId">The manual entry id</param>
+    /// <param name="queryParameter">Query parameter (limit, offset)</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ManualEntryFile>?>> GetFiles(int manualEntryId, [Optional] QueryParameterManualEntry? queryParameter, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single file attached to a manual compound entry, including its base64-encoded content.
+    /// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/ShowManualCompoundEntryFile">Show Manual Compound Entry File</see>
+    /// </summary>
+    /// <param name="manualEntryId">The manual entry id</param>
+    /// <param name="fileId">The file id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ManualEntryFileDetail>> GetFileById(int manualEntryId, int fileId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// List all files attached to a specific manual entry line. <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/ListManualEntryFiles">List Manual Entry Files</see>
+    /// </summary>
+    /// <param name="manualEntryId">The manual entry id</param>
+    /// <param name="entryId">The manual entry line id</param>
+    /// <param name="queryParameter">Query parameter (limit, offset)</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ManualEntryFile>?>> GetEntryFiles(int manualEntryId, int entryId, [Optional] QueryParameterManualEntry? queryParameter, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single file attached to a manual entry line, including its base64-encoded content.
+    /// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/ShowManualEntryFile">Show Manual Entry File</see>
+    /// </summary>
+    /// <param name="manualEntryId">The manual entry id</param>
+    /// <param name="entryId">The manual entry line id</param>
+    /// <param name="fileId">The file id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ManualEntryFileDetail>> GetEntryFileById(int manualEntryId, int entryId, int fileId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
     /// Delete a manual entry
     /// </summary>
     /// <param name="id"></param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
     public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete the connection between a file and a manual compound entry.
+    /// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/DeleteManualCompoundEntryFile">Delete Manual Compound Entry File</see>
+    /// </summary>
+    /// <param name="manualEntryId">The manual entry id</param>
+    /// <param name="fileId">The file id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> DeleteFile(int manualEntryId, int fileId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete the connection between a file and a manual entry line.
+    /// <see href="https://docs.bexio.com/#tag/Manual-Entries/operation/DeleteManualEntryFile">Delete Manual Entry File</see>
+    /// </summary>
+    /// <param name="manualEntryId">The manual entry id</param>
+    /// <param name="entryId">The manual entry line id</param>
+    /// <param name="fileId">The file id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> DeleteEntryFile(int manualEntryId, int entryId, int fileId, [Optional] CancellationToken cancellationToken);
 }

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/IReportService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/IReportService.cs
@@ -1,0 +1,46 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Accounting.Reports;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Accounting;
+
+/// <summary>
+/// Service for reading accounting reports such as the journal. <see href="https://docs.bexio.com/#tag/Reports">Reports</see>
+/// </summary>
+public interface IReportService
+{
+    /// <summary>
+    /// Get the accounting journal (list of all journal bookings). <see href="https://docs.bexio.com/#tag/Reports/operation/ListJournalEntries">List Journal Entries</see>
+    /// </summary>
+    /// <param name="queryParameterJournal">Query parameters (date range, account filter, paging).</param>
+    /// <param name="autoPage">Fetch all possible results by walking pagination.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> containing the journal entries returned by the API.</returns>
+    public Task<ApiResult<List<Journal>>> GetJournal([Optional] QueryParameterJournal? queryParameterJournal, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/ITaxService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/ITaxService.cs
@@ -43,4 +43,20 @@ public interface ITaxService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
     public Task<ApiResult<List<Tax>>> Get([Optional] QueryParameterTax? queryParameterTax, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single tax by id. <see href="https://docs.bexio.com/#tag/Taxes/operation/ShowTax">Show Tax</see>
+    /// </summary>
+    /// <param name="id">The id of the tax</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Tax>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a tax. <see href="https://docs.bexio.com/#tag/Taxes/operation/DeleteTax">Delete Tax</see>
+    /// </summary>
+    /// <param name="id">The id of the tax</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
 }

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/IVatPeriodService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/IVatPeriodService.cs
@@ -1,0 +1,54 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Accounting.VatPeriods;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Accounting;
+
+/// <summary>
+/// Service for getting vat periods in accounting namespace. <see href="https://docs.bexio.com/#tag/Vat-Periods">Vat Periods</see>
+/// </summary>
+public interface IVatPeriodService
+{
+    /// <summary>
+    /// Get a list of vat periods. <see href="https://docs.bexio.com/#tag/Vat-Periods/operation/ListVatPeriods">List Vat Periods</see>
+    /// </summary>
+    /// <param name="queryParameterVatPeriod">Query parameter specific for vat periods</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<VatPeriod>>> Get([Optional] QueryParameterVatPeriod? queryParameterVatPeriod, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single vat period by its id. <see href="https://docs.bexio.com/#tag/Vat-Periods/operation/ShowVatPeriod">Show Vat Period</see>
+    /// </summary>
+    /// <param name="id">The id of the vat period</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<VatPeriod>> GetById(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Banking/IBankAccountService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Banking/IBankAccountService.cs
@@ -43,4 +43,12 @@ public interface IBankAccountService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
     public Task<ApiResult<List<BankAccountGet>>> Get([Optional] QueryParameterBankAccount queryParameterBankAccount, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single bank account by its identifier. <see href="https://docs.bexio.com/#tag/Bank-Accounts/operation/ShowBankAccount">Show Bank Account</see>
+    /// </summary>
+    /// <param name="id">ID of the bank account to return</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<BankAccountGet>> GetById(int id, [Optional] CancellationToken cancellationToken);
 }

--- a/src/BexioApiNet/Interfaces/Connectors/Banking/IOutgoingPaymentService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Banking/IOutgoingPaymentService.cs
@@ -1,0 +1,85 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Banking;
+
+/// <summary>
+/// Service for managing outgoing payments in the purchase namespace.
+/// <see href="https://docs.bexio.com/#tag/Outgoing-Payment">Outgoing Payment</see>
+/// </summary>
+public interface IOutgoingPaymentService
+{
+    /// <summary>
+    /// List outgoing payments for a given bill.
+    /// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPaymentList_GET">List Outgoing Payments</see>
+    /// </summary>
+    /// <param name="queryParameterOutgoingPayment">Query parameters — <c>bill_id</c> is mandatory per the Bexio spec.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the paged <see cref="OutgoingPaymentListResponse"/> envelope.</returns>
+    public Task<ApiResult<OutgoingPaymentListResponse>> Get(QueryParameterOutgoingPayment queryParameterOutgoingPayment, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single outgoing payment by id.
+    /// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPayment_GET">Get Outgoing Payment</see>
+    /// </summary>
+    /// <param name="id">Outgoing payment identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the full <see cref="OutgoingPayment"/>.</returns>
+    public Task<ApiResult<OutgoingPayment>> GetById(Guid id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new outgoing payment for a non-draft bill.
+    /// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPayment_POST">Create Outgoing Payment</see>
+    /// </summary>
+    /// <param name="payload">Create view containing the payment details.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the newly created <see cref="OutgoingPayment"/>.</returns>
+    public Task<ApiResult<OutgoingPayment>> Create(OutgoingPaymentCreate payload, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update an existing outgoing payment. The target payment is identified by <see cref="OutgoingPaymentUpdate.PaymentId"/>
+    /// inside the request body — the Bexio v4.0 PUT endpoint does not use <c>{id}</c> in the URL.
+    /// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPayment_PUT">Edit Outgoing Payment</see>
+    /// </summary>
+    /// <param name="payload">Update view containing the payment id and the mutable fields.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated <see cref="OutgoingPayment"/>.</returns>
+    public Task<ApiResult<OutgoingPayment>> Update(OutgoingPaymentUpdate payload, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete an outgoing payment.
+    /// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPayment_DELETE">Delete Outgoing Payment</see>
+    /// </summary>
+    /// <param name="id">Outgoing payment identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> indicating success or failure.</returns>
+    public Task<ApiResult<object>> Delete(Guid id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Banking/IPaymentService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Banking/IPaymentService.cs
@@ -1,0 +1,95 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.Payments;
+using BexioApiNet.Abstractions.Models.Banking.Payments.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Banking;
+
+/// <summary>
+/// Service for managing payments in the banking namespace.
+/// <see href="https://docs.bexio.com/#tag/Payments">Payments</see>
+/// </summary>
+public interface IPaymentService
+{
+    /// <summary>
+    /// Fetch a list of payments.
+    /// <see href="https://docs.bexio.com/#tag/Payments/operation/NewFetchAllPayments">Fetch all payments</see>
+    /// </summary>
+    /// <param name="queryParameterPayment">Optional query parameters (pagination and filter).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of payments.</returns>
+    public Task<ApiResult<List<Payment>?>> Get([Optional] QueryParameterPayment? queryParameterPayment, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single payment by its identifier.
+    /// <see href="https://docs.bexio.com/#tag/Payments/operation/NewGetPayment">Get payment</see>
+    /// </summary>
+    /// <param name="paymentId">UUID of the payment.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the payment.</returns>
+    public Task<ApiResult<Payment>> GetById(Guid paymentId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new payment.
+    /// <see href="https://docs.bexio.com/#tag/Payments/operation/NewCreatePayment">Create payment</see>
+    /// </summary>
+    /// <param name="payment">Create view for the payment.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the created payment.</returns>
+    public Task<ApiResult<Payment>> Create(PaymentCreate payment, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Cancel an existing payment. A payment can only be cancelled when its status
+    /// is <c>downloaded</c>, <c>transferred</c> or <c>error</c>.
+    /// <see href="https://docs.bexio.com/#tag/Payments/operation/NewCancelPayment">Cancel payment</see>
+    /// </summary>
+    /// <param name="paymentId">UUID of the payment to cancel.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the cancelled payment.</returns>
+    public Task<ApiResult<Payment>> Cancel(Guid paymentId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update an existing payment.
+    /// <see href="https://docs.bexio.com/#tag/Payments/operation/NewUpdatePayment">Update payment</see>
+    /// </summary>
+    /// <param name="paymentId">UUID of the payment to update.</param>
+    /// <param name="payment">Update view with the fields to change.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated payment.</returns>
+    public Task<ApiResult<Payment>> Update(Guid paymentId, PaymentUpdate payment, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete an existing payment permanently. This cannot be undone.
+    /// <see href="https://docs.bexio.com/#tag/Payments/operation/NewDeletePayment">Delete payment</see>
+    /// </summary>
+    /// <param name="paymentId">UUID of the payment to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> indicating whether the delete succeeded.</returns>
+    public Task<ApiResult<object>> Delete(Guid paymentId, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Banking/IPaymentTypeService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Banking/IPaymentTypeService.cs
@@ -1,0 +1,60 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.PaymentTypes;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Banking;
+
+/// <summary>
+///     Service for accessing payment types. <see href="https://docs.bexio.com/#tag/Payment-Types">Payment Types</see>
+/// </summary>
+public interface IPaymentTypeService
+{
+    /// <summary>
+    ///     Get a list of payment types.
+    ///     <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2ListPaymentTypes">List Payment Types</see>
+    /// </summary>
+    /// <param name="queryParameterPaymentType">Query parameter specific for payment types</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<PaymentType>>> Get([Optional] QueryParameterPaymentType? queryParameterPaymentType,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Search payment types.
+    ///     <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2SearchPaymentTypes">Search Payment Types</see>
+    /// </summary>
+    /// <param name="searchCriteria">The search criteria sent as JSON array body. Supported field: <c>name</c>.</param>
+    /// <param name="queryParameterPaymentType">Optional query parameter specific for payment types</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<PaymentType>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterPaymentType? queryParameterPaymentType,
+        [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Contacts/IAdditionalAddressService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Contacts/IAdditionalAddressService.cs
@@ -1,0 +1,101 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses;
+using BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Contacts;
+
+/// <summary>
+/// Service for Bexio additional addresses attached to a contact. All routes are nested
+/// under <c>2.0/contact/{contactId}/additional_address</c>, so every method accepts the
+/// parent contact identifier. <see href="https://docs.bexio.com/#tag/Additional-Addresses">Additional Addresses</see>
+/// </summary>
+public interface IAdditionalAddressService
+{
+    /// <summary>
+    /// Fetch all additional addresses for a given contact. <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2ListAdditionalAddresses"/>
+    /// </summary>
+    /// <param name="contactId">The parent contact identifier.</param>
+    /// <param name="queryParameterAdditionalAddress">Optional query parameters (limit, offset).</param>
+    /// <param name="autoPage">Fetch all pages using <see cref="IBexioConnectionHandler.FetchAll{T}"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The API result wrapping the list of additional addresses.</returns>
+    public Task<ApiResult<List<AdditionalAddress>?>> Get(int contactId, [Optional] QueryParameterAdditionalAddress? queryParameterAdditionalAddress, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single additional address by identifier for a given contact. <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2ShowAdditionalAddress"/>
+    /// </summary>
+    /// <param name="contactId">The parent contact identifier.</param>
+    /// <param name="id">The additional address identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The API result wrapping the additional address.</returns>
+    public Task<ApiResult<AdditionalAddress>> GetById(int contactId, int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new additional address for a given contact. <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2CreateAdditionalAddress"/>
+    /// </summary>
+    /// <param name="contactId">The parent contact identifier.</param>
+    /// <param name="additionalAddress">The create view payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The API result wrapping the created additional address.</returns>
+    public Task<ApiResult<AdditionalAddress>> Create(int contactId, AdditionalAddressCreate additionalAddress, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search additional addresses for a given contact via query criteria. Supported fields:
+    /// <c>name</c>, <c>address</c>, <c>postcode</c>, <c>city</c>, <c>country_id</c>, <c>subject</c>, <c>email</c>.
+    /// <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2SearchAdditionalAddresses"/>
+    /// </summary>
+    /// <param name="contactId">The parent contact identifier.</param>
+    /// <param name="searchCriteria">List of search criteria entries sent as the JSON body.</param>
+    /// <param name="queryParameterAdditionalAddress">Optional query parameters (limit, offset).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The API result wrapping the list of matching additional addresses.</returns>
+    public Task<ApiResult<List<AdditionalAddress>>> Search(int contactId, List<SearchCriteria> searchCriteria, [Optional] QueryParameterAdditionalAddress? queryParameterAdditionalAddress, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update (edit) an existing additional address. Bexio implements this as an HTTP
+    /// <c>POST</c> against the single-address path (not <c>PUT</c>).
+    /// <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2EditAdditionalAddress"/>
+    /// </summary>
+    /// <param name="contactId">The parent contact identifier.</param>
+    /// <param name="id">The additional address identifier.</param>
+    /// <param name="additionalAddress">The update view payload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The API result wrapping the updated additional address.</returns>
+    public Task<ApiResult<AdditionalAddress>> Update(int contactId, int id, AdditionalAddressUpdate additionalAddress, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete an additional address permanently. <see href="https://docs.bexio.com/#tag/Additional-Addresses/operation/v2DeleteAdditionalAddress"/>
+    /// </summary>
+    /// <param name="contactId">The parent contact identifier.</param>
+    /// <param name="id">The additional address identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The API result for the delete operation.</returns>
+    public Task<ApiResult<object>> Delete(int contactId, int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Contacts/IContactGroupService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Contacts/IContactGroupService.cs
@@ -1,0 +1,89 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Contacts;
+
+/// <summary>
+/// Service for managing contact groups. <see href="https://docs.bexio.com/#tag/Contact-Groups">Contact Groups</see>
+/// </summary>
+public interface IContactGroupService
+{
+    /// <summary>
+    /// Fetch a list of contact groups. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2ListContactGroups">List Contact Groups</see>
+    /// </summary>
+    /// <param name="queryParameterContactGroup">Query parameter specific for contact group</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ContactGroup>?>> Get([Optional] QueryParameterContactGroup? queryParameterContactGroup, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single contact group by id. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2ShowContactGroup">Show Contact Group</see>
+    /// </summary>
+    /// <param name="id">The contact group id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ContactGroup?>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a contact group. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2CreateContactGroup">Create Contact Group</see>
+    /// </summary>
+    /// <param name="contactGroup">Create view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ContactGroup>> Create(ContactGroupCreate contactGroup, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search contact groups. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2SearchContactGroups">Search Contact Groups</see>
+    /// </summary>
+    /// <param name="searchCriteria">The search criteria list. Supported fields: <c>name</c>.</param>
+    /// <param name="queryParameterContactGroup">Optional pagination parameters</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ContactGroup>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterContactGroup? queryParameterContactGroup, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update (edit) a contact group. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2EditContactGroup">Edit Contact Group</see>
+    /// </summary>
+    /// <param name="id">The contact group id</param>
+    /// <param name="contactGroup">Update view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ContactGroup>> Update(int id, ContactGroupUpdate contactGroup, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a contact group. <see href="https://docs.bexio.com/#tag/Contact-Groups/operation/v2DeleteContactGroup">Delete Contact Group</see>
+    /// </summary>
+    /// <param name="id">The contact group id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Contacts/IContactRelationService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Contacts/IContactRelationService.cs
@@ -1,0 +1,90 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactRelations;
+using BexioApiNet.Abstractions.Models.Contacts.ContactRelations.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Contacts;
+
+/// <summary>
+/// Service for managing contact relations. <see href="https://docs.bexio.com/#tag/Contact-Relations">Contact Relations</see>
+/// </summary>
+public interface IContactRelationService
+{
+    /// <summary>
+    /// Get a list of contact relations. <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2ListContactRelations">List Contact Relations</see>
+    /// </summary>
+    /// <param name="queryParameterContactRelation">Query parameter specific for contact relations</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ContactRelation>?>> Get([Optional] QueryParameterContactRelation? queryParameterContactRelation, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single contact relation by id. <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2ShowContactRelation">Show Contact Relation</see>
+    /// </summary>
+    /// <param name="id">The contact relation id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ContactRelation>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new contact relation. <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2CreateContactRelation">Create Contact Relation</see>
+    /// </summary>
+    /// <param name="payload">Create view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ContactRelation>> Create(ContactRelationCreate payload, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search contact relations by one or more criteria. <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2SearchContactRelations">Search Contact Relations</see>
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria list sent as the JSON body</param>
+    /// <param name="queryParameterContactRelation">Optional pagination / ordering query parameters</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ContactRelation>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterContactRelation? queryParameterContactRelation, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update an existing contact relation. Bexio uses HTTP POST on the resource URL for edit on v2.0 endpoints.
+    /// <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2EditContactRelation">Edit Contact Relation</see>
+    /// </summary>
+    /// <param name="id">The contact relation id</param>
+    /// <param name="payload">Update view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<ContactRelation>> Update(int id, ContactRelationUpdate payload, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a contact relation. <see href="https://docs.bexio.com/#tag/Contact-Relations/operation/v2DeleteContactRelation">Delete Contact Relation</see>
+    /// </summary>
+    /// <param name="id">The contact relation id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Contacts/IContactSectorService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Contacts/IContactSectorService.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactSectors;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Contacts;
+
+/// <summary>
+/// Service for contact sectors. Bexio exposes these under the <c>/2.0/contact_branch</c>
+/// routes, but the documented concept is "contact sector".
+/// <see href="https://docs.bexio.com/#tag/Contact-Sectors"/>
+/// </summary>
+public interface IContactSectorService
+{
+    /// <summary>
+    /// Fetch a list of contact sectors. <see href="https://docs.bexio.com/#tag/Contact-Sectors/operation/v2ListContactSectors"/>
+    /// </summary>
+    /// <param name="queryParameterContactSector">Query parameters (pagination / ordering)</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ContactSector>?>> Get([Optional] QueryParameterContactSector? queryParameterContactSector, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search contact sectors. <see href="https://docs.bexio.com/#tag/Contact-Sectors/operation/v2SearchContactSectors"/>
+    /// Supported search fields: <c>name</c>.
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria sent as JSON body</param>
+    /// <param name="queryParameterContactSector">Optional pagination / ordering parameters appended to the URI</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<ContactSector>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterContactSector? queryParameterContactSector, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Contacts/IContactService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Contacts/IContactService.cs
@@ -1,0 +1,108 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.Contacts;
+using BexioApiNet.Abstractions.Models.Contacts.Contacts.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Contacts;
+
+/// <summary>
+/// Service for the Bexio contacts endpoints. <see href="https://docs.bexio.com/#tag/Contacts">Contacts</see>
+/// </summary>
+public interface IContactService
+{
+    /// <summary>
+    /// List all contacts. <see href="https://docs.bexio.com/#tag/Contacts/operation/v2ListContacts">List Contacts</see>
+    /// </summary>
+    /// <param name="queryParameterContact">Optional query parameters (limit/offset/order_by/show_archived).</param>
+    /// <param name="autoPage">When <see langword="true"/>, transparently pages through all remaining results via <c>X-Total-Count</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> with the full page (or all pages) of contacts.</returns>
+    public Task<ApiResult<List<Contact>?>> Get([Optional] QueryParameterContact? queryParameterContact, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single contact by id. <see href="https://docs.bexio.com/#tag/Contacts/operation/v2ShowContact">Show Contact</see>
+    /// </summary>
+    /// <param name="id">The contact id.</param>
+    /// <param name="queryParameterContact">Optional query parameters (only <c>show_archived</c> is meaningful on this endpoint).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The contact including the <c>ContactWithDetails</c> fields when present.</returns>
+    public Task<ApiResult<Contact>> GetById(int id, [Optional] QueryParameterContact? queryParameterContact, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a single contact. <see href="https://docs.bexio.com/#tag/Contacts/operation/v2CreateContact">Create Contact</see>
+    /// </summary>
+    /// <param name="contact">The contact create view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created contact as returned by Bexio.</returns>
+    public Task<ApiResult<Contact>> Create(ContactCreate contact, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create multiple contacts in one request. <see href="https://docs.bexio.com/#tag/Contacts/operation/v2BulkCreateContacts">Bulk Create Contacts</see>
+    /// </summary>
+    /// <param name="contacts">The list of contact create views to submit.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The contacts as returned by Bexio, in the same order as the input.</returns>
+    public Task<ApiResult<List<Contact>>> BulkCreate(List<ContactCreate> contacts, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search contacts by criteria. <see href="https://docs.bexio.com/#tag/Contacts/operation/v2SearchContact">Search Contacts</see>
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria submitted as the JSON array body.</param>
+    /// <param name="queryParameterContact">Optional query parameters (limit/offset/order_by/show_archived).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching contacts.</returns>
+    public Task<ApiResult<List<Contact>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterContact? queryParameterContact, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Edit an existing contact. Bexio uses <c>POST /2.0/contact/{id}</c> (not <c>PUT</c>) for
+    /// full-replacement updates — see <see href="https://docs.bexio.com/#tag/Contacts/operation/v2EditContact">Edit Contact</see>.
+    /// </summary>
+    /// <param name="id">The contact id.</param>
+    /// <param name="contact">The contact update view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated contact as returned by Bexio.</returns>
+    public Task<ApiResult<Contact>> Update(int id, ContactUpdate contact, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Restore a previously archived contact. Bexio uses <c>PATCH</c> on this endpoint —
+    /// see <see href="https://docs.bexio.com/#tag/Contacts/operation/v2RestoreContact">Restore Contact</see>.
+    /// </summary>
+    /// <param name="id">The contact id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Restore(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete (archive) a contact. <see href="https://docs.bexio.com/#tag/Contacts/operation/v2DeleteContact">Delete Contact</see>
+    /// </summary>
+    /// <param name="id">The contact id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -25,6 +25,7 @@ SOFTWARE.
 
 using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Interfaces.Connectors.Contacts;
 
 namespace BexioApiNet.Interfaces;
 
@@ -57,4 +58,69 @@ public interface IBexioApiClient : IDisposable
     /// Bexio currency connector. <see href="https://docs.bexio.com/#tag/Taxes">Taxes</see>
     /// </summary>
     public ITaxService Taxes { get; set; }
+
+    /// <summary>
+    /// Bexio account group connector. <see href="https://docs.bexio.com/#tag/Account-Groups">Account Groups</see>
+    /// </summary>
+    public IAccountGroupService AccountGroups { get; set; }
+
+    /// <summary>
+    /// Bexio accounting business years connector. <see href="https://docs.bexio.com/#tag/Business-Years">Business Years</see>
+    /// </summary>
+    public IBusinessYearService AccountingBusinessYears { get; set; }
+
+    /// <summary>
+    /// Bexio accounting calendar years connector. <see href="https://docs.bexio.com/#tag/Calendar-Years">Calendar Years</see>
+    /// </summary>
+    public ICalendarYearService AccountingCalendarYears { get; set; }
+
+    /// <summary>
+    /// Bexio accounting VAT periods connector. <see href="https://docs.bexio.com/#tag/Vat-Periods">Vat Periods</see>
+    /// </summary>
+    public IVatPeriodService AccountingVatPeriods { get; set; }
+
+    /// <summary>
+    /// Bexio accounting reports connector. <see href="https://docs.bexio.com/#tag/Reports">Reports</see>
+    /// </summary>
+    public IReportService AccountingReports { get; set; }
+
+    /// <summary>
+    /// Bexio payment types connector. <see href="https://docs.bexio.com/#tag/Payment-Types">Payment Types</see>
+    /// </summary>
+    public IPaymentTypeService PaymentTypes { get; set; }
+
+    /// <summary>
+    /// Bexio banking payments connector. <see href="https://docs.bexio.com/#tag/Payments">Payments</see>
+    /// </summary>
+    public IPaymentService BankingPayments { get; set; }
+
+    /// <summary>
+    /// Bexio purchase outgoing payments connector. <see href="https://docs.bexio.com/#tag/Outgoing-Payment">Outgoing Payment</see>
+    /// </summary>
+    public IOutgoingPaymentService PurchaseOutgoingPayments { get; set; }
+
+    /// <summary>
+    /// Bexio contacts connector. <see href="https://docs.bexio.com/#tag/Contacts">Contacts</see>
+    /// </summary>
+    public IContactService Contacts { get; set; }
+
+    /// <summary>
+    /// Bexio contact groups connector. <see href="https://docs.bexio.com/#tag/Contact-Groups">Contact Groups</see>
+    /// </summary>
+    public IContactGroupService ContactGroups { get; set; }
+
+    /// <summary>
+    /// Bexio contact relations connector. <see href="https://docs.bexio.com/#tag/Contact-Relations">Contact Relations</see>
+    /// </summary>
+    public IContactRelationService ContactRelations { get; set; }
+
+    /// <summary>
+    /// Bexio contact sectors connector. <see href="https://docs.bexio.com/#tag/Contact-Sectors">Contact Sectors</see>
+    /// </summary>
+    public IContactSectorService ContactSectors { get; set; }
+
+    /// <summary>
+    /// Bexio additional addresses connector, nested under contacts. <see href="https://docs.bexio.com/#tag/Additional-Addresses">Additional Addresses</see>
+    /// </summary>
+    public IAdditionalAddressService ContactAdditionalAddresses { get; set; }
 }

--- a/src/BexioApiNet/Models/QueryParameterAccountGroup.cs
+++ b/src/BexioApiNet/Models/QueryParameterAccountGroup.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters
+/// </summary>
+public sealed record QueryParameterAccountGroup(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Models/QueryParameterAdditionalAddress.cs
+++ b/src/BexioApiNet/Models/QueryParameterAdditionalAddress.cs
@@ -1,0 +1,47 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters used by the additional address list and search endpoints.
+/// </summary>
+/// <param name="Limit">Maximum number of results to return (Bexio max 2000, default 500).</param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+public sealed record QueryParameterAdditionalAddress(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    /// The wrapped <see cref="QueryParameter"/> containing the <c>limit</c> and <c>offset</c> values.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Models/QueryParameterBusinessYear.cs
+++ b/src/BexioApiNet/Models/QueryParameterBusinessYear.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Dictionary for optional query parameters
+/// </summary>
+public sealed record QueryParameterBusinessYear(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(new Dictionary<string, object>
+        {
+            { "limit", Limit },
+            { "offset", Offset }
+        });
+}

--- a/src/BexioApiNet/Models/QueryParameterCalendarYear.cs
+++ b/src/BexioApiNet/Models/QueryParameterCalendarYear.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters
+/// </summary>
+public sealed record QueryParameterCalendarYear(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Models/QueryParameterContact.cs
+++ b/src/BexioApiNet/Models/QueryParameterContact.cs
@@ -1,0 +1,69 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Typed query parameter wrapper for the Bexio contacts endpoints
+/// (<c>GET /2.0/contact</c>, <c>GET /2.0/contact/{id}</c> and <c>POST /2.0/contact/search</c>).
+/// Each constructor argument is optional so callers can supply only the parameters they need;
+/// <see langword="null"/> values are skipped and not serialized onto the URL.
+/// </summary>
+/// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+/// <param name="OrderBy">Sort clause — one of <c>id</c>, <c>nr</c>, <c>name_1</c>, <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.</param>
+/// <param name="ShowArchived">When <see langword="true"/>, returns archived contacts only.</param>
+public sealed record QueryParameterContact(
+    int? Limit = null,
+    int? Offset = null,
+    string? OrderBy = null,
+    bool? ShowArchived = null
+)
+{
+    /// <summary>
+    /// The underlying <see cref="Models.QueryParameter"/> passed to <see cref="Interfaces.IBexioConnectionHandler"/>.
+    /// <see langword="null"/> when every input is <see langword="null"/> so the handler appends no query string.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy, ShowArchived);
+
+    private static QueryParameter? BuildQueryParameter(int? limit, int? offset, string? orderBy, bool? showArchived)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l)
+            parameters["limit"] = l;
+
+        if (offset is { } o)
+            parameters["offset"] = o;
+
+        if (!string.IsNullOrWhiteSpace(orderBy))
+            parameters["order_by"] = orderBy;
+
+        if (showArchived is { } s)
+            parameters["show_archived"] = s ? "true" : "false";
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+};

--- a/src/BexioApiNet/Models/QueryParameterContactGroup.cs
+++ b/src/BexioApiNet/Models/QueryParameterContactGroup.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters
+/// </summary>
+public sealed record QueryParameterContactGroup(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Models/QueryParameterContactRelation.cs
+++ b/src/BexioApiNet/Models/QueryParameterContactRelation.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters for contact relation endpoints.
+/// </summary>
+public sealed record QueryParameterContactRelation(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    /// The composed <see cref="Models.QueryParameter"/> carrying <c>limit</c> and <c>offset</c>.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Models/QueryParameterContactSector.cs
+++ b/src/BexioApiNet/Models/QueryParameterContactSector.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters on contact sector endpoints
+/// (<c>GET /2.0/contact_branch</c> and <c>POST /2.0/contact_branch/search</c>).
+/// </summary>
+/// <param name="Limit">Limit the number of results (Bexio max is 2000).</param>
+/// <param name="Offset">Skip over the given number of elements before returning results.</param>
+public sealed record QueryParameterContactSector(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    /// Parameter dictionary rendered onto the request URI by the connection handler.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Models/QueryParameterExchangeRate.cs
+++ b/src/BexioApiNet/Models/QueryParameterExchangeRate.cs
@@ -1,0 +1,52 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Optional query parameters for the <c>3.0/currencies/{id}/exchange_rates</c> endpoint.
+/// </summary>
+/// <param name="Date">The validity date of the exchange rate to fetch (formatted as <c>yyyy-MM-dd</c>).</param>
+public sealed record QueryParameterExchangeRate(
+    DateOnly? Date = null
+)
+{
+    /// <summary>
+    ///     The wrapped <see cref="QueryParameter" /> built from the supplied options. Returns <see langword="null" /> when no
+    ///     optional value was provided so the connection handler can skip query string composition entirely.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Date);
+
+    private static QueryParameter? BuildQueryParameter(DateOnly? date)
+    {
+        if (date is null)
+            return null;
+
+        return new QueryParameter(new Dictionary<string, object>
+        {
+            { "date", date.Value.ToString("yyyy-MM-dd") }
+        });
+    }
+}

--- a/src/BexioApiNet/Models/QueryParameterJournal.cs
+++ b/src/BexioApiNet/Models/QueryParameterJournal.cs
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters for the accounting journal endpoint.
+/// </summary>
+/// <param name="From">Filter for entries after this date.</param>
+/// <param name="To">Filter for entries until this date.</param>
+/// <param name="AccountUuid">Filter for entries with account with this uuid.</param>
+/// <param name="Limit">Limit the number of results (max is 2000).</param>
+/// <param name="Offset">Skip over a number of elements by specifying an offset value.</param>
+public sealed record QueryParameterJournal(
+    DateOnly? From = null,
+    DateOnly? To = null,
+    string? AccountUuid = null,
+    int? Limit = null,
+    int? Offset = null
+)
+{
+    /// <summary>
+    /// Wrapped dictionary of query parameters to serialize onto the URL. Only parameters with a value are emitted.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = Build(From, To, AccountUuid, Limit, Offset);
+
+    private static QueryParameter? Build(DateOnly? from, DateOnly? to, string? accountUuid, int? limit, int? offset)
+    {
+        var parameters = new Dictionary<string, object>();
+        if (from is { } f) parameters["from"] = f.ToString("yyyy-MM-dd");
+        if (to is { } t) parameters["to"] = t.ToString("yyyy-MM-dd");
+        if (!string.IsNullOrWhiteSpace(accountUuid)) parameters["account_uuid"] = accountUuid;
+        if (limit is { } l) parameters["limit"] = l;
+        if (offset is { } o) parameters["offset"] = o;
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+}

--- a/src/BexioApiNet/Models/QueryParameterOutgoingPayment.cs
+++ b/src/BexioApiNet/Models/QueryParameterOutgoingPayment.cs
@@ -1,0 +1,67 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Query parameters for <c>GET /4.0/purchase/outgoing-payments</c>. <c>bill_id</c> is mandatory per the Bexio v4.0 spec;
+/// all other parameters are optional and only added to the final URI when supplied.
+/// <see href="https://docs.bexio.com/#tag/Outgoing-Payment/operation/ApiOutgoingPaymentList_GET">List Outgoing Payments</see>
+/// </summary>
+public sealed record QueryParameterOutgoingPayment
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryParameterOutgoingPayment"/> record.
+    /// </summary>
+    /// <param name="billId">Bill identifier to filter by. Required by the Bexio API.</param>
+    /// <param name="limit">Page size (1 or more). Bexio default is 100.</param>
+    /// <param name="page">1-based page number. Bexio default is 1.</param>
+    /// <param name="order">Sort direction. Must be <c>asc</c> or <c>desc</c>. Bexio default is <c>asc</c>.</param>
+    /// <param name="sort">Field name to sort by (e.g. <c>payment_type</c>).</param>
+    public QueryParameterOutgoingPayment(
+        Guid billId,
+        int? limit = null,
+        int? page = null,
+        string? order = null,
+        string? sort = null)
+    {
+        var parameters = new Dictionary<string, object>
+        {
+            ["bill_id"] = billId
+        };
+
+        if (limit is { } l) parameters["limit"] = l;
+        if (page is { } p) parameters["page"] = p;
+        if (!string.IsNullOrWhiteSpace(order)) parameters["order"] = order;
+        if (!string.IsNullOrWhiteSpace(sort)) parameters["sort"] = sort;
+
+        QueryParameter = new(parameters);
+    }
+
+    /// <summary>
+    /// Serializable query parameter dictionary forwarded to <c>ConnectionHandler</c>.
+    /// </summary>
+    public QueryParameter QueryParameter { get; }
+}

--- a/src/BexioApiNet/Models/QueryParameterPayment.cs
+++ b/src/BexioApiNet/Models/QueryParameterPayment.cs
@@ -1,0 +1,66 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Optional query parameters for the Bexio banking payments list endpoint
+/// (<c>GET /4.0/banking/payments</c>). The v4 list endpoint uses <c>page</c> and
+/// <c>per-page</c> for pagination and a <c>filter-by</c> expression for filtering,
+/// which differs from the <c>limit</c>/<c>offset</c> convention of older endpoints.
+/// <see href="https://docs.bexio.com/#tag/Payments/operation/NewFetchAllPayments"/>
+/// </summary>
+/// <param name="Page">1-based page offset to skip.</param>
+/// <param name="PerPage">Page size (maximum 2000 per Bexio API contract).</param>
+/// <param name="FilterBy">Filter expression. See the Bexio docs for syntax details.</param>
+public sealed record QueryParameterPayment(
+    int? Page = null,
+    int? PerPage = null,
+    string? FilterBy = null
+)
+{
+    /// <summary>
+    /// The underlying <see cref="BexioApiNet.Models.QueryParameter"/> forwarded to
+    /// <see cref="BexioApiNet.Interfaces.IBexioConnectionHandler.GetAsync{TResult}"/>.
+    /// Only the properties that have been set by the caller are added to the dictionary.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = Build(Page, PerPage, FilterBy);
+
+    private static QueryParameter? Build(int? page, int? perPage, string? filterBy)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (page is { } p)
+            parameters["page"] = p;
+
+        if (perPage is { } pp)
+            parameters["per-page"] = pp;
+
+        if (!string.IsNullOrWhiteSpace(filterBy))
+            parameters["filter-by"] = filterBy;
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+}

--- a/src/BexioApiNet/Models/QueryParameterPaymentType.cs
+++ b/src/BexioApiNet/Models/QueryParameterPaymentType.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Dictionary for optional query parameters
+/// </summary>
+public sealed record QueryParameterPaymentType(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(new Dictionary<string, object>
+        {
+            { "limit", Limit },
+            { "offset", Offset }
+        });
+}

--- a/src/BexioApiNet/Models/QueryParameterVatPeriod.cs
+++ b/src/BexioApiNet/Models/QueryParameterVatPeriod.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters
+/// </summary>
+public sealed record QueryParameterVatPeriod(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -26,6 +26,7 @@ SOFTWARE.
 using BexioApiNet.Interfaces;
 using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Interfaces.Connectors.Contacts;
 
 namespace BexioApiNet.Services;
 
@@ -52,6 +53,45 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public ITaxService Taxes { get; set; }
 
+    /// <inheritdoc />
+    public IAccountGroupService AccountGroups { get; set; }
+
+    /// <inheritdoc />
+    public IBusinessYearService AccountingBusinessYears { get; set; }
+
+    /// <inheritdoc />
+    public ICalendarYearService AccountingCalendarYears { get; set; }
+
+    /// <inheritdoc />
+    public IVatPeriodService AccountingVatPeriods { get; set; }
+
+    /// <inheritdoc />
+    public IReportService AccountingReports { get; set; }
+
+    /// <inheritdoc />
+    public IPaymentTypeService PaymentTypes { get; set; }
+
+    /// <inheritdoc />
+    public IPaymentService BankingPayments { get; set; }
+
+    /// <inheritdoc />
+    public IOutgoingPaymentService PurchaseOutgoingPayments { get; set; }
+
+    /// <inheritdoc />
+    public IContactService Contacts { get; set; }
+
+    /// <inheritdoc />
+    public IContactGroupService ContactGroups { get; set; }
+
+    /// <inheritdoc />
+    public IContactRelationService ContactRelations { get; set; }
+
+    /// <inheritdoc />
+    public IContactSectorService ContactSectors { get; set; }
+
+    /// <inheritdoc />
+    public IAdditionalAddressService ContactAdditionalAddresses { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -61,7 +101,20 @@ public sealed class BexioApiClient : IBexioApiClient
         IAccountService accountingAccounts,
         ICurrencyService currencies,
         IManualEntryService accountingManualEntries,
-        ITaxService taxes)
+        ITaxService taxes,
+        IAccountGroupService accountGroups,
+        IBusinessYearService accountingBusinessYears,
+        ICalendarYearService accountingCalendarYears,
+        IVatPeriodService accountingVatPeriods,
+        IReportService accountingReports,
+        IPaymentTypeService paymentTypes,
+        IPaymentService bankingPayments,
+        IOutgoingPaymentService purchaseOutgoingPayments,
+        IContactService contacts,
+        IContactGroupService contactGroups,
+        IContactRelationService contactRelations,
+        IContactSectorService contactSectors,
+        IAdditionalAddressService contactAdditionalAddresses)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -69,6 +122,19 @@ public sealed class BexioApiClient : IBexioApiClient
         Currencies = currencies;
         AccountingManualEntries = accountingManualEntries;
         Taxes = taxes;
+        AccountGroups = accountGroups;
+        AccountingBusinessYears = accountingBusinessYears;
+        AccountingCalendarYears = accountingCalendarYears;
+        AccountingVatPeriods = accountingVatPeriods;
+        AccountingReports = accountingReports;
+        PaymentTypes = paymentTypes;
+        BankingPayments = bankingPayments;
+        PurchaseOutgoingPayments = purchaseOutgoingPayments;
+        Contacts = contacts;
+        ContactGroups = contactGroups;
+        ContactRelations = contactRelations;
+        ContactSectors = contactSectors;
+        ContactAdditionalAddresses = contactAdditionalAddresses;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/Connectors/Accounting/AccountGroupConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/AccountGroupConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <summary>
+/// Account group endpoint configuration
+/// </summary>
+public struct AccountGroupConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "account_groups";
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/AccountGroupService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/AccountGroupService.cs
@@ -34,9 +34,7 @@ using BexioApiNet.Services.Connectors.Base;
 
 namespace BexioApiNet.Services.Connectors.Accounting;
 
-
 /// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Accounting.IAccountGroupService" />
-
 public sealed class AccountGroupService : ConnectorService, IAccountGroupService
 {
     /// <summary>

--- a/src/BexioApiNet/Services/Connectors/Accounting/AccountGroupService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/AccountGroupService.cs
@@ -1,0 +1,74 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Accounting.AccountGroups;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Accounting;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Accounting.IAccountGroupService" />
+
+public sealed class AccountGroupService : ConnectorService, IAccountGroupService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = AccountGroupConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = AccountGroupConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public AccountGroupService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<AccountGroup>>> Get([Optional] QueryParameterAccountGroup? queryParameterAccountGroup, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<AccountGroup>>($"{ApiVersion}/{EndpointRoot}", queryParameterAccountGroup?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<AccountGroup>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterAccountGroup?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/BusinessYearConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/BusinessYearConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <summary>
+///     Business year endpoint configuration
+/// </summary>
+public struct BusinessYearConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    ///     The request path
+    /// </summary>
+    public const string EndpointRoot = "accounting/business_years";
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/BusinessYearService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/BusinessYearService.cs
@@ -1,0 +1,83 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Accounting.BusinessYears;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Accounting;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Accounting.IBusinessYearService" />
+public sealed class BusinessYearService : ConnectorService, IBusinessYearService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = BusinessYearConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = BusinessYearConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public BusinessYearService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<BusinessYear>>> Get(
+        [Optional] QueryParameterBusinessYear? queryParameterBusinessYear, [Optional] bool autoPage,
+        [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<BusinessYear>>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterBusinessYear?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<BusinessYear>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterBusinessYear?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<BusinessYear>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<BusinessYear>($"{ApiVersion}/{EndpointRoot}/{id}", null,
+            cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/CalendarYearConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/CalendarYearConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <summary>
+/// Calendar year endpoint configuration
+/// </summary>
+public struct CalendarYearConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "accounting/calendar_years";
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/CalendarYearService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/CalendarYearService.cs
@@ -1,0 +1,91 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears;
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Views;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Accounting;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Accounting.ICalendarYearService" />
+public sealed class CalendarYearService : ConnectorService, ICalendarYearService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = CalendarYearConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = CalendarYearConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public CalendarYearService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<CalendarYear>?>> Get([Optional] QueryParameterCalendarYear? queryParameterCalendarYear, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<CalendarYear>?>($"{ApiVersion}/{EndpointRoot}", queryParameterCalendarYear?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<CalendarYear>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterCalendarYear?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<CalendarYear>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<CalendarYear>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<CalendarYear>>> Create(CalendarYearCreate calendarYearCreate, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<List<CalendarYear>, CalendarYearCreate>(calendarYearCreate, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<CalendarYear>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterCalendarYear? queryParameterCalendarYear, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<CalendarYear>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterCalendarYear?.QueryParameter, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/CurrencyService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/CurrencyService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
@@ -26,6 +26,7 @@ SOFTWARE.
 using System.Runtime.InteropServices;
 using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Abstractions.Models.Accounting.Currencies;
+using BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Interfaces;
 using BexioApiNet.Interfaces.Connectors.Accounting;
@@ -34,18 +35,16 @@ using BexioApiNet.Services.Connectors.Base;
 
 namespace BexioApiNet.Services.Connectors.Accounting;
 
-
 /// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Accounting.ICurrencyService" />
-
 public sealed class CurrencyService : ConnectorService, ICurrencyService
 {
     /// <summary>
-    /// The api endpoint version
+    ///     The api endpoint version
     /// </summary>
     private const string ApiVersion = CurrencyConfiguration.ApiVersion;
 
     /// <summary>
-    /// The api request path
+    ///     The api request path
     /// </summary>
     private const string EndpointRoot = CurrencyConfiguration.EndpointRoot;
 
@@ -55,11 +54,14 @@ public sealed class CurrencyService : ConnectorService, ICurrencyService
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<List<Currency>>> Get([Optional] QueryParameterCurrency? queryParameterCurrency, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<List<Currency>>> Get([Optional] QueryParameterCurrency? queryParameterCurrency,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
     {
-        var res = await ConnectionHandler.GetAsync<List<Currency>>($"{ApiVersion}/{EndpointRoot}", queryParameterCurrency?.QueryParameter, cancellationToken);
+        var res = await ConnectionHandler.GetAsync<List<Currency>>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterCurrency?.QueryParameter, cancellationToken);
 
-        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
             return res;
 
         res.Data.AddRange(await ConnectionHandler.FetchAll<Currency>(
@@ -70,5 +72,49 @@ public sealed class CurrencyService : ConnectorService, ICurrencyService
             cancellationToken));
 
         return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<string>>> GetCodes([Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<string>>($"{ApiVersion}/{EndpointRoot}/codes", null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Currency>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Currency>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ExchangeRate>>> GetExchangeRates(int id,
+        [Optional] QueryParameterExchangeRate? queryParameterExchangeRate,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<ExchangeRate>>($"{ApiVersion}/{EndpointRoot}/{id}/exchange_rates",
+            queryParameterExchangeRate?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Currency>> Create(CurrencyCreate currency,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Currency, CurrencyCreate>(currency, $"{ApiVersion}/{EndpointRoot}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Currency>> Patch(int id, CurrencyPatch currency,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PatchAsync<Currency, CurrencyPatch>(currency,
+            $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
     }
 }

--- a/src/BexioApiNet/Services/Connectors/Accounting/ManualEntryService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/ManualEntryService.cs
@@ -91,9 +91,83 @@ public sealed class ManualEntryService : ConnectorService, IManualEntryService
     }
 
     /// <inheritdoc />
+    public async Task<ApiResult<ManualEntry>> Put(int manualEntryId, ManualEntryUpdate payload, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<ManualEntry, ManualEntryUpdate>(payload, $"{ApiVersion}/{EndpointRoot}/{manualEntryId}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ManualEntryNextRefNr>> GetNextRefNr([Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<ManualEntryNextRefNr>($"{ApiVersion}/{EndpointRoot}/next_ref_nr", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ManualEntryFile>?>> GetFiles(int manualEntryId, [Optional] QueryParameterManualEntry? queryParameter, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var path = $"{ApiVersion}/{EndpointRoot}/{manualEntryId}/files";
+        var res = await ConnectionHandler.GetAsync<List<ManualEntryFile>?>(path, queryParameter?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<ManualEntryFile>(
+            res.Data.Count,
+            totalResults,
+            path,
+            queryParameter?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ManualEntryFileDetail>> GetFileById(int manualEntryId, int fileId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<ManualEntryFileDetail>($"{ApiVersion}/{EndpointRoot}/{manualEntryId}/files/{fileId}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ManualEntryFile>?>> GetEntryFiles(int manualEntryId, int entryId, [Optional] QueryParameterManualEntry? queryParameter, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var path = $"{ApiVersion}/{EndpointRoot}/{manualEntryId}/entries/{entryId}/files";
+        var res = await ConnectionHandler.GetAsync<List<ManualEntryFile>?>(path, queryParameter?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<ManualEntryFile>(
+            res.Data.Count,
+            totalResults,
+            path,
+            queryParameter?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ManualEntryFileDetail>> GetEntryFileById(int manualEntryId, int entryId, int fileId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<ManualEntryFileDetail>($"{ApiVersion}/{EndpointRoot}/{manualEntryId}/entries/{entryId}/files/{fileId}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
     {
         var res = await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
         return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> DeleteFile(int manualEntryId, int fileId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{manualEntryId}/files/{fileId}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> DeleteEntryFile(int manualEntryId, int entryId, int fileId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{manualEntryId}/entries/{entryId}/files/{fileId}", cancellationToken);
     }
 }

--- a/src/BexioApiNet/Services/Connectors/Accounting/ReportConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/ReportConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <summary>
+/// Reports endpoint configuration
+/// </summary>
+public struct ReportConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    /// The request path for the accounting journal.
+    /// </summary>
+    public const string JournalEndpointRoot = "accounting/journal";
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/ReportService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/ReportService.cs
@@ -1,0 +1,75 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Accounting.Reports;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Accounting;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <inheritdoc cref="IReportService" />
+public sealed class ReportService : ConnectorService, IReportService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = ReportConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path for the accounting journal.
+    /// </summary>
+    private const string JournalEndpointRoot = ReportConfiguration.JournalEndpointRoot;
+
+    /// <inheritdoc />
+    public ReportService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Journal>>> GetJournal(
+        [Optional] QueryParameterJournal? queryParameterJournal,
+        [Optional] bool autoPage,
+        [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Journal>>($"{ApiVersion}/{JournalEndpointRoot}", queryParameterJournal?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Journal>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{JournalEndpointRoot}",
+            queryParameterJournal?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/TaxService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/TaxService.cs
@@ -71,4 +71,16 @@ public sealed class TaxService : ConnectorService, ITaxService
 
         return res;
     }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Tax>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Tax>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
 }

--- a/src/BexioApiNet/Services/Connectors/Accounting/TaxService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/TaxService.cs
@@ -34,9 +34,7 @@ using BexioApiNet.Services.Connectors.Base;
 
 namespace BexioApiNet.Services.Connectors.Accounting;
 
-
-/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Accounting.ICurrencyService" />
-
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Accounting.ITaxService" />
 public sealed class TaxService : ConnectorService, ITaxService
 {
     /// <summary>

--- a/src/BexioApiNet/Services/Connectors/Accounting/VatPeriodConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/VatPeriodConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <summary>
+/// Vat period endpoint configuration
+/// </summary>
+public struct VatPeriodConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "accounting/vat_periods";
+}

--- a/src/BexioApiNet/Services/Connectors/Accounting/VatPeriodService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/VatPeriodService.cs
@@ -1,0 +1,76 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Accounting.VatPeriods;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Accounting;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Accounting;
+
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Accounting.IVatPeriodService" />
+public sealed class VatPeriodService : ConnectorService, IVatPeriodService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = VatPeriodConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = VatPeriodConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public VatPeriodService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<VatPeriod>>> Get([Optional] QueryParameterVatPeriod? queryParameterVatPeriod, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<VatPeriod>>($"{ApiVersion}/{EndpointRoot}", queryParameterVatPeriod?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<VatPeriod>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterVatPeriod?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<VatPeriod>> GetById(int id, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.GetAsync<VatPeriod>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+}

--- a/src/BexioApiNet/Services/Connectors/Banking/BankAccountService.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/BankAccountService.cs
@@ -60,4 +60,10 @@ public sealed class BankAccountService : ConnectorService, IBankAccountService
     {
         return await ConnectionHandler.GetAsync<List<BankAccountGet>>($"{ApiVersion}/{EndpointRoot}", queryParameterBankAccount?.QueryParameter, cancellationToken);
     }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<BankAccountGet>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<BankAccountGet>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
 }

--- a/src/BexioApiNet/Services/Connectors/Banking/OutgoingPaymentConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/OutgoingPaymentConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Banking;
+
+/// <summary>
+/// Outgoing payment endpoint configuration. Bexio <c>4.0/purchase/outgoing-payments</c>.
+/// </summary>
+public struct OutgoingPaymentConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "4.0";
+
+    /// <summary>
+    /// The request path.
+    /// </summary>
+    public const string EndpointRoot = "purchase/outgoing-payments";
+}

--- a/src/BexioApiNet/Services/Connectors/Banking/OutgoingPaymentService.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/OutgoingPaymentService.cs
@@ -1,0 +1,84 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Banking;
+
+/// <inheritdoc cref="IOutgoingPaymentService" />
+public sealed class OutgoingPaymentService : ConnectorService, IOutgoingPaymentService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = OutgoingPaymentConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = OutgoingPaymentConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public OutgoingPaymentService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<OutgoingPaymentListResponse>> Get(QueryParameterOutgoingPayment queryParameterOutgoingPayment, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<OutgoingPaymentListResponse>($"{ApiVersion}/{EndpointRoot}", queryParameterOutgoingPayment.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<OutgoingPayment>> GetById(Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<OutgoingPayment>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<OutgoingPayment>> Create(OutgoingPaymentCreate payload, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<OutgoingPayment, OutgoingPaymentCreate>(payload, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<OutgoingPayment>> Update(OutgoingPaymentUpdate payload, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<OutgoingPayment, OutgoingPaymentUpdate>(payload, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Banking/PaymentConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/PaymentConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Banking;
+
+/// <summary>
+/// Payment endpoint configuration (v4 banking payments).
+/// </summary>
+public struct PaymentConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "4.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "banking/payments";
+}

--- a/src/BexioApiNet/Services/Connectors/Banking/PaymentService.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/PaymentService.cs
@@ -35,7 +35,7 @@ using BexioApiNet.Services.Connectors.Base;
 namespace BexioApiNet.Services.Connectors.Banking;
 
 /// <inheritdoc cref="IPaymentService" />
-internal sealed class PaymentService : ConnectorService, IPaymentService
+public sealed class PaymentService : ConnectorService, IPaymentService
 {
     /// <summary>
     /// The api endpoint version

--- a/src/BexioApiNet/Services/Connectors/Banking/PaymentService.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/PaymentService.cs
@@ -1,0 +1,81 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.Payments;
+using BexioApiNet.Abstractions.Models.Banking.Payments.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Banking;
+
+/// <inheritdoc cref="IPaymentService" />
+internal sealed class PaymentService : ConnectorService, IPaymentService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = PaymentConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = PaymentConfiguration.EndpointRoot;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PaymentService"/> class.
+    /// </summary>
+    /// <param name="bexioConnectionHandler">Bexio connection handler.</param>
+    public PaymentService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Payment>?>> Get([Optional] QueryParameterPayment? queryParameterPayment, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.GetAsync<List<Payment>?>($"{ApiVersion}/{EndpointRoot}", queryParameterPayment?.QueryParameter, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Payment>> GetById(Guid paymentId, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.GetAsync<Payment>($"{ApiVersion}/{EndpointRoot}/{paymentId}", null, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Payment>> Create(PaymentCreate payment, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PostAsync<Payment, PaymentCreate>(payment, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Payment>> Cancel(Guid paymentId, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PostActionAsync<Payment>($"{ApiVersion}/{EndpointRoot}/{paymentId}/cancel", cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Payment>> Update(Guid paymentId, PaymentUpdate payment, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PutAsync<Payment, PaymentUpdate>(payment, $"{ApiVersion}/{EndpointRoot}/{paymentId}", cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(Guid paymentId, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{paymentId}", cancellationToken);
+}

--- a/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Banking;
+
+/// <summary>
+///     Payment type endpoint configuration
+/// </summary>
+public struct PaymentTypeConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    ///     The request path
+    /// </summary>
+    public const string EndpointRoot = "payment_type";
+}

--- a/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeService.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeService.cs
@@ -1,0 +1,74 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.PaymentTypes;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Banking;
+
+/// <inheritdoc cref="IPaymentTypeService" />
+public sealed class PaymentTypeService : ConnectorService, IPaymentTypeService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = PaymentTypeConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = PaymentTypeConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public PaymentTypeService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<PaymentType>>> Get(
+        [Optional] QueryParameterPaymentType? queryParameterPaymentType,
+        [Optional] bool autoPage,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<PaymentType>>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterPaymentType?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<PaymentType>>> Search(
+        List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterPaymentType? queryParameterPaymentType,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<PaymentType>(searchCriteria,
+            $"{ApiVersion}/{EndpointRoot}/search", queryParameterPaymentType?.QueryParameter, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeService.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeService.cs
@@ -23,8 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-
 using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Abstractions.Models.Banking.PaymentTypes;
 using BexioApiNet.Interfaces;
@@ -58,8 +58,20 @@ public sealed class PaymentTypeService : ConnectorService, IPaymentTypeService
         [Optional] bool autoPage,
         [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.GetAsync<List<PaymentType>>($"{ApiVersion}/{EndpointRoot}",
+        var res = await ConnectionHandler.GetAsync<List<PaymentType>>($"{ApiVersion}/{EndpointRoot}",
             queryParameterPaymentType?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<PaymentType>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterPaymentType?.QueryParameter,
+            cancellationToken));
+
+        return res;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/Connectors/Contacts/AdditionalAddressConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/AdditionalAddressConfiguration.cs
@@ -1,0 +1,50 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <summary>
+/// Additional address endpoint configuration. Routes are nested under
+/// <c>2.0/contact/{contactId}/additional_address</c>; the parent contact id is
+/// supplied per-call by the service so only the version and trailing segment
+/// live here.
+/// </summary>
+public struct AdditionalAddressConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// Parent resource segment (contacts) under which additional addresses are nested.
+    /// </summary>
+    public const string ParentEndpoint = "contact";
+
+    /// <summary>
+    /// The trailing request path segment below the parent contact id.
+    /// </summary>
+    public const string EndpointSegment = "additional_address";
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/AdditionalAddressService.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/AdditionalAddressService.cs
@@ -1,0 +1,101 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses;
+using BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Contacts.IAdditionalAddressService" />
+public sealed class AdditionalAddressService : ConnectorService, IAdditionalAddressService
+{
+    /// <summary>
+    /// The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = AdditionalAddressConfiguration.ApiVersion;
+
+    /// <summary>
+    /// Parent resource segment (contacts) under which additional addresses are nested.
+    /// </summary>
+    private const string ParentEndpoint = AdditionalAddressConfiguration.ParentEndpoint;
+
+    /// <summary>
+    /// The trailing request path segment below the parent contact id.
+    /// </summary>
+    private const string EndpointSegment = AdditionalAddressConfiguration.EndpointSegment;
+
+    /// <inheritdoc />
+    public AdditionalAddressService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<AdditionalAddress>?>> Get(int contactId, [Optional] QueryParameterAdditionalAddress? queryParameterAdditionalAddress, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var endpointRoot = BuildEndpointRoot(contactId);
+        var res = await ConnectionHandler.GetAsync<List<AdditionalAddress>?>(endpointRoot, queryParameterAdditionalAddress?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<AdditionalAddress>(
+            res.Data.Count,
+            totalResults,
+            endpointRoot,
+            queryParameterAdditionalAddress?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<AdditionalAddress>> GetById(int contactId, int id, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.GetAsync<AdditionalAddress>($"{BuildEndpointRoot(contactId)}/{id}", null, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<AdditionalAddress>> Create(int contactId, AdditionalAddressCreate additionalAddress, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PostAsync<AdditionalAddress, AdditionalAddressCreate>(additionalAddress, BuildEndpointRoot(contactId), cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<AdditionalAddress>>> Search(int contactId, List<SearchCriteria> searchCriteria, [Optional] QueryParameterAdditionalAddress? queryParameterAdditionalAddress, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PostSearchAsync<AdditionalAddress>(searchCriteria, $"{BuildEndpointRoot(contactId)}/search", queryParameterAdditionalAddress?.QueryParameter, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<AdditionalAddress>> Update(int contactId, int id, AdditionalAddressUpdate additionalAddress, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PostAsync<AdditionalAddress, AdditionalAddressUpdate>(additionalAddress, $"{BuildEndpointRoot(contactId)}/{id}", cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int contactId, int id, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.Delete($"{BuildEndpointRoot(contactId)}/{id}", cancellationToken);
+
+    private static string BuildEndpointRoot(int contactId) => $"{ApiVersion}/{ParentEndpoint}/{contactId}/{EndpointSegment}";
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/ContactConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/ContactConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <summary>
+/// Contact endpoint configuration
+/// </summary>
+public struct ContactConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "contact";
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/ContactGroupConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/ContactGroupConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <summary>
+/// Contact group endpoint configuration
+/// </summary>
+public struct ContactGroupConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "contact_group";
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/ContactGroupService.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/ContactGroupService.cs
@@ -1,0 +1,103 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.Contacts.IContactGroupService" />
+public sealed class ContactGroupService : ConnectorService, IContactGroupService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = ContactGroupConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = ContactGroupConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public ContactGroupService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ContactGroup>?>> Get([Optional] QueryParameterContactGroup? queryParameterContactGroup, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<ContactGroup>?>($"{ApiVersion}/{EndpointRoot}", queryParameterContactGroup?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<ContactGroup>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterContactGroup?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ContactGroup?>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<ContactGroup?>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ContactGroup>> Create(ContactGroupCreate contactGroup, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<ContactGroup, ContactGroupCreate>(contactGroup, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ContactGroup>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterContactGroup? queryParameterContactGroup, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<ContactGroup>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterContactGroup?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ContactGroup>> Update(int id, ContactGroupUpdate contactGroup, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<ContactGroup, ContactGroupUpdate>(contactGroup, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/ContactRelationConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/ContactRelationConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <summary>
+/// Contact relation endpoint configuration
+/// </summary>
+public struct ContactRelationConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "contact_relation";
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/ContactRelationService.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/ContactRelationService.cs
@@ -1,0 +1,107 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactRelations;
+using BexioApiNet.Abstractions.Models.Contacts.ContactRelations.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <inheritdoc cref="IContactRelationService" />
+public sealed class ContactRelationService : ConnectorService, IContactRelationService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = ContactRelationConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = ContactRelationConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public ContactRelationService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ContactRelation>?>> Get(
+        [Optional] QueryParameterContactRelation? queryParameterContactRelation,
+        [Optional] bool autoPage,
+        [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<ContactRelation>?>(
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterContactRelation?.QueryParameter,
+            cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<ContactRelation>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterContactRelation?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ContactRelation>> GetById(int id, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.GetAsync<ContactRelation>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ContactRelation>> Create(ContactRelationCreate payload, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PostAsync<ContactRelation, ContactRelationCreate>(payload, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ContactRelation>>> Search(
+        List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterContactRelation? queryParameterContactRelation,
+        [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PostSearchAsync<ContactRelation>(
+            searchCriteria,
+            $"{ApiVersion}/{EndpointRoot}/search",
+            queryParameterContactRelation?.QueryParameter,
+            cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ContactRelation>> Update(int id, ContactRelationUpdate payload, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.PostAsync<ContactRelation, ContactRelationUpdate>(payload, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+        => await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/ContactSectorConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/ContactSectorConfiguration.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <summary>
+/// Contact sector endpoint configuration. The Bexio API exposes the resource
+/// under the legacy path segment <c>contact_branch</c> while the documented
+/// concept is "contact sector".
+/// </summary>
+public struct ContactSectorConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "contact_branch";
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/ContactSectorService.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/ContactSectorService.cs
@@ -1,0 +1,78 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactSectors;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <inheritdoc cref="IContactSectorService" />
+public sealed class ContactSectorService : ConnectorService, IContactSectorService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = ContactSectorConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = ContactSectorConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public ContactSectorService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ContactSector>?>> Get([Optional] QueryParameterContactSector? queryParameterContactSector, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<ContactSector>?>($"{ApiVersion}/{EndpointRoot}", queryParameterContactSector?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<ContactSector>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterContactSector?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<ContactSector>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterContactSector? queryParameterContactSector, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<ContactSector>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterContactSector?.QueryParameter, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Contacts/ContactService.cs
+++ b/src/BexioApiNet/Services/Connectors/Contacts/ContactService.cs
@@ -1,0 +1,115 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.Contacts;
+using BexioApiNet.Abstractions.Models.Contacts.Contacts.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Contacts;
+
+/// <inheritdoc cref="IContactService" />
+public sealed class ContactService : ConnectorService, IContactService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = ContactConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = ContactConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public ContactService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Contact>?>> Get([Optional] QueryParameterContact? queryParameterContact, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Contact>?>($"{ApiVersion}/{EndpointRoot}", queryParameterContact?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Contact>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterContact?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Contact>> GetById(int id, [Optional] QueryParameterContact? queryParameterContact, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Contact>($"{ApiVersion}/{EndpointRoot}/{id}", queryParameterContact?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Contact>> Create(ContactCreate contact, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Contact, ContactCreate>(contact, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Contact>>> BulkCreate(List<ContactCreate> contacts, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostBulkAsync<Contact, ContactCreate>(contacts, $"{ApiVersion}/{EndpointRoot}/_bulk_create", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Contact>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterContact? queryParameterContact, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Contact>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterContact?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Contact>> Update(int id, ContactUpdate contact, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Contact, ContactUpdate>(contact, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Restore(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PatchAsync<object, object?>(null, $"{ApiVersion}/{EndpointRoot}/{id}/restore", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -26,6 +26,7 @@ SOFTWARE.
 using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Services.Connectors.Accounting;
 using BexioApiNet.Services.Connectors.Banking;
+using BexioApiNet.Services.Connectors.Contacts;
 
 namespace BexioApiNet.E2eTests;
 
@@ -76,7 +77,20 @@ public abstract class BexioE2eTestBase
             new AccountService(connectionHandler),
             new CurrencyService(connectionHandler),
             new ManualEntryService(connectionHandler),
-            new TaxService(connectionHandler));
+            new TaxService(connectionHandler),
+            new AccountGroupService(connectionHandler),
+            new BusinessYearService(connectionHandler),
+            new CalendarYearService(connectionHandler),
+            new VatPeriodService(connectionHandler),
+            new ReportService(connectionHandler),
+            new PaymentTypeService(connectionHandler),
+            new PaymentService(connectionHandler),
+            new OutgoingPaymentService(connectionHandler),
+            new ContactService(connectionHandler),
+            new ContactGroupService(connectionHandler),
+            new ContactRelationService(connectionHandler),
+            new ContactSectorService(connectionHandler),
+            new AdditionalAddressService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/AccountGroups/AccountGroupServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/AccountGroups/AccountGroupServiceE2eTests.cs
@@ -1,0 +1,100 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.AccountGroups;
+
+/// <summary>
+/// Live end-to-end tests for the <see cref="AccountGroupService"/>. The service
+/// is constructed directly against the Bexio API so the test suite does not
+/// depend on wire-up in <c>IBexioApiClient</c> / <c>BexioApiClient</c>
+/// (that wire-up is handled by sub-issue #49).
+/// </summary>
+[Category("E2E")]
+public class AccountGroupServiceE2eTests
+{
+    private AccountGroupService? _service;
+    private BexioConnectionHandler? _connectionHandler;
+
+    /// <summary>
+    /// Reads <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> from
+    /// environment variables. Calls <see cref="Assert.Ignore(string)"/> if either
+    /// is missing so the test suite does not fail CI or AI agent runs that lack
+    /// live credentials.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        _service = new AccountGroupService(_connectionHandler);
+    }
+
+    /// <summary>
+    /// Disposes the connection handler if it was created for the test.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    /// Fetches all account groups from the live Bexio tenant and asserts the
+    /// response is successful with at least one account group returned.
+    /// </summary>
+    [Test]
+    public async Task GetAll()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        var res = await _service!.Get(autoPage: true);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.First().Id, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/BusinessYears/BusinessYearServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/BusinessYears/BusinessYearServiceE2eTests.cs
@@ -1,0 +1,123 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.BusinessYears;
+
+/// <summary>
+///     Live end-to-end smoke tests for <see cref="BusinessYearService" />. Constructs the
+///     service directly because the <c>BexioApiClient</c> aggregate wiring for business
+///     years is tracked by a separate issue. Tests are automatically skipped when
+///     <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> are not set.
+/// </summary>
+[Category("E2E")]
+public sealed class BusinessYearServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private BusinessYearService? _service;
+
+    /// <summary>
+    ///     Reads <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> from
+    ///     environment variables. Calls <see cref="Assert.Ignore(string)" /> if either
+    ///     is missing so the test suite does not fail CI runs that lack live credentials.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+        _service = new BusinessYearService(_connectionHandler);
+    }
+
+    /// <summary>
+    ///     Disposes the connection handler if one was created.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    ///     Fetches the full list of business years from the live tenant and asserts
+    ///     at least one entry is returned with a valid id.
+    /// </summary>
+    [Test]
+    public async Task GetAll()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        var res = await _service!.Get(autoPage: true);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.First().Id, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    ///     Fetches a single business year by id (using the first one returned by the
+    ///     list endpoint) and asserts round-trip equality on the id.
+    /// </summary>
+    [Test]
+    public async Task GetById()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        var list = await _service!.Get(autoPage: true);
+        Assert.That(list.IsSuccess, Is.True);
+        Assert.That(list.Data, Is.Not.Null.And.Not.Empty);
+
+        var firstId = list.Data!.First().Id;
+        var res = await _service.GetById(firstId);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.Id, Is.EqualTo(firstId));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/CalendarYears/CalendarYearServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/CalendarYears/CalendarYearServiceE2eTests.cs
@@ -1,0 +1,187 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Interfaces.Connectors.Accounting;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.CalendarYears;
+
+/// <summary>
+/// Live end-to-end tests for <see cref="CalendarYearService"/>. Tests are skipped when
+/// credentials are not configured (see <see cref="BexioE2eTestBase"/>). Constructs the
+/// service directly from its own <see cref="BexioConnectionHandler"/> because the
+/// aggregate <see cref="IBexioApiClient"/> wire-up lives in a separate sub-issue.
+/// </summary>
+public class CalendarYearServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private ICalendarYearService? _sut;
+
+    /// <summary>
+    /// Reads <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> from the
+    /// environment. Calls <see cref="Assert.Ignore(string)"/> if either is missing so
+    /// the test suite does not fail CI or AI agent runs that lack live credentials.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        _sut = new CalendarYearService(_connectionHandler);
+    }
+
+    /// <summary>
+    /// Disposes the connection handler if it was created for the test.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    /// Fetches the paginated list of calendar years from the live tenant.
+    /// </summary>
+    [Test]
+    [Category("E2E")]
+    public async Task Get_ListsCalendarYears()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        var result = await _sut!.Get(new QueryParameterCalendarYear(Limit: 5, Offset: 0));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches a single calendar year by id, using the first id returned by <c>Get</c>.
+    /// </summary>
+    [Test]
+    [Category("E2E")]
+    public async Task GetById_FetchesCalendarYear()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        var list = await _sut!.Get(new QueryParameterCalendarYear(Limit: 1, Offset: 0));
+        Assert.That(list.Data, Is.Not.Null.And.Not.Empty, "tenant has no calendar years to fetch");
+
+        var id = list.Data![0].Id;
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+        });
+    }
+
+    /// <summary>
+    /// Searches calendar years matching a start date criterion against the live tenant.
+    /// </summary>
+    [Test]
+    [Category("E2E")]
+    public async Task Search_FindsCalendarYearsByStart()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        var list = await _sut!.Get(new QueryParameterCalendarYear(Limit: 1, Offset: 0));
+        Assert.That(list.Data, Is.Not.Null.And.Not.Empty, "tenant has no calendar years to search");
+
+        var start = list.Data![0].Start.ToString("yyyy-MM-dd");
+
+        var result = await _sut.Search([
+            new SearchCriteria { Field = "start", Value = start, Criteria = "=" }
+        ]);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Creates the calendar year for a future target year. Kept as an explicit stub because
+    /// Bexio persists the created years in the live tenant — this test is intentionally
+    /// skipped by default (<see cref="IgnoreAttribute"/>) and should only be enabled
+    /// manually when the tenant is safe to mutate.
+    /// </summary>
+    [Test]
+    [Category("E2E")]
+    [Ignore("Mutates live tenant; calendar year creation is not reversible via API. Run manually when safe.")]
+    public async Task Create_CreatesCalendarYear()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        var targetYear = (DateTime.UtcNow.Year + 1).ToString();
+
+        var result = await _sut!.Create(new(
+            Year: targetYear,
+            IsVatSubject: true,
+            IsAnnualReporting: false,
+            VatAccountingMethod: Abstractions.Models.Accounting.CalendarYears.Enums.VatAccountingMethod.effective,
+            VatAccountingType: Abstractions.Models.Accounting.CalendarYears.Enums.VatAccountingType.agreed,
+            DefaultTaxIncomeId: 1,
+            DefaultTaxExpenseId: 2));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null.And.Not.Empty);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/CreatePatchAndDelete.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/CreatePatchAndDelete.cs
@@ -1,0 +1,82 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.Currencies;
+
+/// <summary>
+///     E2E coverage for the full create / patch / delete cycle of <c>CurrencyService</c>
+///     against the live Bexio API. The test cleans up after itself by deleting the
+///     currency it created so it can be re-run safely.
+/// </summary>
+public class TestCreatePatchAndDelete : BexioE2eTestBase
+{
+    /// <summary>
+    ///     Creates a unique throwaway currency code (<c>X??</c>), patches its round factor and
+    ///     finally deletes it. Each step asserts a successful response and the test
+    ///     guarantees the created currency is removed even when the assertion order changes.
+    /// </summary>
+    [Test]
+    public async Task CreatePatchAndDelete()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var name = $"X{Random.Shared.Next(10, 99)}";
+
+        var created = await BexioApiClient!.Currencies.Create(new CurrencyCreate(name, 0.05));
+
+        Assert.That(created, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(created.IsSuccess, Is.True);
+            Assert.That(created.ApiError, Is.Null);
+            Assert.That(created.Data, Is.Not.Null);
+            Assert.That(created.Data!.Name, Is.EqualTo(name));
+        });
+
+        try
+        {
+            var patched = await BexioApiClient!.Currencies.Patch(created.Data!.Id, new CurrencyPatch(0.10));
+
+            Assert.That(patched, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(patched.IsSuccess, Is.True);
+                Assert.That(patched.ApiError, Is.Null);
+                Assert.That(patched.Data, Is.Not.Null);
+                Assert.That(patched.Data!.Id, Is.EqualTo(created.Data!.Id));
+                Assert.That(patched.Data!.RoundFactor, Is.EqualTo(0.10));
+            });
+        }
+        finally
+        {
+            var deleted = await BexioApiClient!.Currencies.Delete(created.Data!.Id);
+
+            Assert.That(deleted, Is.Not.Null);
+            Assert.That(deleted.IsSuccess, Is.True);
+        }
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetById.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetById.cs
@@ -1,0 +1,60 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.Currencies;
+
+/// <summary>
+///     E2E coverage for <c>CurrencyService.GetById</c> against the live Bexio API.
+/// </summary>
+public class TestGetById : BexioE2eTestBase
+{
+    /// <summary>
+    ///     Fetches the first currency returned by <c>Get()</c> and asserts that
+    ///     <c>GetById</c> returns the same record. Using a discovered id keeps the
+    ///     test stable across tenants.
+    /// </summary>
+    [Test]
+    public async Task GetById()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Currencies.Get();
+        Assert.That(list.IsSuccess, Is.True);
+        Assert.That(list.Data, Is.Not.Null.And.Not.Empty);
+
+        var first = list.Data!.First();
+        var res = await BexioApiClient!.Currencies.GetById(first.Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+            Assert.That(res.Data!.Id, Is.EqualTo(first.Id));
+            Assert.That(res.Data!.Name, Is.EqualTo(first.Name));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetCodes.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetCodes.cs
@@ -1,0 +1,53 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.Currencies;
+
+/// <summary>
+///     E2E coverage for <c>CurrencyService.GetCodes</c> against the live Bexio API.
+/// </summary>
+public class TestGetCodes : BexioE2eTestBase
+{
+    /// <summary>
+    ///     Lists the configured ISO 4217 currency codes for the tenant. Asserts a successful
+    ///     response containing at least one code (typically <c>CHF</c>, <c>EUR</c> are present).
+    /// </summary>
+    [Test]
+    public async Task GetCodes()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var res = await BexioApiClient!.Currencies.GetCodes();
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+            Assert.That(res.Data, Is.Not.Empty);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetExchangeRates.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetExchangeRates.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.Currencies;
+
+/// <summary>
+///     E2E coverage for <c>CurrencyService.GetExchangeRates</c> against the live Bexio API.
+/// </summary>
+public class TestGetExchangeRates : BexioE2eTestBase
+{
+    /// <summary>
+    ///     Fetches the first currency returned by <c>Get()</c> and queries its configured
+    ///     exchange rates. Asserts on a successful response — the data list may be empty
+    ///     when no rates are configured for the discovered currency.
+    /// </summary>
+    [Test]
+    public async Task GetExchangeRates()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Currencies.Get();
+        Assert.That(list.IsSuccess, Is.True);
+        Assert.That(list.Data, Is.Not.Null.And.Not.Empty);
+
+        var first = list.Data!.First();
+        var res = await BexioApiClient!.Currencies.GetExchangeRates(first.Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/DeleteEntryFile.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/DeleteEntryFile.cs
@@ -1,0 +1,72 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.ManualEntries;
+
+/// <summary>
+/// Live E2E coverage for <see cref="IManualEntryService.DeleteEntryFile" />. Creates and
+/// attaches a file to a specific line, then deletes the line-to-file association.
+/// </summary>
+public class DeleteEntryFile : BexioE2eTestBase
+{
+    /// <summary>
+    /// Deletes the connection between a file and a manual entry line.
+    /// </summary>
+    [Test]
+    public async Task DeleteManualEntryFile()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var created = await BexioApiClient!.AccountingManualEntries.Create(new(
+            Type: ManualEntryType.manual_single_entry,
+            Date: DateOnly.FromDateTime(DateTime.Now),
+            ReferenceNr: "LINE-FILE-DEL",
+            Entries: new[]
+            {
+                new ManualEntryCreate(DebitAccountId: 89, CreditAccountId: 90, TaxId: 15, TaxAccountId: 90, Amount: 25m, CurrencyId: 1, Description: "Delete line file source", CurrencyFactor: 1)
+            }));
+
+        Assert.That(created.Data, Is.Not.Null);
+        var entryId = created.Data!.Entries[0].Id!.Value;
+
+        var uploaded = await BexioApiClient.AccountingManualEntries.AddAttachment(
+            created.Data.Id,
+            entryId,
+            new List<FileInfo> { new("Assets/letter.pdf") });
+
+        Assert.That(uploaded.Data, Is.Not.Null.And.Not.Empty);
+
+        var res = await BexioApiClient.AccountingManualEntries.DeleteEntryFile(
+            created.Data.Id,
+            entryId,
+            uploaded.Data![0].Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.That(res.IsSuccess, Is.True);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/DeleteFile.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/DeleteFile.cs
@@ -1,0 +1,68 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.ManualEntries;
+
+/// <summary>
+/// Live E2E coverage for <see cref="IManualEntryService.DeleteFile" />. Creates and attaches a
+/// file, then deletes the compound-entry-to-file association.
+/// </summary>
+public class DeleteFile : BexioE2eTestBase
+{
+    /// <summary>
+    /// Deletes the connection between a file and a manual compound entry.
+    /// </summary>
+    [Test]
+    public async Task DeleteManualCompoundEntryFile()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var created = await BexioApiClient!.AccountingManualEntries.Create(new(
+            Type: ManualEntryType.manual_single_entry,
+            Date: DateOnly.FromDateTime(DateTime.Now),
+            ReferenceNr: "FILE-DEL",
+            Entries: new[]
+            {
+                new ManualEntryCreate(DebitAccountId: 89, CreditAccountId: 90, TaxId: 15, TaxAccountId: 90, Amount: 24m, CurrencyId: 1, Description: "Delete file source", CurrencyFactor: 1)
+            }));
+
+        Assert.That(created.Data, Is.Not.Null);
+
+        var uploaded = await BexioApiClient.AccountingManualEntries.AddAttachment(
+            created.Data!.Id,
+            created.Data.Entries[0].Id!.Value,
+            new List<FileInfo> { new("Assets/letter.pdf") });
+
+        Assert.That(uploaded.Data, Is.Not.Null.And.Not.Empty);
+
+        var res = await BexioApiClient.AccountingManualEntries.DeleteFile(created.Data.Id, uploaded.Data![0].Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.That(res.IsSuccess, Is.True);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetEntryFileById.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetEntryFileById.cs
@@ -1,0 +1,78 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.ManualEntries;
+
+/// <summary>
+/// Live E2E coverage for <see cref="IManualEntryService.GetEntryFileById" />. Creates and
+/// attaches a file to a specific line, then fetches that file by id including base64 content.
+/// </summary>
+public class GetEntryFileById : BexioE2eTestBase
+{
+    /// <summary>
+    /// Fetches a single manual entry line file by id.
+    /// </summary>
+    [Test]
+    public async Task ShowManualEntryFile()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var created = await BexioApiClient!.AccountingManualEntries.Create(new(
+            Type: ManualEntryType.manual_single_entry,
+            Date: DateOnly.FromDateTime(DateTime.Now),
+            ReferenceNr: "LINE-FILE-SHOW",
+            Entries: new[]
+            {
+                new ManualEntryCreate(DebitAccountId: 89, CreditAccountId: 90, TaxId: 15, TaxAccountId: 90, Amount: 23m, CurrencyId: 1, Description: "Line file show source", CurrencyFactor: 1)
+            }));
+
+        Assert.That(created.Data, Is.Not.Null);
+        var entryId = created.Data!.Entries[0].Id!.Value;
+
+        var uploaded = await BexioApiClient.AccountingManualEntries.AddAttachment(
+            created.Data.Id,
+            entryId,
+            new List<FileInfo> { new("Assets/letter.pdf") });
+
+        Assert.That(uploaded.Data, Is.Not.Null.And.Not.Empty);
+
+        var res = await BexioApiClient.AccountingManualEntries.GetEntryFileById(
+            created.Data.Id,
+            entryId,
+            uploaded.Data![0].Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.Data, Is.Not.Null.And.Not.Empty);
+            Assert.That(res.Data?.MimeType, Is.EqualTo("application/pdf"));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetEntryFiles.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetEntryFiles.cs
@@ -1,0 +1,74 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.ManualEntries;
+
+/// <summary>
+/// Live E2E coverage for <see cref="IManualEntryService.GetEntryFiles" />. Creates a manual
+/// entry, attaches a file to a specific line, and lists files attached to that line.
+/// </summary>
+public class GetEntryFiles : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists files attached to a specific manual entry line.
+    /// </summary>
+    [Test]
+    public async Task ListManualEntryFiles()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var created = await BexioApiClient!.AccountingManualEntries.Create(new(
+            Type: ManualEntryType.manual_single_entry,
+            Date: DateOnly.FromDateTime(DateTime.Now),
+            ReferenceNr: "LINE-FILES",
+            Entries: new[]
+            {
+                new ManualEntryCreate(DebitAccountId: 89, CreditAccountId: 90, TaxId: 15, TaxAccountId: 90, Amount: 22m, CurrencyId: 1, Description: "Line file source", CurrencyFactor: 1)
+            }));
+
+        Assert.That(created.Data, Is.Not.Null);
+        var entryId = created.Data!.Entries[0].Id!.Value;
+
+        var uploaded = await BexioApiClient.AccountingManualEntries.AddAttachment(
+            created.Data.Id,
+            entryId,
+            new List<FileInfo> { new("Assets/letter.pdf") });
+
+        Assert.That(uploaded.IsSuccess, Is.True);
+
+        var res = await BexioApiClient.AccountingManualEntries.GetEntryFiles(created.Data.Id, entryId);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null.And.Not.Empty);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetFileById.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetFileById.cs
@@ -1,0 +1,74 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.ManualEntries;
+
+/// <summary>
+/// Live E2E coverage for <see cref="IManualEntryService.GetFileById" />. Creates and attaches a
+/// file, then fetches a single file by id including its base64-encoded content.
+/// </summary>
+public class GetFileById : BexioE2eTestBase
+{
+    /// <summary>
+    /// Fetches a single compound entry file and asserts the payload contains base64 content.
+    /// </summary>
+    [Test]
+    public async Task ShowManualCompoundEntryFile()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var created = await BexioApiClient!.AccountingManualEntries.Create(new(
+            Type: ManualEntryType.manual_single_entry,
+            Date: DateOnly.FromDateTime(DateTime.Now),
+            ReferenceNr: "FILE-SHOW",
+            Entries: new[]
+            {
+                new ManualEntryCreate(DebitAccountId: 89, CreditAccountId: 90, TaxId: 15, TaxAccountId: 90, Amount: 21m, CurrencyId: 1, Description: "Show file source", CurrencyFactor: 1)
+            }));
+
+        Assert.That(created.Data, Is.Not.Null);
+
+        var uploaded = await BexioApiClient.AccountingManualEntries.AddAttachment(
+            created.Data!.Id,
+            created.Data.Entries[0].Id!.Value,
+            new List<FileInfo> { new("Assets/letter.pdf") });
+
+        Assert.That(uploaded.Data, Is.Not.Null.And.Not.Empty);
+
+        var res = await BexioApiClient.AccountingManualEntries.GetFileById(created.Data.Id, uploaded.Data![0].Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.Data, Is.Not.Null.And.Not.Empty);
+            Assert.That(res.Data?.MimeType, Is.EqualTo("application/pdf"));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetFiles.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetFiles.cs
@@ -1,0 +1,73 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.ManualEntries;
+
+/// <summary>
+/// Live E2E coverage for <see cref="IManualEntryService.GetFiles" />. Creates a manual entry,
+/// attaches a file to one of its lines, then lists all files for the compound entry.
+/// </summary>
+public class GetFiles : BexioE2eTestBase
+{
+    /// <summary>
+    /// Creates a manual entry, uploads an attachment, and lists compound entry files.
+    /// </summary>
+    [Test]
+    public async Task ListManualCompoundEntryFiles()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var created = await BexioApiClient!.AccountingManualEntries.Create(new(
+            Type: ManualEntryType.manual_single_entry,
+            Date: DateOnly.FromDateTime(DateTime.Now),
+            ReferenceNr: "FILES-LIST",
+            Entries: new[]
+            {
+                new ManualEntryCreate(DebitAccountId: 89, CreditAccountId: 90, TaxId: 15, TaxAccountId: 90, Amount: 20m, CurrencyId: 1, Description: "List files source", CurrencyFactor: 1)
+            }));
+
+        Assert.That(created.Data, Is.Not.Null);
+
+        var uploaded = await BexioApiClient.AccountingManualEntries.AddAttachment(
+            created.Data!.Id,
+            created.Data.Entries[0].Id!.Value,
+            new List<FileInfo> { new("Assets/letter.pdf") });
+
+        Assert.That(uploaded.IsSuccess, Is.True);
+
+        var res = await BexioApiClient.AccountingManualEntries.GetFiles(created.Data.Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null.And.Not.Empty);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetNextRefNr.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/GetNextRefNr.cs
@@ -1,0 +1,52 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.ManualEntries;
+
+/// <summary>
+/// Live E2E coverage for <see cref="IManualEntryService.GetNextRefNr" />. Verifies the server
+/// returns a non-empty suggestion for the next manual entry reference number.
+/// </summary>
+public class GetNextRefNr : BexioE2eTestBase
+{
+    /// <summary>
+    /// Fetches the next suggested reference number.
+    /// </summary>
+    [Test]
+    public async Task GetNextReferenceNumber()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var res = await BexioApiClient!.AccountingManualEntries.GetNextRefNr();
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.NextRefNr, Is.Not.Null.And.Not.Empty);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/Put.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/ManualEntries/Put.cs
@@ -1,0 +1,86 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Enums;
+using BexioApiNet.Abstractions.Models.Accounting.ManualEntries.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.ManualEntries;
+
+/// <summary>
+/// Live E2E coverage for <see cref="IManualEntryService.Put" />. Creates a manual entry, then
+/// replaces it via PUT and verifies the server returns the updated payload.
+/// </summary>
+public class Put : BexioE2eTestBase
+{
+    /// <summary>
+    /// Creates a manual entry, issues a PUT with a different reference number, and asserts the
+    /// response reflects the update.
+    /// </summary>
+    [Test]
+    public async Task UpdateSingleEntry()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var created = await BexioApiClient!.AccountingManualEntries.Create(new(
+            Type: ManualEntryType.manual_single_entry,
+            Date: DateOnly.FromDateTime(DateTime.Now),
+            ReferenceNr: "PUT-SRC",
+            Entries: new[]
+            {
+                new ManualEntryCreate(DebitAccountId: 89, CreditAccountId: 90, TaxId: 15, TaxAccountId: 90, Amount: 50m, CurrencyId: 1, Description: "Source entry", CurrencyFactor: 1)
+            }));
+
+        Assert.That(created.Data, Is.Not.Null);
+
+        var updated = await BexioApiClient.AccountingManualEntries.Put(
+            created.Data!.Id,
+            new ManualEntryUpdate(
+                Type: ManualEntryType.manual_single_entry,
+                Date: DateOnly.FromDateTime(DateTime.Now),
+                ReferenceNr: "PUT-DST",
+                Entries: new[]
+                {
+                    new ManualEntryEntryUpdate(
+                        DebitAccountId: 89,
+                        CreditAccountId: 90,
+                        TaxId: 15,
+                        TaxAccountId: 90,
+                        Description: "Updated entry",
+                        Amount: 75m,
+                        CurrencyId: 1,
+                        CurrencyFactor: 1,
+                        Id: created.Data.Entries[0].Id)
+                },
+                Id: created.Data.Id));
+
+        Assert.That(updated, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(updated.IsSuccess, Is.True);
+            Assert.That(updated.Data!.ReferenceNr, Is.EqualTo("PUT-DST"));
+            Assert.That(updated.Data!.Entries[0].Amount, Is.EqualTo(75m));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Reports/ReportServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Reports/ReportServiceE2eTests.cs
@@ -1,0 +1,73 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.Reports;
+
+/// <summary>
+/// Live end-to-end test for <see cref="ReportService"/>. Skipped automatically
+/// when <c>BexioApiNet__BaseUri</c> / <c>BexioApiNet__JwtToken</c> are not set.
+///
+/// Note: <see cref="IReportService"/> is not yet exposed on <c>IBexioApiClient</c>
+/// — DI wire-up is handled by sub-issue #49. The test therefore instantiates
+/// <see cref="ReportService"/> directly using the credentials from the env vars.
+/// </summary>
+public class ReportServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Fetches the accounting journal and verifies the request succeeded
+    /// and the handler returned a non-null list of entries.
+    /// </summary>
+    [Test]
+    public async Task GetJournal_ReturnsSuccessfulApiResult()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        using var connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri!,
+                JwtToken = jwtToken!,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        var service = new ReportService(connectionHandler);
+
+        var res = await service.GetJournal();
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Taxes/Delete.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Taxes/Delete.cs
@@ -1,0 +1,55 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.Taxes;
+
+/// <summary>
+/// Live end-to-end coverage of <c>DELETE /3.0/taxes/{id}</c>. The Bexio API
+/// rejects deletion of taxes that are referenced or assigned to digit 000
+/// with a 409 Conflict — see <see href="https://docs.bexio.com/#tag/Taxes/operation/DeleteTax"/>.
+/// This stub probes the call against a clearly non-existent id so it does not
+/// destroy production data; both 404 and 409 are acceptable terminal states.
+/// </summary>
+public class TestDelete : BexioE2eTestBase
+{
+    /// <summary>
+    /// Calls <c>Delete</c> with a deliberately invalid id. Asserts the call
+    /// produced a populated <see cref="ApiResult{T}"/> — either success (if the
+    /// id by coincidence matched a deletable tax) or a non-success with a
+    /// populated <see cref="ApiError"/>.
+    /// </summary>
+    [Test]
+    public async Task DeleteNonExistentReturnsApiError()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        const int nonExistentId = int.MaxValue;
+        var res = await BexioApiClient!.Taxes.Delete(nonExistentId);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.That(res.IsSuccess, Is.False);
+        Assert.That(res.ApiError, Is.Not.Null);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Taxes/GetById.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Taxes/GetById.cs
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.Taxes;
+
+/// <summary>
+/// Live end-to-end coverage of <c>GET /3.0/taxes/{id}</c>. Lists all taxes,
+/// picks the first one and re-fetches it by id to confirm round-trip parity.
+/// </summary>
+public class TestGetById : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists taxes, picks the first id, and re-fetches that tax via
+    /// <c>GetById</c>. Asserts the response is successful and the id matches.
+    /// </summary>
+    [Test]
+    public async Task GetById()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Taxes.Get(autoPage: true);
+        Assert.That(list.IsSuccess, Is.True);
+        Assert.That(list.Data, Is.Not.Null.And.Not.Empty);
+
+        var firstId = list.Data!.First().Id;
+
+        var res = await BexioApiClient!.Taxes.GetById(firstId);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.Id, Is.EqualTo(firstId));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/VatPeriods/VatPeriodServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/VatPeriods/VatPeriodServiceE2eTests.cs
@@ -1,0 +1,133 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Interfaces.Connectors.Accounting;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.E2eTests.Tests.Accounting.VatPeriods;
+
+/// <summary>
+/// Live end-to-end tests for <see cref="VatPeriodService"/>. The service is not yet
+/// wired into <see cref="IBexioApiClient"/> — that is the responsibility of the
+/// follow-up wire-up issue — so these tests construct their own
+/// <see cref="BexioConnectionHandler"/> and <see cref="VatPeriodService"/> directly
+/// from the live credentials supplied via environment variables. The test is
+/// skipped automatically when credentials are missing.
+/// </summary>
+[TestFixture]
+public class VatPeriodServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private IVatPeriodService? _vatPeriods;
+
+    /// <summary>
+    /// Reads <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> from
+    /// environment variables and wires a standalone connection handler + service
+    /// for the duration of each test. Calls <see cref="Assert.Ignore(string)"/>
+    /// if either credential is missing.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        _vatPeriods = new VatPeriodService(_connectionHandler);
+    }
+
+    /// <summary>
+    /// Disposes the connection handler if it was created for the test.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    /// Lists all vat periods in the test tenant. Expects a successful response
+    /// with a non-null data list and a valid id on the first returned period.
+    /// </summary>
+    [Test]
+    [Category("E2E")]
+    public async Task Get_ReturnsVatPeriods()
+    {
+        Assert.That(_vatPeriods, Is.Not.Null);
+
+        var res = await _vatPeriods!.Get(autoPage: true);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches a single vat period by id using the first id returned from the
+    /// list endpoint. Expects a successful response and a matching id in the
+    /// payload.
+    /// </summary>
+    [Test]
+    [Category("E2E")]
+    public async Task GetById_ReturnsVatPeriod()
+    {
+        Assert.That(_vatPeriods, Is.Not.Null);
+
+        var list = await _vatPeriods!.Get();
+        Assert.That(list.IsSuccess, Is.True);
+        Assert.That(list.Data, Is.Not.Null.And.Not.Empty);
+
+        var firstId = list.Data!.First().Id;
+
+        var res = await _vatPeriods.GetById(firstId);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+            Assert.That(res.Data!.Id, Is.EqualTo(firstId));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/BankAccount/GetById.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/BankAccount/GetById.cs
@@ -1,0 +1,65 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Banking.BankAccount;
+
+/// <summary>
+/// Live E2E coverage for <c>GET /3.0/banking/accounts/{id}</c>. The test fetches
+/// the first bank account via the list endpoint and then re-fetches it by id,
+/// asserting the round-trip returns the same identifier.
+/// </summary>
+public class TestGetById : BexioE2eTestBase
+{
+    /// <summary>
+    /// Retrieves the first bank account from the list endpoint, then verifies
+    /// that <c>GetById</c> returns the same record against the live API.
+    /// </summary>
+    [Test]
+    public async Task GetById()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.BankingBankAccounts.Get();
+        Assert.Multiple(() =>
+        {
+            Assert.That(list, Is.Not.Null);
+            Assert.That(list.IsSuccess, Is.True);
+            Assert.That(list.Data, Is.Not.Null.And.Not.Empty);
+        });
+
+        var firstId = list.Data!.First().Id;
+        Assert.That(firstId, Is.Not.Null);
+
+        var res = await BexioApiClient!.BankingBankAccounts.GetById(firstId!.Value);
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+            Assert.That(res.Data!.Id, Is.EqualTo(firstId));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/OutgoingPayments/CreateUpdateDelete.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/OutgoingPayments/CreateUpdateDelete.cs
@@ -1,0 +1,104 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Views;
+
+namespace BexioApiNet.E2eTests.Tests.Banking.OutgoingPayments;
+
+/// <summary>
+/// Live exercises POST, PUT, and DELETE on <c>/4.0/purchase/outgoing-payments</c>.
+/// <para>
+/// The test is intentionally left as a stub: the Bexio API enforces many preconditions
+/// (existing non-draft bill, sender bank account, business-year window, valid IBAN, etc.)
+/// that cannot be asserted in isolation without a fully-seeded test tenant. Setting the
+/// env var <c>BexioApiNet__OutgoingPaymentRunMutating</c> to <c>true</c> opts a
+/// properly-configured environment into the full create/update/delete cycle.
+/// </para>
+/// </summary>
+public class TestCreateUpdateDelete : OutgoingPaymentE2eTestBase
+{
+    /// <summary>
+    /// End-to-end create → update → delete flow. Skipped by default. Enable by setting
+    /// the env vars <c>BexioApiNet__OutgoingPaymentRunMutating=true</c>,
+    /// <c>BexioApiNet__OutgoingPaymentBillId</c>, and
+    /// <c>BexioApiNet__OutgoingPaymentSenderBankAccountId</c> on a seeded tenant.
+    /// </summary>
+    [Test]
+    public async Task CreateUpdateDelete()
+    {
+        if (Environment.GetEnvironmentVariable("BexioApiNet__OutgoingPaymentRunMutating") is not { } mutating
+            || !bool.TryParse(mutating, out var runMutating)
+            || !runMutating)
+        {
+            Assert.Ignore("mutating E2E disabled — set BexioApiNet__OutgoingPaymentRunMutating=true to run");
+            return;
+        }
+
+        var billId = RequireBillId();
+        Assert.That(OutgoingPayments, Is.Not.Null);
+
+        if (!int.TryParse(Environment.GetEnvironmentVariable("BexioApiNet__OutgoingPaymentSenderBankAccountId"), out var senderBankAccountId))
+        {
+            Assert.Ignore("BexioApiNet__OutgoingPaymentSenderBankAccountId not configured");
+            return;
+        }
+
+        var createPayload = new OutgoingPaymentCreate(
+            BillId: billId,
+            PaymentType: OutgoingPaymentType.MANUAL,
+            ExecutionDate: DateOnly.FromDateTime(DateTime.UtcNow.Date),
+            Amount: 0.01m,
+            CurrencyCode: "CHF",
+            ExchangeRate: 1m,
+            SenderBankAccountId: senderBankAccountId,
+            IsSalaryPayment: false);
+
+        var created = await OutgoingPayments!.Create(createPayload);
+        Assert.Multiple(() =>
+        {
+            Assert.That(created.IsSuccess, Is.True, created.ApiError?.Message);
+            Assert.That(created.Data, Is.Not.Null);
+        });
+
+        var createdId = created.Data!.Id;
+
+        var updatePayload = new OutgoingPaymentUpdate(
+            PaymentId: createdId,
+            ExecutionDate: createPayload.ExecutionDate,
+            Amount: createPayload.Amount,
+            IsSalaryPayment: false);
+
+        var updated = await OutgoingPayments.Update(updatePayload);
+        Assert.Multiple(() =>
+        {
+            Assert.That(updated.IsSuccess, Is.True, updated.ApiError?.Message);
+            Assert.That(updated.Data?.Id, Is.EqualTo(createdId));
+        });
+
+        var deleted = await OutgoingPayments.Delete(createdId);
+        Assert.That(deleted.IsSuccess, Is.True, deleted.ApiError?.Message);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/OutgoingPayments/GetAll.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/OutgoingPayments/GetAll.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Banking.OutgoingPayments;
+
+/// <summary>
+/// Live GET <c>/4.0/purchase/outgoing-payments</c> — lists outgoing payments for a bill.
+/// Requires <c>BexioApiNet__OutgoingPaymentBillId</c> to be configured.
+/// </summary>
+public class TestGetAll : OutgoingPaymentE2eTestBase
+{
+    /// <summary>
+    /// Lists outgoing payments filtered by <c>bill_id</c> and asserts the response envelope
+    /// deserialises correctly (data list present, paging metadata populated).
+    /// </summary>
+    [Test]
+    public async Task GetAll()
+    {
+        var billId = RequireBillId();
+        Assert.That(OutgoingPayments, Is.Not.Null);
+
+        var res = await OutgoingPayments!.Get(new QueryParameterOutgoingPayment(billId));
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+            Assert.That(res.Data!.Data, Is.Not.Null);
+            Assert.That(res.Data.Paging, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/OutgoingPayments/GetById.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/OutgoingPayments/GetById.cs
@@ -1,0 +1,69 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Banking.OutgoingPayments;
+
+/// <summary>
+/// Live GET <c>/4.0/purchase/outgoing-payments/{id}</c> — fetches a single outgoing payment
+/// by id. The test first lists payments for the configured bill to discover a valid id; if
+/// the list is empty the test is skipped.
+/// </summary>
+public class TestGetById : OutgoingPaymentE2eTestBase
+{
+    /// <summary>
+    /// Lists existing payments to discover an id, then fetches that payment by id and asserts
+    /// the full model deserialises with a matching <c>Id</c>.
+    /// </summary>
+    [Test]
+    public async Task GetById()
+    {
+        var billId = RequireBillId();
+        Assert.That(OutgoingPayments, Is.Not.Null);
+
+        var list = await OutgoingPayments!.Get(new QueryParameterOutgoingPayment(billId));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is null || list.Data.Data.Count == 0)
+        {
+            Assert.Ignore("no existing outgoing payments available for bill");
+            return;
+        }
+
+        var firstId = list.Data.Data[0].Id;
+
+        var res = await OutgoingPayments.GetById(firstId);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+            Assert.That(res.Data!.Id, Is.EqualTo(firstId));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/OutgoingPayments/OutgoingPaymentE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/OutgoingPayments/OutgoingPaymentE2eTestBase.cs
@@ -1,0 +1,115 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.E2eTests.Tests.Banking.OutgoingPayments;
+
+/// <summary>
+/// Dedicated live E2E base for the <see cref="OutgoingPaymentService"/>. Builds the
+/// service against a real <see cref="BexioConnectionHandler"/> so the tests don't
+/// depend on <c>IBexioApiClient.BankingOutgoingPayments</c> being wired up (that
+/// aggregate wiring is tracked in sub-issue #49).
+/// <para>
+/// Tests are skipped when <c>BexioApiNet__BaseUri</c> or <c>BexioApiNet__JwtToken</c>
+/// env vars are missing. A <c>BexioApiNet__OutgoingPaymentBillId</c> env var may be
+/// supplied for tests that need a real bill id; otherwise dependent tests are skipped.
+/// </para>
+/// </summary>
+[Category("E2E")]
+public abstract class OutgoingPaymentE2eTestBase
+{
+    /// <summary>
+    /// Live outgoing-payment service for each test, or <see langword="null"/> when the
+    /// test was skipped because credentials are missing.
+    /// </summary>
+    protected IOutgoingPaymentService? OutgoingPayments;
+
+    private BexioConnectionHandler? _connectionHandler;
+
+    /// <summary>
+    /// Optional bill id populated from <c>BexioApiNet__OutgoingPaymentBillId</c>. Tests
+    /// that require a specific bill should call <see cref="RequireBillId"/> to auto-skip
+    /// when this is not provided.
+    /// </summary>
+    protected Guid? BillId;
+
+    /// <summary>
+    /// Reads credentials from environment variables, builds a dedicated connection
+    /// handler and <see cref="OutgoingPaymentService"/>, and parses the optional bill
+    /// id. Calls <see cref="Assert.Ignore(string)"/> when credentials are missing.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        OutgoingPayments = new OutgoingPaymentService(_connectionHandler);
+
+        if (Guid.TryParse(Environment.GetEnvironmentVariable("BexioApiNet__OutgoingPaymentBillId"), out var billId))
+            BillId = billId;
+    }
+
+    /// <summary>
+    /// Disposes the dedicated connection handler if it was created for this test.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    /// Helper for tests that need a bill id — skips the test with
+    /// <see cref="Assert.Ignore(string)"/> when <c>BexioApiNet__OutgoingPaymentBillId</c>
+    /// is not configured.
+    /// </summary>
+    /// <returns>The configured bill id.</returns>
+    protected Guid RequireBillId()
+    {
+        if (BillId is { } id)
+            return id;
+
+        Assert.Ignore("BexioApiNet__OutgoingPaymentBillId not configured");
+        return default;
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/PaymentType/PaymentTypeServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/PaymentType/PaymentTypeServiceE2eTests.cs
@@ -1,0 +1,130 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.E2eTests.Tests.Banking.PaymentType;
+
+/// <summary>
+///     Live end-to-end tests for <see cref="PaymentTypeService" />. Skipped
+///     automatically when <c>BexioApiNet__BaseUri</c> / <c>BexioApiNet__JwtToken</c>
+///     are missing. The service is instantiated directly here because wiring the
+///     connector into <see cref="IBexioApiClient" /> is deferred to the Wave 1
+///     aggregation issue (#49).
+/// </summary>
+[Category("E2E")]
+public sealed class PaymentTypeServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private IPaymentTypeService? _paymentTypeService;
+
+    /// <summary>
+    ///     Builds a dedicated <see cref="BexioConnectionHandler" /> and
+    ///     <see cref="PaymentTypeService" /> per test. Calls <see cref="Assert.Ignore(string)" />
+    ///     when credentials are not provided via environment variables so CI and
+    ///     agent runs without a Bexio tenant do not surface false failures.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+        _paymentTypeService = new PaymentTypeService(_connectionHandler);
+    }
+
+    /// <summary>
+    ///     Disposes the connection handler if one was created for the test.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    ///     <c>GET /2.0/payment_type</c> must return a non-null, non-empty list of
+    ///     payment types for a provisioned Bexio tenant. Bexio ships default entries
+    ///     (e.g., <c>Cash</c>, <c>Bank</c>) so the list is expected to be populated.
+    /// </summary>
+    [Test]
+    public async Task GetAll_ReturnsPaymentTypes()
+    {
+        Assert.That(_paymentTypeService, Is.Not.Null);
+
+        var result = await _paymentTypeService!.Get();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.First().Name, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    ///     <c>POST /2.0/payment_type/search</c> with an <c>is_null=false</c>
+    ///     <c>name</c> criterion must return a non-null list of payment types
+    ///     matching the search filter.
+    /// </summary>
+    [Test]
+    public async Task Search_WithNameCriteria_ReturnsPaymentTypes()
+    {
+        Assert.That(_paymentTypeService, Is.Not.Null);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = string.Empty, Criteria = "not_null" }
+        };
+
+        var result = await _paymentTypeService!.Search(criteria);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/PaymentTypes/PaymentTypeServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/PaymentTypes/PaymentTypeServiceE2eTests.cs
@@ -28,7 +28,7 @@ using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Services.Connectors.Banking;
 
-namespace BexioApiNet.E2eTests.Tests.Banking.PaymentType;
+namespace BexioApiNet.E2eTests.Tests.Banking.PaymentTypes;
 
 /// <summary>
 ///     Live end-to-end tests for <see cref="PaymentTypeService" />. Skipped

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/Payments/PaymentServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/Payments/PaymentServiceE2eTests.cs
@@ -1,0 +1,298 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Banking.Payments;
+using BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+using BexioApiNet.Abstractions.Models.Banking.Payments.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.E2eTests.Tests.Banking.Payments;
+
+/// <summary>
+/// Live end-to-end smoke tests for <see cref="PaymentService"/>. These tests construct
+/// the service directly from a <see cref="BexioConnectionHandler"/> because the
+/// aggregate <see cref="IBexioApiClient"/> wire-up lives in a separate issue (#49).
+/// All tests skip automatically when <c>BexioApiNet__BaseUri</c> or
+/// <c>BexioApiNet__JwtToken</c> is missing.
+/// </summary>
+[Category("E2E")]
+public sealed class PaymentServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private PaymentService? _sut;
+
+    /// <summary>
+    /// Reads credentials from environment variables and prepares a
+    /// <see cref="PaymentService"/> bound to a live <see cref="BexioConnectionHandler"/>.
+    /// Calls <see cref="Assert.Ignore(string)"/> when credentials are absent.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        _sut = new PaymentService(_connectionHandler);
+    }
+
+    /// <summary>
+    /// Releases the connection handler created for the test.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    /// GET <c>4.0/banking/payments</c> returns a successful <see cref="ApiResult{T}"/> and
+    /// a (possibly empty) list of payments.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsPayments()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        var result = await _sut!.Get();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// GET <c>4.0/banking/payments</c> honours pagination parameters (<c>page</c>, <c>per-page</c>).
+    /// </summary>
+    [Test]
+    public async Task Get_WithPagination_ReturnsPayments()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        var result = await _sut!.Get(new QueryParameterPayment(Page: 1, PerPage: 10));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+        });
+    }
+
+    /// <summary>
+    /// GET <c>4.0/banking/payments/{id}</c> resolves to a payment when the first listed
+    /// payment is requested by UUID. Test is skipped when the account has no payments.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsPayment()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        var list = await _sut!.Get(new QueryParameterPayment(Page: 1, PerPage: 1));
+        if (list.Data is null || list.Data.Count is 0 || list.Data[0].Uuid is null)
+        {
+            Assert.Ignore("no existing payments to read by id");
+            return;
+        }
+
+        var result = await _sut.GetById(Guid.Parse(list.Data[0].Uuid!));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data?.Uuid, Is.EqualTo(list.Data[0].Uuid));
+        });
+    }
+
+    /// <summary>
+    /// POST <c>4.0/banking/payments</c> creates a payment. Mutating test — only runs when
+    /// <c>BexioApiNet__AllowMutatingE2E</c> is set to prevent accidental writes in CI.
+    /// </summary>
+    [Test]
+    public async Task Create_CreatesPayment()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("BexioApiNet__AllowMutatingE2E"),
+                "true",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Ignore("set BexioApiNet__AllowMutatingE2E=true to run mutating payment tests");
+            return;
+        }
+
+        var accountIdValue = Environment.GetEnvironmentVariable("BexioApiNet__PaymentAccountId");
+        if (!Guid.TryParse(accountIdValue, out var accountId))
+        {
+            Assert.Ignore("set BexioApiNet__PaymentAccountId to a valid bank account UUID");
+            return;
+        }
+
+        var payload = new PaymentCreate(
+            Type: PaymentType.iban,
+            AccountId: accountId,
+            Recipient: new PaymentRecipient(
+                Name: "E2E Test Recipient",
+                Iban: "CH9300762011623852957",
+                Address: new PaymentAddress(
+                    StreetName: "Bahnhofstrasse",
+                    HouseNumber: "1",
+                    Zip: "8001",
+                    City: "Zurich",
+                    CountryCode: "CH")),
+            Amount: 1m,
+            Currency: "CHF",
+            ExecutionDate: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)),
+            IsSalary: false);
+
+        var result = await _sut!.Create(payload);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data?.Uuid, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// POST <c>4.0/banking/payments/{id}/cancel</c> cancels an existing payment.
+    /// Mutating test — gated by <c>BexioApiNet__AllowMutatingE2E</c> and a caller-supplied
+    /// payment UUID via <c>BexioApiNet__CancelPaymentId</c>.
+    /// </summary>
+    [Test]
+    public async Task Cancel_CancelsPayment()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("BexioApiNet__AllowMutatingE2E"),
+                "true",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Ignore("set BexioApiNet__AllowMutatingE2E=true to run mutating payment tests");
+            return;
+        }
+
+        var paymentIdValue = Environment.GetEnvironmentVariable("BexioApiNet__CancelPaymentId");
+        if (!Guid.TryParse(paymentIdValue, out var paymentId))
+        {
+            Assert.Ignore("set BexioApiNet__CancelPaymentId to a cancellable payment UUID");
+            return;
+        }
+
+        var result = await _sut!.Cancel(paymentId);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.IsSuccess, Is.True);
+    }
+
+    /// <summary>
+    /// PUT <c>4.0/banking/payments/{id}</c> updates a payment. Mutating test — gated by
+    /// <c>BexioApiNet__AllowMutatingE2E</c> and <c>BexioApiNet__UpdatePaymentId</c>.
+    /// </summary>
+    [Test]
+    public async Task Update_UpdatesPayment()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("BexioApiNet__AllowMutatingE2E"),
+                "true",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Ignore("set BexioApiNet__AllowMutatingE2E=true to run mutating payment tests");
+            return;
+        }
+
+        var paymentIdValue = Environment.GetEnvironmentVariable("BexioApiNet__UpdatePaymentId");
+        if (!Guid.TryParse(paymentIdValue, out var paymentId))
+        {
+            Assert.Ignore("set BexioApiNet__UpdatePaymentId to an editable payment UUID");
+            return;
+        }
+
+        var payload = new PaymentUpdate(AdditionalInformation: "Updated by BexioApiNet E2E test");
+
+        var result = await _sut!.Update(paymentId, payload);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.IsSuccess, Is.True);
+    }
+
+    /// <summary>
+    /// DELETE <c>4.0/banking/payments/{id}</c> removes a payment. Mutating test — gated by
+    /// <c>BexioApiNet__AllowMutatingE2E</c> and <c>BexioApiNet__DeletePaymentId</c>.
+    /// </summary>
+    [Test]
+    public async Task Delete_DeletesPayment()
+    {
+        Assert.That(_sut, Is.Not.Null);
+
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("BexioApiNet__AllowMutatingE2E"),
+                "true",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.Ignore("set BexioApiNet__AllowMutatingE2E=true to run mutating payment tests");
+            return;
+        }
+
+        var paymentIdValue = Environment.GetEnvironmentVariable("BexioApiNet__DeletePaymentId");
+        if (!Guid.TryParse(paymentIdValue, out var paymentId))
+        {
+            Assert.Ignore("set BexioApiNet__DeletePaymentId to a deletable payment UUID");
+            return;
+        }
+
+        var result = await _sut!.Delete(paymentId);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.IsSuccess, Is.True);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Contacts/AdditionalAddresses/AdditionalAddressServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Contacts/AdditionalAddresses/AdditionalAddressServiceE2eTests.cs
@@ -1,0 +1,205 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.E2eTests.Tests.Contacts.AdditionalAddresses;
+
+/// <summary>
+/// Live end-to-end tests for <see cref="AdditionalAddressService"/>. Because the
+/// <c>BexioApiClient</c> aggregator does not yet expose the additional-address
+/// service (wired in a follow-up issue), these tests build the service directly
+/// from a <see cref="BexioConnectionHandler"/>. Tests are skipped automatically
+/// when the required environment variables (<c>BexioApiNet__BaseUri</c>,
+/// <c>BexioApiNet__JwtToken</c>, <c>BexioApiNet__ContactId</c>) are not configured.
+/// </summary>
+[Category("E2E")]
+public sealed class AdditionalAddressServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private AdditionalAddressService? _service;
+    private int _contactId;
+
+    /// <summary>
+    /// Reads credentials and a parent contact identifier from environment variables
+    /// and constructs the service under test. Calls <see cref="Assert.Ignore(string)"/>
+    /// when any value is missing so the suite stays green in environments without live
+    /// credentials.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+        var contactIdRaw = Environment.GetEnvironmentVariable("BexioApiNet__ContactId");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken) || !int.TryParse(contactIdRaw, out _contactId))
+        {
+            Assert.Ignore("credentials or parent contact id not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        _service = new AdditionalAddressService(_connectionHandler);
+    }
+
+    /// <summary>
+    /// Disposes the connection handler owned by the test when present.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    /// Lists additional addresses attached to the configured parent contact.
+    /// </summary>
+    [Test]
+    public async Task Get_ListsAdditionalAddresses()
+    {
+        var res = await _service!.Get(_contactId, new QueryParameterAdditionalAddress(Limit: 5, Offset: 0));
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches the first listed additional address by identifier.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsAdditionalAddress()
+    {
+        var list = await _service!.Get(_contactId, new QueryParameterAdditionalAddress(Limit: 1, Offset: 0));
+        Assert.That(list.IsSuccess, Is.True);
+        Assert.That(list.Data, Is.Not.Null.And.Not.Empty);
+
+        var id = list.Data![0].Id;
+
+        var res = await _service!.GetById(_contactId, id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.Id, Is.EqualTo(id));
+        });
+    }
+
+    /// <summary>
+    /// Creates, updates, and deletes an additional address to exercise the full
+    /// write path in a single end-to-end scenario.
+    /// </summary>
+    [Test]
+    public async Task CreateUpdateDelete_RoundTripsAdditionalAddress()
+    {
+        var create = await _service!.Create(_contactId, new AdditionalAddressCreate(
+            Name: "E2E Additional Address",
+            NameAddition: null,
+            StreetName: "Test Street",
+            HouseNumber: "1",
+            AddressAddition: null,
+            Postcode: "8000",
+            City: "Zurich",
+            CountryId: 1,
+            Subject: "E2E",
+            Description: "Created by AdditionalAddressServiceE2eTests"));
+
+        Assert.That(create, Is.Not.Null);
+        Assert.That(create.IsSuccess, Is.True);
+        Assert.That(create.Data, Is.Not.Null);
+
+        var createdId = create.Data!.Id;
+
+        try
+        {
+            var update = await _service!.Update(_contactId, createdId, new AdditionalAddressUpdate(
+                Name: "E2E Additional Address (updated)",
+                NameAddition: null,
+                StreetName: "Test Street",
+                HouseNumber: "2",
+                AddressAddition: null,
+                Postcode: "8000",
+                City: "Zurich",
+                CountryId: 1,
+                Subject: "E2E",
+                Description: "Updated by AdditionalAddressServiceE2eTests"));
+
+            Assert.That(update, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(update.IsSuccess, Is.True);
+                Assert.That(update.Data?.Id, Is.EqualTo(createdId));
+                Assert.That(update.Data?.Name, Does.Contain("updated"));
+            });
+        }
+        finally
+        {
+            var delete = await _service!.Delete(_contactId, createdId);
+            Assert.That(delete.IsSuccess, Is.True);
+        }
+    }
+
+    /// <summary>
+    /// Searches additional addresses with a single criterion to confirm wire
+    /// compatibility with Bexio's search endpoint.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsMatchingAdditionalAddresses()
+    {
+        var res = await _service!.Search(
+            _contactId,
+            new List<SearchCriteria>
+            {
+                new() { Field = "city", Value = "Zurich", Criteria = "=" }
+            },
+            new QueryParameterAdditionalAddress(Limit: 5, Offset: 0));
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Contacts/ContactGroups/ContactGroupServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Contacts/ContactGroups/ContactGroupServiceE2eTests.cs
@@ -1,0 +1,224 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups.Views;
+using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.E2eTests.Tests.Contacts.ContactGroups;
+
+/// <summary>
+/// Live end-to-end tests for <see cref="ContactGroupService"/>. Tests are skipped when
+/// the required environment variables (<c>BexioApiNet__BaseUri</c>, <c>BexioApiNet__JwtToken</c>)
+/// are not present. The service is constructed directly because it is not yet wired into
+/// <c>IBexioApiClient</c> (tracked separately in issue #49).
+/// </summary>
+[Category("E2E")]
+public class ContactGroupServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private IContactGroupService _sut = null!;
+
+    /// <summary>
+    /// Reads the required credentials from environment variables. Calls
+    /// <see cref="Assert.Ignore(string)"/> when either is missing so the suite does not
+    /// fail CI or AI agent runs that lack live credentials.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        _sut = new ContactGroupService(_connectionHandler);
+    }
+
+    /// <summary>
+    /// Disposes the connection handler if it was created for the test.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+        _connectionHandler = null;
+    }
+
+    /// <summary>
+    /// Verifies that listing contact groups returns a successful response.
+    /// </summary>
+    [Test]
+    public async Task Get()
+    {
+        var res = await _sut.Get(autoPage: true);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that fetching a single contact group by id succeeds when at least one group exists.
+    /// </summary>
+    [Test]
+    public async Task GetById()
+    {
+        var list = await _sut.Get();
+        Assert.That(list, Is.Not.Null);
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existing)
+        {
+            Assert.Ignore("no contact groups available on this tenant");
+            return;
+        }
+
+        var res = await _sut.GetById(existing[0].Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data?.Id, Is.EqualTo(existing[0].Id));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that creating a contact group succeeds and returns the persisted record.
+    /// Cleans up the created group as part of the test.
+    /// </summary>
+    [Test]
+    public async Task Create()
+    {
+        var name = $"Test group {Guid.NewGuid():N}";
+        var res = await _sut.Create(new ContactGroupCreate(name));
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+            Assert.That(res.Data?.Name, Is.EqualTo(name));
+        });
+
+        if (res.Data is { } created)
+            await _sut.Delete(created.Id);
+    }
+
+    /// <summary>
+    /// Verifies that searching contact groups by name returns a successful response.
+    /// </summary>
+    [Test]
+    public async Task Search()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Test", Criteria = "like" }
+        };
+
+        var res = await _sut.Search(criteria);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that updating a contact group changes the name and returns the updated record.
+    /// Creates and deletes a temporary group as part of the test.
+    /// </summary>
+    [Test]
+    public async Task Update()
+    {
+        var created = await _sut.Create(new ContactGroupCreate($"Test group {Guid.NewGuid():N}"));
+        Assert.That(created.IsSuccess, Is.True);
+        Assert.That(created.Data, Is.Not.Null);
+
+        try
+        {
+            var newName = $"Updated group {Guid.NewGuid():N}";
+            var res = await _sut.Update(created.Data!.Id, new ContactGroupUpdate(newName));
+
+            Assert.That(res, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(res.IsSuccess, Is.True);
+                Assert.That(res.ApiError, Is.Null);
+                Assert.That(res.Data?.Name, Is.EqualTo(newName));
+            });
+        }
+        finally
+        {
+            await _sut.Delete(created.Data!.Id);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that deleting a contact group succeeds.
+    /// </summary>
+    [Test]
+    public async Task Delete()
+    {
+        var created = await _sut.Create(new ContactGroupCreate($"Test group {Guid.NewGuid():N}"));
+        Assert.That(created.IsSuccess, Is.True);
+        Assert.That(created.Data, Is.Not.Null);
+
+        var res = await _sut.Delete(created.Data!.Id);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Contacts/ContactRelations/ContactRelationServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Contacts/ContactRelations/ContactRelationServiceE2eTests.cs
@@ -1,0 +1,240 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactRelations.Views;
+using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.E2eTests.Tests.Contacts.ContactRelations;
+
+/// <summary>
+/// Live E2E test stubs for <see cref="ContactRelationService"/>. Stand-alone class (does not
+/// inherit <see cref="BexioE2eTestBase"/>) so that this sub-issue does not modify the shared
+/// test base — DI wire-up is handled by a separate sub-issue (#49). Credentials are read from
+/// the same environment variables; tests are skipped via <see cref="Assert.Ignore(string)"/>
+/// when they are missing.
+/// </summary>
+[Category("E2E")]
+public class ContactRelationServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private IContactRelationService? _service;
+
+    /// <summary>
+    /// Reads <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> from the environment.
+    /// When either is missing the test is skipped so CI and agent runs without live credentials
+    /// do not fail.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+
+        _service = new ContactRelationService(_connectionHandler);
+    }
+
+    /// <summary>
+    /// Disposes the locally owned connection handler.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    /// Stub — live test for <c>GET /2.0/contact_relation</c>. Requires a tenant with at least
+    /// one contact relation.
+    /// </summary>
+    [Test]
+    public async Task GetList_ReturnsContactRelations()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        var result = await _service!.Get(new QueryParameterContactRelation(5, 0));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.IsSuccess, Is.True);
+    }
+
+    /// <summary>
+    /// Stub — live test for <c>GET /2.0/contact_relation/{id}</c>. Fetches the first
+    /// contact relation from the list and looks it up by id.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsContactRelation()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        var list = await _service!.Get(new QueryParameterContactRelation(1, 0));
+        Assert.That(list.IsSuccess, Is.True);
+        if (list.Data is null || list.Data.Count is 0)
+            Assert.Ignore("no contact relation available to query by id");
+
+        var id = list.Data![0].Id;
+
+        var result = await _service.GetById(id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data?.Id, Is.EqualTo(id));
+        });
+    }
+
+    /// <summary>
+    /// Stub — live test for <c>POST /2.0/contact_relation</c>. The create/delete cycle requires
+    /// two valid contact ids in the target tenant; skip rather than fail if none are available.
+    /// </summary>
+    [Test]
+    public async Task Create_CreatesAndDeletesContactRelation()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        const int contactId = 1;
+        const int contactSubId = 2;
+
+        var created = await _service!.Create(new ContactRelationCreate(
+            ContactId: contactId,
+            ContactSubId: contactSubId,
+            Description: "E2E-ContactRelation"));
+
+        if (!created.IsSuccess)
+            Assert.Ignore($"create failed ({created.StatusCode}) — check that contact ids {contactId} and {contactSubId} exist in the tenant");
+
+        Assert.That(created.Data, Is.Not.Null);
+
+        var cleanup = await _service.Delete(created.Data!.Id);
+        Assert.That(cleanup.IsSuccess, Is.True);
+    }
+
+    /// <summary>
+    /// Stub — live test for <c>POST /2.0/contact_relation/search</c>.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsContactRelations()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "contact_id", Value = "1", Criteria = "=" }
+        };
+
+        var result = await _service!.Search(criteria);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.IsSuccess, Is.True);
+    }
+
+    /// <summary>
+    /// Stub — live test for <c>POST /2.0/contact_relation/{id}</c> (Bexio v2.0 edit semantics).
+    /// Creates a contact relation, updates its description, then cleans up.
+    /// </summary>
+    [Test]
+    public async Task Update_EditsContactRelation()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        const int contactId = 1;
+        const int contactSubId = 2;
+
+        var created = await _service!.Create(new ContactRelationCreate(
+            ContactId: contactId,
+            ContactSubId: contactSubId,
+            Description: "E2E-ContactRelation-Update"));
+
+        if (!created.IsSuccess)
+            Assert.Ignore($"create failed ({created.StatusCode}) — check that contact ids {contactId} and {contactSubId} exist in the tenant");
+
+        Assert.That(created.Data, Is.Not.Null);
+
+        try
+        {
+            var updated = await _service.Update(created.Data!.Id, new ContactRelationUpdate(
+                ContactId: contactId,
+                ContactSubId: contactSubId,
+                Description: "E2E-ContactRelation-Updated"));
+
+            Assert.That(updated, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(updated.IsSuccess, Is.True);
+                Assert.That(updated.Data?.Description, Is.EqualTo("E2E-ContactRelation-Updated"));
+            });
+        }
+        finally
+        {
+            await _service.Delete(created.Data!.Id);
+        }
+    }
+
+    /// <summary>
+    /// Stub — live test for <c>DELETE /2.0/contact_relation/{id}</c>. Creates a contact relation,
+    /// deletes it, and verifies the API reports success.
+    /// </summary>
+    [Test]
+    public async Task Delete_RemovesContactRelation()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        const int contactId = 1;
+        const int contactSubId = 2;
+
+        var created = await _service!.Create(new ContactRelationCreate(
+            ContactId: contactId,
+            ContactSubId: contactSubId,
+            Description: "E2E-ContactRelation-Delete"));
+
+        if (!created.IsSuccess)
+            Assert.Ignore($"create failed ({created.StatusCode}) — check that contact ids {contactId} and {contactSubId} exist in the tenant");
+
+        Assert.That(created.Data, Is.Not.Null);
+
+        var result = await _service.Delete(created.Data!.Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.IsSuccess, Is.True);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Contacts/ContactSectors/ContactSectorServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Contacts/ContactSectors/ContactSectorServiceE2eTests.cs
@@ -1,0 +1,121 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.E2eTests.Tests.Contacts.ContactSectors;
+
+/// <summary>
+/// Live end-to-end smoke tests for <see cref="ContactSectorService"/>. Instantiates the
+/// service directly against a fresh <see cref="BexioConnectionHandler"/> so the tests do
+/// not depend on the aggregate <c>IBexioApiClient</c> being wired up (that wire-up lands
+/// in a follow-up issue). Skipped automatically when <c>BexioApiNet__BaseUri</c> or
+/// <c>BexioApiNet__JwtToken</c> are missing from the environment.
+/// </summary>
+[Category("E2E")]
+[TestFixture]
+public sealed class ContactSectorServiceE2eTests
+{
+    private BexioConnectionHandler? _connectionHandler;
+    private ContactSectorService? _service;
+
+    /// <summary>
+    /// Reads credentials from the environment and constructs the service under test.
+    /// Skips the test via <see cref="Assert.Ignore(string)"/> when credentials are absent
+    /// so CI runs without secrets still pass.
+    /// </summary>
+    [SetUp]
+    public void Setup()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri");
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken");
+
+        if (string.IsNullOrWhiteSpace(baseUri) || string.IsNullOrWhiteSpace(jwtToken))
+        {
+            Assert.Ignore("credentials not configured");
+            return;
+        }
+
+        _connectionHandler = new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+        _service = new ContactSectorService(_connectionHandler);
+    }
+
+    /// <summary>
+    /// Disposes the handler if the test was not skipped.
+    /// </summary>
+    [TearDown]
+    public void Teardown()
+    {
+        _connectionHandler?.Dispose();
+    }
+
+    /// <summary>
+    /// Lists all contact sectors with auto-paging enabled. Contact sectors are a
+    /// system-seeded lookup list, so every tenant should return at least one entry.
+    /// </summary>
+    [Test]
+    public async Task GetAll_ReturnsContactSectors()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        var res = await _service!.Get(autoPage: true);
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Posts an empty search body — Bexio treats this as "match everything" and returns
+    /// the full list of sectors the caller is allowed to see.
+    /// </summary>
+    [Test]
+    public async Task Search_WithEmptyCriteria_ReturnsAllSectors()
+    {
+        Assert.That(_service, Is.Not.Null);
+
+        var res = await _service!.Search(new List<SearchCriteria>());
+
+        Assert.That(res, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.IsSuccess, Is.True);
+            Assert.That(res.ApiError, Is.Null);
+            Assert.That(res.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Contacts/Contacts/TestList.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Contacts/Contacts/TestList.cs
@@ -1,0 +1,74 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.E2eTests.Tests.Contacts.Contacts;
+
+/// <summary>
+/// Live E2E tests for <see cref="ContactService.Get"/>. The DI wire-up that exposes
+/// <c>Contacts</c> on <see cref="IBexioApiClient"/> is delivered in issue #49; until
+/// then the service is constructed directly from the same environment credentials
+/// that drive <see cref="BexioE2eTestBase"/>.
+/// </summary>
+public class TestList : BexioE2eTestBase
+{
+    /// <summary>
+    /// List the first page of contacts and confirm the request round-trips successfully.
+    /// </summary>
+    [Test]
+    public async Task List_ReturnsContacts()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        using var connectionHandler = CreateConnectionHandler();
+        var service = new ContactService(connectionHandler);
+
+        var result = await service.Get(new QueryParameterContact(Limit: 5));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    private static BexioConnectionHandler CreateConnectionHandler()
+    {
+        var baseUri = Environment.GetEnvironmentVariable("BexioApiNet__BaseUri")!;
+        var jwtToken = Environment.GetEnvironmentVariable("BexioApiNet__JwtToken")!;
+        return new BexioConnectionHandler(
+            new BexioConfiguration
+            {
+                BaseUri = baseUri,
+                JwtToken = jwtToken,
+                AcceptHeaderFormat = ApiAcceptHeaders.JsonFormatted
+            });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/AccountGroupSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/AccountGroupSmokeTests.cs
@@ -1,0 +1,65 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Accounting;
+
+/// <summary>
+///     Smoke tests covering the <see cref="AccountGroupService" /> entry points against
+///     WireMock stubs. Verifies the path composed from <see cref="AccountGroupConfiguration" />
+///     (<c>2.0/account_groups</c>) reaches the handler correctly and that the expected HTTP
+///     verb is used.
+/// </summary>
+public sealed class AccountGroupSmokeTests : IntegrationTestBase
+{
+    private const string AccountGroupsPath = "/2.0/account_groups";
+
+    /// <summary>
+    ///     <c>AccountGroupService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/2.0/account_groups</c> and return a successful <c>ApiResult</c> when the server
+    ///     returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task AccountGroupService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(AccountGroupsPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new AccountGroupService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(AccountGroupsPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/BusinessYearSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/BusinessYearSmokeTests.cs
@@ -1,0 +1,105 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Accounting;
+
+/// <summary>
+///     Smoke tests covering the <see cref="BusinessYearService" /> entry points against
+///     WireMock stubs. Verifies the path composed from <see cref="BusinessYearConfiguration" />
+///     (<c>3.0/accounting/business_years</c>) reaches the handler correctly and that the
+///     expected HTTP verbs are used.
+/// </summary>
+public sealed class BusinessYearSmokeTests : IntegrationTestBase
+{
+    private const string BusinessYearsPath = "/3.0/accounting/business_years";
+
+    private const string BusinessYearResponse = """
+                                                {
+                                                    "id": 1,
+                                                    "start": "2024-01-01",
+                                                    "end": "2024-12-31",
+                                                    "status": "open",
+                                                    "closed_at": null
+                                                }
+                                                """;
+
+    /// <summary>
+    ///     <c>BusinessYearService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/3.0/accounting/business_years</c> and return a successful <c>ApiResult</c>
+    ///     when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task BusinessYearService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(BusinessYearsPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new BusinessYearService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(BusinessYearsPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>BusinessYearService.GetById</c> must issue a <c>GET</c> request that includes the
+    ///     target id in the URL path and surface the returned business year on success.
+    /// </summary>
+    [Test]
+    public async Task BusinessYearService_GetById_SendsGetRequestWithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{BusinessYearsPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(BusinessYearResponse));
+
+        var service = new BusinessYearService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/CalendarYearSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/CalendarYearSmokeTests.cs
@@ -1,0 +1,175 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Views;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Accounting;
+
+/// <summary>
+///     Smoke tests covering the <see cref="CalendarYearService" /> entry points against
+///     WireMock stubs. Verifies the path composed from <see cref="CalendarYearConfiguration" />
+///     (<c>3.0/accounting/calendar_years</c>) reaches the handler correctly and that the
+///     expected HTTP verbs are used.
+/// </summary>
+public sealed class CalendarYearSmokeTests : IntegrationTestBase
+{
+    private const string CalendarYearsPath = "/3.0/accounting/calendar_years";
+
+    private const string CalendarYearResponse = """
+                                                {
+                                                    "id": 1,
+                                                    "start": "2024-01-01",
+                                                    "end": "2024-12-31",
+                                                    "is_vat_subject": true,
+                                                    "is_annual_reporting": false,
+                                                    "created_at": "2024-01-01T00:00:00",
+                                                    "updated_at": "2024-01-01T00:00:00",
+                                                    "vat_accounting_method": "effective",
+                                                    "vat_accounting_type": "agreed"
+                                                }
+                                                """;
+
+    /// <summary>
+    ///     <c>CalendarYearService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/3.0/accounting/calendar_years</c> and return a successful <c>ApiResult</c>
+    ///     when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task CalendarYearService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(CalendarYearsPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new CalendarYearService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(CalendarYearsPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>CalendarYearService.GetById</c> must issue a <c>GET</c> request that includes the
+    ///     target id in the URL path and surface the returned calendar year on success.
+    /// </summary>
+    [Test]
+    public async Task CalendarYearService_GetById_SendsGetRequestWithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{CalendarYearsPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(CalendarYearResponse));
+
+        var service = new CalendarYearService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>CalendarYearService.Create</c> must issue a <c>POST</c> request whose body is the
+    ///     serialized <see cref="CalendarYearCreate" /> payload.
+    /// </summary>
+    [Test]
+    public async Task CalendarYearService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(CalendarYearsPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody($"[{CalendarYearResponse}]"));
+
+        var service = new CalendarYearService(ConnectionHandler);
+
+        var result = await service.Create(
+            new CalendarYearCreate("2024", true, false, null, null, null, null),
+            TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(CalendarYearsPath));
+            Assert.That(request.Body, Does.Contain("\"year\":\"2024\""));
+            Assert.That(request.Body, Does.Contain("\"is_vat_subject\":true"));
+        });
+    }
+
+    /// <summary>
+    ///     <c>CalendarYearService.Search</c> must issue a <c>POST</c> request against
+    ///     <c>/3.0/accounting/calendar_years/search</c> with the search criteria as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task CalendarYearService_Search_SendsPostRequestToSearchPath()
+    {
+        var expectedPath = $"{CalendarYearsPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{CalendarYearResponse}]"));
+
+        var service = new CalendarYearService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "is_vat_subject", Value = "true", Criteria = "=" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"is_vat_subject\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"=\""));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/CurrencySmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/CurrencySmokeTests.cs
@@ -1,0 +1,230 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Accounting;
+
+/// <summary>
+///     Smoke tests covering the new <see cref="CurrencyService" /> entry points against
+///     WireMock stubs. Verifies the path composed from <see cref="CurrencyConfiguration" />
+///     (<c>3.0/currencies</c>) reaches the handler correctly and that the expected HTTP
+///     verbs and query parameters are used.
+/// </summary>
+public sealed class CurrencySmokeTests : IntegrationTestBase
+{
+    private const string CurrenciesPath = "/3.0/currencies";
+
+    private const string CurrencyResponse = """
+                                            {
+                                                "id": 1,
+                                                "name": "CHF",
+                                                "round_factor": 0.05
+                                            }
+                                            """;
+
+    /// <summary>
+    ///     <c>CurrencyService.GetCodes</c> must issue a <c>GET</c> request to
+    ///     <c>/3.0/currencies/codes</c> and surface the array of currency codes.
+    /// </summary>
+    [Test]
+    public async Task CurrencyService_GetCodes_SendsGetRequestToCodesPath()
+    {
+        const string codesPath = $"{CurrenciesPath}/codes";
+        Server
+            .Given(Request.Create().WithPath(codesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[\"EUR\",\"GBP\",\"PLN\"]"));
+
+        var service = new CurrencyService(ConnectionHandler);
+
+        var result = await service.GetCodes(TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.EqualTo(new[] { "EUR", "GBP", "PLN" }));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(codesPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>CurrencyService.GetById</c> must issue a <c>GET</c> request that includes the
+    ///     currency id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task CurrencyService_GetById_SendsGetRequestWithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{CurrenciesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(CurrencyResponse));
+
+        var service = new CurrencyService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>CurrencyService.GetExchangeRates</c> must issue a <c>GET</c> request to the nested
+    ///     <c>/3.0/currencies/{id}/exchange_rates</c> path and forward an optional <c>date</c>
+    ///     query parameter when supplied.
+    /// </summary>
+    [Test]
+    public async Task CurrencyService_GetExchangeRates_WithDate_AppendsDateQuery()
+    {
+        const int id = 1;
+        var expectedPath = $"{CurrenciesPath}/{id}/exchange_rates";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new CurrencyService(ConnectionHandler);
+
+        var result = await service.GetExchangeRates(
+            id,
+            new QueryParameterExchangeRate(new DateOnly(2024, 5, 1)),
+            TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.RawQuery, Does.Contain("date=2024-05-01"));
+        });
+    }
+
+    /// <summary>
+    ///     <c>CurrencyService.Create</c> must issue a <c>POST</c> request whose body is the
+    ///     serialized <see cref="CurrencyCreate" /> payload.
+    /// </summary>
+    [Test]
+    public async Task CurrencyService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(CurrenciesPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(CurrencyResponse));
+
+        var service = new CurrencyService(ConnectionHandler);
+
+        var result = await service.Create(
+            new CurrencyCreate("CHF", 0.05),
+            TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(CurrenciesPath));
+            Assert.That(request.Body, Does.Contain("\"name\":\"CHF\""));
+            Assert.That(request.Body, Does.Contain("\"round_factor\":0.05"));
+        });
+    }
+
+    /// <summary>
+    ///     <c>CurrencyService.Patch</c> must issue a <c>PATCH</c> request that includes the id in
+    ///     the URL path and serializes the payload as the body.
+    /// </summary>
+    [Test]
+    public async Task CurrencyService_Patch_SendsPatchRequestWithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{CurrenciesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPatch())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(CurrencyResponse));
+
+        var service = new CurrencyService(ConnectionHandler);
+
+        var result = await service.Patch(
+            id,
+            new CurrencyPatch(0.10),
+            TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("PATCH"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"round_factor\":0.1"));
+        });
+    }
+
+    /// <summary>
+    ///     <c>CurrencyService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    ///     target id in the URL path and surface a successful <c>ApiResult</c>.
+    /// </summary>
+    [Test]
+    public async Task CurrencyService_Delete_SendsDeleteRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{CurrenciesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new CurrencyService(ConnectionHandler);
+
+        var result = await service.Delete(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/ReportSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/ReportSmokeTests.cs
@@ -1,0 +1,97 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Accounting;
+
+/// <summary>
+///     Smoke tests covering the <see cref="ReportService" /> entry points against WireMock
+///     stubs. Verifies the path composed from <see cref="ReportConfiguration" />
+///     (<c>3.0/accounting/journal</c>) reaches the handler correctly and that the expected
+///     HTTP verb and query parameters are used.
+/// </summary>
+public sealed class ReportSmokeTests : IntegrationTestBase
+{
+    private const string JournalPath = "/3.0/accounting/journal";
+
+    /// <summary>
+    ///     <c>ReportService.GetJournal()</c> must issue a <c>GET</c> request against
+    ///     <c>/3.0/accounting/journal</c> and return a successful <c>ApiResult</c> when the
+    ///     server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task ReportService_GetJournal_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(JournalPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new ReportService(ConnectionHandler);
+
+        var result = await service.GetJournal(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(JournalPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ReportService.GetJournal</c> with a <see cref="QueryParameterJournal" /> must
+    ///     forward the <c>from</c> and <c>to</c> query parameters onto the URL.
+    /// </summary>
+    [Test]
+    public async Task ReportService_GetJournal_WithDateRange_AppendsQueryParameters()
+    {
+        Server
+            .Given(Request.Create().WithPath(JournalPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new ReportService(ConnectionHandler);
+
+        var result = await service.GetJournal(
+            new QueryParameterJournal(
+                From: new DateOnly(2024, 1, 1),
+                To: new DateOnly(2024, 12, 31)),
+            cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(JournalPath));
+            Assert.That(request.RawQuery, Does.Contain("from=2024-01-01"));
+            Assert.That(request.RawQuery, Does.Contain("to=2024-12-31"));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/TaxSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/TaxSmokeTests.cs
@@ -1,0 +1,142 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Accounting;
+
+/// <summary>
+///     Smoke tests covering the <see cref="TaxService" /> entry points against WireMock stubs.
+///     Verifies the path composed from <see cref="TaxConfiguration" /> (<c>3.0/taxes</c>)
+///     reaches the handler correctly and that the expected HTTP verbs are used.
+/// </summary>
+public sealed class TaxSmokeTests : IntegrationTestBase
+{
+    private const string TaxesPath = "/3.0/taxes";
+
+    private const string TaxResponse = """
+                                       {
+                                           "id": 1,
+                                           "uuid": "abc-123",
+                                           "name": "MwSt 8.1%",
+                                           "code": "UN81",
+                                           "digit": "312",
+                                           "type": "sales_tax",
+                                           "account_id": 2200,
+                                           "tax_settlement_type": "none",
+                                           "value": 8.1,
+                                           "net_tax_value": null,
+                                           "start_year": 2024,
+                                           "end_year": null,
+                                           "is_active": true,
+                                           "display_name": "MwSt 8.1% (312)",
+                                           "start_month": 1,
+                                           "end_month": null
+                                       }
+                                       """;
+
+    /// <summary>
+    ///     <c>TaxService.Get()</c> must issue a <c>GET</c> request against <c>/3.0/taxes</c>
+    ///     and return a successful <c>ApiResult</c> when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task TaxService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(TaxesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new TaxService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(TaxesPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>TaxService.GetById</c> must issue a <c>GET</c> request that includes the target id
+    ///     in the URL path and surface the returned tax on success.
+    /// </summary>
+    [Test]
+    public async Task TaxService_GetById_SendsGetRequestWithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{TaxesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(TaxResponse));
+
+        var service = new TaxService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>TaxService.Delete</c> must issue a <c>DELETE</c> request that includes the target id
+    ///     in the URL path.
+    /// </summary>
+    [Test]
+    public async Task TaxService_Delete_SendsDeleteRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{TaxesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new TaxService(ConnectionHandler);
+
+        var result = await service.Delete(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/VatPeriodSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Accounting/VatPeriodSmokeTests.cs
@@ -1,0 +1,106 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Accounting;
+
+/// <summary>
+///     Smoke tests covering the <see cref="VatPeriodService" /> entry points against WireMock
+///     stubs. Verifies the path composed from <see cref="VatPeriodConfiguration" />
+///     (<c>3.0/accounting/vat_periods</c>) reaches the handler correctly and that the expected
+///     HTTP verbs are used.
+/// </summary>
+public sealed class VatPeriodSmokeTests : IntegrationTestBase
+{
+    private const string VatPeriodsPath = "/3.0/accounting/vat_periods";
+
+    private const string VatPeriodResponse = """
+                                             {
+                                                 "id": 1,
+                                                 "start": "2024-01-01",
+                                                 "end": "2024-03-31",
+                                                 "type": "quarter",
+                                                 "status": "open",
+                                                 "closed_at": null
+                                             }
+                                             """;
+
+    /// <summary>
+    ///     <c>VatPeriodService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/3.0/accounting/vat_periods</c> and return a successful <c>ApiResult</c> when the
+    ///     server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task VatPeriodService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(VatPeriodsPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(VatPeriodsPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>VatPeriodService.GetById</c> must issue a <c>GET</c> request that includes the
+    ///     target id in the URL path and surface the returned vat period on success.
+    /// </summary>
+    [Test]
+    public async Task VatPeriodService_GetById_SendsGetRequestWithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{VatPeriodsPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(VatPeriodResponse));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Banking/OutgoingPaymentSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Banking/OutgoingPaymentSmokeTests.cs
@@ -1,0 +1,264 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Naef <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Banking;
+
+/// <summary>
+///     Smoke tests covering the CRUD entry points of <see cref="OutgoingPaymentService" /> against
+///     WireMock stubs. Verifies the path composed from <see cref="OutgoingPaymentConfiguration" />
+///     (<c>4.0/purchase/outgoing-payments</c>) reaches the handler correctly and that the expected
+///     HTTP verbs are used for each operation (Get, GetById, Create, Update, Delete).
+///     Note: Update uses <c>PUT</c> on the collection path (no <c>/{id}</c>) per the Bexio API spec.
+/// </summary>
+public sealed class OutgoingPaymentSmokeTests : IntegrationTestBase
+{
+    private const string OutgoingPaymentsPath = "/4.0/purchase/outgoing-payments";
+
+    private const string OutgoingPaymentResponse = """
+                                                   {
+                                                       "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                                                       "status": "PENDING",
+                                                       "created_at": "2024-01-15T10:00:00+01:00",
+                                                       "bill_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                                                       "payment_type": "MANUAL",
+                                                       "execution_date": "2024-06-01",
+                                                       "amount": 250.00,
+                                                       "currency_code": "CHF",
+                                                       "exchange_rate": 1.0,
+                                                       "note": "Test payment",
+                                                       "sender_bank_account_id": 1,
+                                                       "sender_iban": null,
+                                                       "sender_name": null,
+                                                       "sender_street": null,
+                                                       "sender_house_no": null,
+                                                       "sender_city": null,
+                                                       "sender_postcode": null,
+                                                       "sender_country_code": null,
+                                                       "sender_bc_no": null,
+                                                       "sender_bank_no": null,
+                                                       "sender_bank_name": null,
+                                                       "receiver_account_no": null,
+                                                       "receiver_iban": null,
+                                                       "receiver_name": null,
+                                                       "receiver_street": null,
+                                                       "receiver_house_no": null,
+                                                       "receiver_city": null,
+                                                       "receiver_postcode": null,
+                                                       "receiver_country_code": null,
+                                                       "receiver_bc_no": null,
+                                                       "receiver_bank_no": null,
+                                                       "receiver_bank_name": null,
+                                                       "fee_type": null,
+                                                       "is_salary_payment": false,
+                                                       "reference_no": null,
+                                                       "message": null,
+                                                       "booking_text": null,
+                                                       "banking_payment_id": null,
+                                                       "banking_payment_entry_id": null,
+                                                       "transaction_id": null
+                                                   }
+                                                   """;
+
+    private const string OutgoingPaymentListResponse = """
+                                                       {
+                                                           "data": [],
+                                                           "paging": {
+                                                               "page": 1,
+                                                               "page_size": 100,
+                                                               "page_count": 0,
+                                                               "item_count": 0
+                                                           }
+                                                       }
+                                                       """;
+
+    private static readonly Guid TestPaymentId = Guid.Parse("b2c3d4e5-f6a7-8901-bcde-f12345678901");
+    private static readonly Guid TestBillId = Guid.Parse("c3d4e5f6-a7b8-9012-cdef-123456789012");
+
+    /// <summary>
+    ///     <c>OutgoingPaymentService.Get</c> must issue a <c>GET</c> against
+    ///     <c>/4.0/purchase/outgoing-payments</c> with the required <c>bill_id</c> query parameter
+    ///     and return a successful <c>ApiResult</c> when the server responds with an empty page.
+    /// </summary>
+    [Test]
+    public async Task OutgoingPaymentService_Get_SendsGetRequestWithBillIdQueryParameter()
+    {
+        Server
+            .Given(Request.Create().WithPath(OutgoingPaymentsPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(OutgoingPaymentListResponse));
+
+        var service = new OutgoingPaymentService(ConnectionHandler);
+
+        var queryParameter = new QueryParameterOutgoingPayment(TestBillId);
+
+        var result = await service.Get(queryParameter, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Data, Is.Empty);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(OutgoingPaymentsPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>OutgoingPaymentService.GetById</c> must issue a <c>GET</c> request that includes the target
+    ///     <see cref="Guid" /> in the URL path and surface the returned outgoing payment on success.
+    /// </summary>
+    [Test]
+    public async Task OutgoingPaymentService_GetById_SendsGetRequestWithIdInPath()
+    {
+        var expectedPath = $"{OutgoingPaymentsPath}/{TestPaymentId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(OutgoingPaymentResponse));
+
+        var service = new OutgoingPaymentService(ConnectionHandler);
+
+        var result = await service.GetById(TestPaymentId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(TestPaymentId));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>OutgoingPaymentService.Create</c> must send a <c>POST</c> request whose body is the
+    ///     serialized <see cref="OutgoingPaymentCreate" /> payload, and must surface the returned
+    ///     outgoing payment on success.
+    /// </summary>
+    [Test]
+    public async Task OutgoingPaymentService_Create_SendsPostRequestWithPayload()
+    {
+        Server
+            .Given(Request.Create().WithPath(OutgoingPaymentsPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(OutgoingPaymentResponse));
+
+        var service = new OutgoingPaymentService(ConnectionHandler);
+
+        var payload = new OutgoingPaymentCreate(
+            TestBillId,
+            OutgoingPaymentType.MANUAL,
+            new DateOnly(2024, 6, 1),
+            250.00m,
+            "CHF",
+            1.0m,
+            1,
+            false,
+            "Test payment");
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(OutgoingPaymentsPath));
+            Assert.That(request.Body, Does.Contain("\"payment_type\":\"MANUAL\""));
+            Assert.That(request.Body, Does.Contain("\"currency_code\":\"CHF\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>OutgoingPaymentService.Update</c> must send a <c>PUT</c> request against
+    ///     <c>/4.0/purchase/outgoing-payments</c> (collection path, no <c>/{id}</c>) whose body is the
+    ///     serialized <see cref="OutgoingPaymentUpdate" /> payload containing the <c>payment_id</c>.
+    ///     This is correct per the Bexio API spec.
+    /// </summary>
+    [Test]
+    public async Task OutgoingPaymentService_Update_SendsPutRequestToCollectionPath()
+    {
+        Server
+            .Given(Request.Create().WithPath(OutgoingPaymentsPath).UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(OutgoingPaymentResponse));
+
+        var service = new OutgoingPaymentService(ConnectionHandler);
+
+        var payload = new OutgoingPaymentUpdate(
+            TestPaymentId,
+            new DateOnly(2024, 6, 15),
+            300.00m,
+            false);
+
+        var result = await service.Update(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("PUT"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(OutgoingPaymentsPath));
+            Assert.That(request.Body, Does.Contain($"\"payment_id\":\"{TestPaymentId}\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>OutgoingPaymentService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    ///     target <see cref="Guid" /> in the URL path.
+    /// </summary>
+    [Test]
+    public async Task OutgoingPaymentService_Delete_SendsDeleteRequestWithIdInPath()
+    {
+        var expectedPath = $"{OutgoingPaymentsPath}/{TestPaymentId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new OutgoingPaymentService(ConnectionHandler);
+
+        var result = await service.Delete(TestPaymentId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Banking/PaymentSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Banking/PaymentSmokeTests.cs
@@ -1,0 +1,222 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Naef <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Banking.Payments;
+using BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+using BexioApiNet.Abstractions.Models.Banking.Payments.Views;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Banking;
+
+/// <summary>
+///     Smoke tests covering the CRUD and Cancel entry points of <see cref="PaymentService" /> against
+///     WireMock stubs. Verifies the path composed from <see cref="PaymentConfiguration" />
+///     (<c>4.0/banking/payments</c>) reaches the handler correctly and that the expected HTTP verbs
+///     are used for each operation (Get, GetById, Create, Cancel, Update, Delete).
+/// </summary>
+public sealed class PaymentSmokeTests : IntegrationTestBase
+{
+    private const string PaymentsPath = "/4.0/banking/payments";
+
+    private const string PaymentResponse = """
+                                           {
+                                               "id": 1,
+                                               "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                                               "sender": null,
+                                               "recipient": null,
+                                               "amount": 100.00,
+                                               "currency": "CHF",
+                                               "execution_date": "2024-06-01",
+                                               "allowance": "fee_split",
+                                               "is_salary": false,
+                                               "instruction_id": null,
+                                               "purchase_reference": null,
+                                               "document_no": "",
+                                               "qr_reference_number": null,
+                                               "additional_information": null,
+                                               "status": "open",
+                                               "type": "iban",
+                                               "due_date": null,
+                                               "created_at": "2024-01-15T10:00:00+01:00",
+                                               "is_editing_restricted": false
+                                           }
+                                           """;
+
+    private static readonly Guid TestPaymentId = Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+
+    /// <summary>
+    ///     <c>PaymentService.Get()</c> must issue a <c>GET</c> against
+    ///     <c>/4.0/banking/payments</c> and return a successful <c>ApiResult</c> when the
+    ///     server responds with an empty collection.
+    /// </summary>
+    [Test]
+    public async Task PaymentService_Get_SendsGetRequestToCorrectPath()
+    {
+        Server
+            .Given(Request.Create().WithPath(PaymentsPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new PaymentService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(PaymentsPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>PaymentService.GetById</c> must issue a <c>GET</c> request that includes the target
+    ///     <see cref="Guid" /> in the URL path and surface the returned payment on success.
+    /// </summary>
+    [Test]
+    public async Task PaymentService_GetById_SendsGetRequestWithIdInPath()
+    {
+        var expectedPath = $"{PaymentsPath}/{TestPaymentId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(PaymentResponse));
+
+        var service = new PaymentService(ConnectionHandler);
+
+        var result = await service.GetById(TestPaymentId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>PaymentService.Create</c> must send a <c>POST</c> request whose body is the serialized
+    ///     <see cref="PaymentCreate" /> payload, and must surface the returned payment on success.
+    /// </summary>
+    [Test]
+    public async Task PaymentService_Create_SendsPostRequestWithPayload()
+    {
+        Server
+            .Given(Request.Create().WithPath(PaymentsPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(PaymentResponse));
+
+        var service = new PaymentService(ConnectionHandler);
+
+        var payload = new PaymentCreate(
+            PaymentType.iban,
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            new PaymentRecipient(
+                "Test Recipient",
+                "CH9300762011623852957",
+                new PaymentAddress(
+                    "Main Street",
+                    "1",
+                    "8000",
+                    "Zurich",
+                    "CH")),
+            100.00m,
+            "CHF",
+            new DateOnly(2024, 6, 1),
+            false);
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(PaymentsPath));
+            Assert.That(request.Body, Does.Contain("\"type\":\"iban\""));
+            Assert.That(request.Body, Does.Contain("\"currency\":\"CHF\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>PaymentService.Cancel</c> must send a <c>POST</c> request against
+    ///     <c>/4.0/banking/payments/{id}/cancel</c> with no body — Bexio uses POST for this action.
+    /// </summary>
+    [Test]
+    public async Task PaymentService_Cancel_SendsPostRequestToCancelPath()
+    {
+        var expectedPath = $"{PaymentsPath}/{TestPaymentId}/cancel";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(PaymentResponse));
+
+        var service = new PaymentService(ConnectionHandler);
+
+        var result = await service.Cancel(TestPaymentId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>PaymentService.Delete</c> must issue a <c>DELETE</c> request that includes the target
+    ///     <see cref="Guid" /> in the URL path.
+    /// </summary>
+    [Test]
+    public async Task PaymentService_Delete_SendsDeleteRequestWithIdInPath()
+    {
+        var expectedPath = $"{PaymentsPath}/{TestPaymentId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new PaymentService(ConnectionHandler);
+
+        var result = await service.Delete(TestPaymentId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Banking/PaymentTypeSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Banking/PaymentTypeSmokeTests.cs
@@ -1,0 +1,102 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Naef <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Banking;
+
+/// <summary>
+///     Smoke tests covering <see cref="PaymentTypeService" />. The request path is composed from
+///     <see cref="PaymentTypeConfiguration" /> (<c>2.0/payment_type</c>) and must reach WireMock
+///     intact when the service is driven through the real connection handler.
+/// </summary>
+public sealed class PaymentTypeSmokeTests : IntegrationTestBase
+{
+    private const string PaymentTypesPath = "/2.0/payment_type";
+
+    /// <summary>
+    ///     <c>PaymentTypeService.Get()</c> must issue a <c>GET</c> against
+    ///     <c>/2.0/payment_type</c> and return a successful <c>ApiResult</c> when the
+    ///     server responds with an empty collection.
+    /// </summary>
+    [Test]
+    public async Task PaymentTypeService_Get_SendsGetRequestToCorrectPath()
+    {
+        Server
+            .Given(Request.Create().WithPath(PaymentTypesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data, Is.Empty);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(PaymentTypesPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>PaymentTypeService.Search</c> must send a <c>POST</c> request against
+    ///     <c>/2.0/payment_type/search</c> with the <see cref="SearchCriteria" /> list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task PaymentTypeService_Search_SendsPostRequestToSearchPath()
+    {
+        var expectedPath = $"{PaymentTypesPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Cash", Criteria = "like" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"name\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/AdditionalAddressSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/AdditionalAddressSmokeTests.cs
@@ -1,0 +1,266 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses.Views;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Contacts;
+
+/// <summary>
+///     Smoke tests covering the CRUD entry points of <see cref="AdditionalAddressService" /> against
+///     WireMock stubs. Additional addresses are nested under a parent contact, so all routes follow the
+///     pattern <c>2.0/contact/{contactId}/additional_address</c> (see
+///     <see cref="AdditionalAddressConfiguration" />). Verifies URL construction with the parent contact
+///     id, that the expected HTTP verbs are used (including the Bexio-specific <c>POST</c> for edits),
+///     and that payloads are serialized with the expected snake_case field names.
+/// </summary>
+public sealed class AdditionalAddressSmokeTests : IntegrationTestBase
+{
+    private const int TestContactId = 42;
+    private const string AdditionalAddressPath = "/2.0/contact/42/additional_address";
+
+    private const string AdditionalAddressResponse = """
+                                                     {
+                                                         "id": 1,
+                                                         "name": "Warehouse",
+                                                         "name_addition": null,
+                                                         "address": "Walter Street 22",
+                                                         "street_name": "Walter Street",
+                                                         "house_number": "22",
+                                                         "address_addition": null,
+                                                         "postcode": "8000",
+                                                         "city": "Zurich",
+                                                         "country_id": 1,
+                                                         "subject": "Delivery address",
+                                                         "description": null
+                                                     }
+                                                     """;
+
+    /// <summary>
+    ///     <c>AdditionalAddressService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/2.0/contact/{contactId}/additional_address</c> and return a successful <c>ApiResult</c>
+    ///     when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task AdditionalAddressService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(AdditionalAddressPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new AdditionalAddressService(ConnectionHandler);
+
+        var result = await service.Get(TestContactId, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(AdditionalAddressPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>AdditionalAddressService.GetById</c> must issue a <c>GET</c> request that includes both
+    ///     the parent contact id and the address id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task AdditionalAddressService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{AdditionalAddressPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(AdditionalAddressResponse));
+
+        var service = new AdditionalAddressService(ConnectionHandler);
+
+        var result = await service.GetById(TestContactId, id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>AdditionalAddressService.Create</c> must send a <c>POST</c> request whose body is the
+    ///     serialized <see cref="AdditionalAddressCreate" /> payload, and must surface the returned
+    ///     additional address on success.
+    /// </summary>
+    [Test]
+    public async Task AdditionalAddressService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(AdditionalAddressPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(AdditionalAddressResponse));
+
+        var service = new AdditionalAddressService(ConnectionHandler);
+
+        var payload = new AdditionalAddressCreate(
+            "Warehouse",
+            null,
+            "Walter Street",
+            "22",
+            null,
+            "8000",
+            "Zurich",
+            1,
+            "Delivery address",
+            null);
+
+        var result = await service.Create(TestContactId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(AdditionalAddressPath));
+            Assert.That(request.Body, Does.Contain("\"name\":\"Warehouse\""));
+            Assert.That(request.Body, Does.Contain("\"street_name\":\"Walter Street\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>AdditionalAddressService.Search</c> must send a <c>POST</c> request against
+    ///     <c>/2.0/contact/{contactId}/additional_address/search</c> with the <see cref="SearchCriteria" />
+    ///     list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task AdditionalAddressService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{AdditionalAddressPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{AdditionalAddressResponse}]"));
+
+        var service = new AdditionalAddressService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Warehouse", Criteria = "=" }
+        };
+
+        var result = await service.Search(TestContactId, criteria,
+            cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"name\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"=\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>AdditionalAddressService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request
+    ///     against <c>/2.0/contact/{contactId}/additional_address/{id}</c> — Bexio uses POST for
+    ///     full-replacement edits on v2.0 resources.
+    /// </summary>
+    [Test]
+    public async Task AdditionalAddressService_Update_SendsPostRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{AdditionalAddressPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(AdditionalAddressResponse));
+
+        var service = new AdditionalAddressService(ConnectionHandler);
+
+        var payload = new AdditionalAddressUpdate(
+            "Warehouse",
+            null,
+            "Walter Street",
+            "22",
+            null,
+            "8000",
+            "Zurich",
+            1,
+            "Delivery address",
+            null);
+
+        var result = await service.Update(TestContactId, id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>AdditionalAddressService.Delete</c> must issue a <c>DELETE</c> request that includes
+    ///     both the parent contact id and the address id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task AdditionalAddressService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{AdditionalAddressPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new AdditionalAddressService(ConnectionHandler);
+
+        var result = await service.Delete(TestContactId, idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/ContactGroupSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/ContactGroupSmokeTests.cs
@@ -1,0 +1,230 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups.Views;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Contacts;
+
+/// <summary>
+///     Smoke tests covering the CRUD entry points of <see cref="ContactGroupService" /> against
+///     WireMock stubs. Verifies the path composed from <see cref="ContactGroupConfiguration" />
+///     (<c>2.0/contact_group</c>) reaches the handler correctly, that the expected HTTP verbs are used
+///     (including the Bexio-specific <c>POST</c> for edits), and that payloads are serialized with the
+///     expected snake_case field names.
+/// </summary>
+public sealed class ContactGroupSmokeTests : IntegrationTestBase
+{
+    private const string ContactGroupPath = "/2.0/contact_group";
+
+    private const string ContactGroupResponse = """
+                                                {
+                                                    "id": 1,
+                                                    "name": "VIP Customers"
+                                                }
+                                                """;
+
+    /// <summary>
+    ///     <c>ContactGroupService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/2.0/contact_group</c> and return a successful <c>ApiResult</c> when the server
+    ///     returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task ContactGroupService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(ContactGroupPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new ContactGroupService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ContactGroupPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactGroupService.GetById</c> must issue a <c>GET</c> request that includes the target
+    ///     id in the URL path and surface the returned contact group on success.
+    /// </summary>
+    [Test]
+    public async Task ContactGroupService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{ContactGroupPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ContactGroupResponse));
+
+        var service = new ContactGroupService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactGroupService.Create</c> must send a <c>POST</c> request whose body is the
+    ///     serialized <see cref="ContactGroupCreate" /> payload, and must surface the returned contact
+    ///     group on success.
+    /// </summary>
+    [Test]
+    public async Task ContactGroupService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(ContactGroupPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(ContactGroupResponse));
+
+        var service = new ContactGroupService(ConnectionHandler);
+
+        var payload = new ContactGroupCreate("VIP Customers");
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ContactGroupPath));
+            Assert.That(request.Body, Does.Contain("\"name\":\"VIP Customers\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactGroupService.Search</c> must send a <c>POST</c> request against
+    ///     <c>/2.0/contact_group/search</c> with the <see cref="SearchCriteria" /> list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task ContactGroupService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{ContactGroupPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{ContactGroupResponse}]"));
+
+        var service = new ContactGroupService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "VIP", Criteria = "like" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"name\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactGroupService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request against
+    ///     <c>/2.0/contact_group/{id}</c> — Bexio uses POST for full-replacement edits on v2.0 resources.
+    /// </summary>
+    [Test]
+    public async Task ContactGroupService_Update_SendsPostRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{ContactGroupPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ContactGroupResponse));
+
+        var service = new ContactGroupService(ConnectionHandler);
+
+        var payload = new ContactGroupUpdate("VIP Customers");
+
+        var result = await service.Update(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactGroupService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    ///     target id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task ContactGroupService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{ContactGroupPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new ContactGroupService(ConnectionHandler);
+
+        var result = await service.Delete(idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/ContactRelationSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/ContactRelationSmokeTests.cs
@@ -1,0 +1,242 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactRelations.Views;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Contacts;
+
+/// <summary>
+///     Smoke tests covering the CRUD entry points of <see cref="ContactRelationService" /> against
+///     WireMock stubs. Verifies the path composed from <see cref="ContactRelationConfiguration" />
+///     (<c>2.0/contact_relation</c>) reaches the handler correctly, that the expected HTTP verbs are
+///     used (including the Bexio-specific <c>POST</c> for edits), and that payloads are serialized with
+///     the expected snake_case field names.
+/// </summary>
+public sealed class ContactRelationSmokeTests : IntegrationTestBase
+{
+    private const string ContactRelationPath = "/2.0/contact_relation";
+
+    private const string ContactRelationResponse = """
+                                                   {
+                                                       "id": 1,
+                                                       "contact_id": 10,
+                                                       "contact_sub_id": 20,
+                                                       "description": "Partner",
+                                                       "updated_at": "2024-01-01 12:00:00"
+                                                   }
+                                                   """;
+
+    /// <summary>
+    ///     <c>ContactRelationService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/2.0/contact_relation</c> and return a successful <c>ApiResult</c> when the server
+    ///     returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task ContactRelationService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(ContactRelationPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new ContactRelationService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ContactRelationPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactRelationService.GetById</c> must issue a <c>GET</c> request that includes the
+    ///     target id in the URL path and surface the returned contact relation on success.
+    /// </summary>
+    [Test]
+    public async Task ContactRelationService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{ContactRelationPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ContactRelationResponse));
+
+        var service = new ContactRelationService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactRelationService.Create</c> must send a <c>POST</c> request whose body is the
+    ///     serialized <see cref="ContactRelationCreate" /> payload, and must surface the returned
+    ///     contact relation on success.
+    /// </summary>
+    [Test]
+    public async Task ContactRelationService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(ContactRelationPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(ContactRelationResponse));
+
+        var service = new ContactRelationService(ConnectionHandler);
+
+        var payload = new ContactRelationCreate(
+            10,
+            20,
+            "Partner");
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ContactRelationPath));
+            Assert.That(request.Body, Does.Contain("\"contact_id\":10"));
+            Assert.That(request.Body, Does.Contain("\"contact_sub_id\":20"));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactRelationService.Search</c> must send a <c>POST</c> request against
+    ///     <c>/2.0/contact_relation/search</c> with the <see cref="SearchCriteria" /> list as the
+    ///     JSON body.
+    /// </summary>
+    [Test]
+    public async Task ContactRelationService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{ContactRelationPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{ContactRelationResponse}]"));
+
+        var service = new ContactRelationService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "contact_id", Value = "10", Criteria = "=" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"contact_id\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"=\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactRelationService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request
+    ///     against <c>/2.0/contact_relation/{id}</c> — Bexio uses POST for full-replacement edits on
+    ///     v2.0 resources.
+    /// </summary>
+    [Test]
+    public async Task ContactRelationService_Update_SendsPostRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{ContactRelationPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ContactRelationResponse));
+
+        var service = new ContactRelationService(ConnectionHandler);
+
+        var payload = new ContactRelationUpdate(
+            10,
+            20,
+            "Partner");
+
+        var result = await service.Update(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactRelationService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    ///     target id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task ContactRelationService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{ContactRelationPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new ContactRelationService(ConnectionHandler);
+
+        var result = await service.Delete(idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/ContactSectorSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/ContactSectorSmokeTests.cs
@@ -1,0 +1,109 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Contacts;
+
+/// <summary>
+///     Smoke tests covering the read-only entry points of <see cref="ContactSectorService" /> against
+///     WireMock stubs. The Bexio API exposes contact sectors under the legacy path
+///     <c>2.0/contact_branch</c> (see <see cref="ContactSectorConfiguration" />). This fixture verifies
+///     that the URL is built correctly and that the expected HTTP verbs are used. The service only
+///     supports <c>Get</c> and <c>Search</c> — there are no Create, Update, or Delete endpoints.
+/// </summary>
+public sealed class ContactSectorSmokeTests : IntegrationTestBase
+{
+    private const string ContactBranchPath = "/2.0/contact_branch";
+
+    private const string ContactSectorResponse = """
+                                                 {
+                                                     "id": 1,
+                                                     "name": "Photography"
+                                                 }
+                                                 """;
+
+    /// <summary>
+    ///     <c>ContactSectorService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/2.0/contact_branch</c> and return a successful <c>ApiResult</c> when the server
+    ///     returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task ContactSectorService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(ContactBranchPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new ContactSectorService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ContactBranchPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>ContactSectorService.Search</c> must send a <c>POST</c> request against
+    ///     <c>/2.0/contact_branch/search</c> with the <see cref="SearchCriteria" /> list as the JSON
+    ///     body.
+    /// </summary>
+    [Test]
+    public async Task ContactSectorService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{ContactBranchPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{ContactSectorResponse}]"));
+
+        var service = new ContactSectorService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Photography", Criteria = "=" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"name\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"=\""));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/ContactSmokeTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Smoke/Contacts/ContactSmokeTests.cs
@@ -1,0 +1,330 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.Contacts.Views;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.IntegrationTests.Smoke.Contacts;
+
+/// <summary>
+/// Smoke tests covering the CRUD entry points of <see cref="ContactService"/> against
+/// WireMock stubs. Verifies the path composed from <see cref="ContactConfiguration"/>
+/// (<c>2.0/contact</c>) reaches the handler correctly, that the expected HTTP verbs are used
+/// (including the Bexio-specific <c>POST</c> for edits and <c>PATCH</c> for restore), and that
+/// payloads are serialized with the expected snake_case field names.
+/// </summary>
+public sealed class ContactSmokeTests : IntegrationTestBase
+{
+    private const string ContactsPath = "/2.0/contact";
+
+    private const string ContactResponse = """
+        {
+            "id": 1,
+            "nr": "1000",
+            "contact_type_id": 1,
+            "name_1": "Acme AG",
+            "name_2": null,
+            "salutation_id": null,
+            "salutation_form": null,
+            "title_id": null,
+            "birthday": null,
+            "address": null,
+            "street_name": null,
+            "house_number": null,
+            "address_addition": null,
+            "postcode": null,
+            "city": null,
+            "country_id": null,
+            "mail": null,
+            "mail_second": null,
+            "phone_fixed": null,
+            "phone_fixed_second": null,
+            "phone_mobile": null,
+            "fax": null,
+            "url": null,
+            "skype_name": null,
+            "remarks": null,
+            "language_id": null,
+            "is_lead": false,
+            "contact_group_ids": null,
+            "contact_branch_ids": null,
+            "user_id": 1,
+            "owner_id": 1,
+            "updated_at": "2024-01-01 12:00:00"
+        }
+        """;
+
+    /// <summary>
+    /// <c>ContactService.Get()</c> must issue a <c>GET</c> request against <c>/2.0/contact</c>
+    /// and return a successful <c>ApiResult</c> when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task ContactService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(ContactsPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new ContactService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ContactsPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>ContactService.GetById</c> must issue a <c>GET</c> request that includes the target id
+    /// in the URL path and surface the returned contact on success.
+    /// </summary>
+    [Test]
+    public async Task ContactService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{ContactsPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ContactResponse));
+
+        var service = new ContactService(ConnectionHandler);
+
+        var result = await service.GetById(id, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>ContactService.Create</c> must send a <c>POST</c> request whose body is the serialized
+    /// <see cref="ContactCreate"/> payload, and must surface the returned contact on success.
+    /// </summary>
+    [Test]
+    public async Task ContactService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(ContactsPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(ContactResponse));
+
+        var service = new ContactService(ConnectionHandler);
+
+        var payload = new ContactCreate(
+            ContactTypeId: 1,
+            Name1: "Acme AG",
+            UserId: 1,
+            OwnerId: 1);
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ContactsPath));
+            Assert.That(request.Body, Does.Contain("\"name_1\":\"Acme AG\""));
+            Assert.That(request.Body, Does.Contain("\"contact_type_id\":1"));
+        });
+    }
+
+    /// <summary>
+    /// <c>ContactService.BulkCreate</c> must send a <c>POST</c> request against
+    /// <c>/2.0/contact/_bulk_create</c> with a JSON array body.
+    /// </summary>
+    [Test]
+    public async Task ContactService_BulkCreate_SendsPostRequest_ToBulkCreatePath()
+    {
+        var expectedPath = $"{ContactsPath}/_bulk_create";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody($"[{ContactResponse}]"));
+
+        var service = new ContactService(ConnectionHandler);
+
+        var payload = new List<ContactCreate>
+        {
+            new(ContactTypeId: 1, Name1: "Acme AG", UserId: 1, OwnerId: 1)
+        };
+
+        var result = await service.BulkCreate(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!, Has.Count.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.StartWith("["));
+        });
+    }
+
+    /// <summary>
+    /// <c>ContactService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/contact/search</c> with the <see cref="SearchCriteria"/> list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task ContactService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{ContactsPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{ContactResponse}]"));
+
+        var service = new ContactService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name_1", Value = "Acme", Criteria = "like" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"name_1\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>ContactService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request against
+    /// <c>/2.0/contact/{id}</c> — Bexio uses POST for full-replacement edits on this resource.
+    /// </summary>
+    [Test]
+    public async Task ContactService_Update_SendsPostRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{ContactsPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ContactResponse));
+
+        var service = new ContactService(ConnectionHandler);
+
+        var payload = new ContactUpdate(
+            ContactTypeId: 1,
+            Name1: "Acme AG",
+            UserId: 1,
+            OwnerId: 1);
+
+        var result = await service.Update(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>ContactService.Restore</c> must send a <c>PATCH</c> request against
+    /// <c>/2.0/contact/{id}/restore</c> with no body — Bexio uses PATCH for this action.
+    /// </summary>
+    [Test]
+    public async Task ContactService_Restore_SendsPatchRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{ContactsPath}/{id}/restore";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPatch())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new ContactService(ConnectionHandler);
+
+        var result = await service.Restore(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("PATCH"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>ContactService.Delete</c> must issue a <c>DELETE</c> request that includes the target id
+    /// in the URL path.
+    /// </summary>
+    [Test]
+    public async Task ContactService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{ContactsPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new ContactService(ConnectionHandler);
+
+        var result = await service.Delete(idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Accounting/AccountGroupServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/AccountGroupServiceTests.cs
@@ -1,0 +1,245 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Accounting.AccountGroups;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.UnitTests.Accounting;
+
+/// <summary>
+/// Offline unit tests for <see cref="AccountGroupService"/>. Verify the connector
+/// builds the right request path, forwards <see cref="QueryParameter"/>s, and
+/// triggers <c>FetchAll</c> only when <c>autoPage</c> is requested and the
+/// response actually carries a <c>X-Total-Count</c> header.
+/// </summary>
+[TestFixture]
+public sealed class AccountGroupServiceTests : ServiceTestBase
+{
+    private const string ExpectedPath = "2.0/account_groups";
+
+    /// <summary>
+    /// With no parameters, the service forwards a single <c>GetAsync</c> call to
+    /// <c>2.0/account_groups</c> with a <see langword="null"/> query parameter and never
+    /// touches <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<AccountGroup>>
+        {
+            IsSuccess = true,
+            Data = []
+        };
+        ConnectionHandler
+            .GetAsync<List<AccountGroup>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new AccountGroupService(ConnectionHandler);
+
+        var result = await service.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<AccountGroup>>(
+            ExpectedPath,
+            null,
+            Arg.Any<CancellationToken>());
+        await ConnectionHandler.DidNotReceive().FetchAll<AccountGroup>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When a <see cref="QueryParameterAccountGroup"/> is supplied, its inner
+    /// <see cref="QueryParameter"/> instance is forwarded to the connection
+    /// handler verbatim — the service must not rewrap or substitute it.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterAccountGroup(Limit: 50, Offset: 100);
+        ConnectionHandler
+            .GetAsync<List<AccountGroup>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<AccountGroup>> { IsSuccess = true, Data = [] }));
+
+        var service = new AccountGroupService(ConnectionHandler);
+
+        await service.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<AccountGroup>>(
+            ExpectedPath,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When <c>autoPage</c> is on and the first response advertises a
+    /// <c>X-Total-Count</c> header, the service must call <c>FetchAll</c> with
+    /// the count of already-fetched items, the total, the same path, and the
+    /// same query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
+    {
+        var firstGroup = NewAccountGroup(1);
+        var firstPage = new ApiResult<List<AccountGroup>>
+        {
+            IsSuccess = true,
+            Data = [firstGroup],
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                [ApiHeaderNames.TotalResults] = 3
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<AccountGroup>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(firstPage));
+        var remaining = new List<AccountGroup> { NewAccountGroup(2), NewAccountGroup(3) };
+        ConnectionHandler
+            .FetchAll<AccountGroup>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(remaining));
+
+        var service = new AccountGroupService(ConnectionHandler);
+
+        var result = await service.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<AccountGroup>(
+            1,
+            3,
+            ExpectedPath,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result.Data, Has.Count.EqualTo(3));
+        Assert.That(result.Data, Is.EquivalentTo(new[] { firstGroup, remaining[0], remaining[1] }));
+    }
+
+    /// <summary>
+    /// When <c>autoPage</c> is requested but the response carries no
+    /// <c>X-Total-Count</c> header, the service must not invoke <c>FetchAll</c>
+    /// — there is nothing more to fetch.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
+    {
+        var response = new ApiResult<List<AccountGroup>>
+        {
+            IsSuccess = true,
+            Data = [NewAccountGroup(1)],
+            ResponseHeaders = new Dictionary<string, int?>()
+        };
+        ConnectionHandler
+            .GetAsync<List<AccountGroup>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new AccountGroupService(ConnectionHandler);
+
+        var result = await service.Get(autoPage: true);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.DidNotReceive().FetchAll<AccountGroup>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The success/failure shape, status code, error and data of the
+    /// <see cref="ApiResult{T}"/> returned by the connection handler must reach
+    /// the caller untouched when no auto-paging happens.
+    /// </summary>
+    [Test]
+    public async Task Get_WhenConnectionHandlerReturnsFailure_PropagatesApiResultUnchanged()
+    {
+        var apiError = new ApiError(ErrorCode: 500, Message: "boom", Errors: new object());
+        var response = new ApiResult<List<AccountGroup>>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.InternalServerError,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<List<AccountGroup>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new AccountGroupService(ConnectionHandler);
+
+        var result = await service.Get(autoPage: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(response));
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ApiError, Is.SameAs(apiError));
+            Assert.That(result.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.InternalServerError));
+            Assert.That(result.Data, Is.Null);
+        });
+        await ConnectionHandler.DidNotReceive().FetchAll<AccountGroup>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller must be forwarded to the
+    /// connection handler so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<AccountGroup>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<AccountGroup>> { IsSuccess = true, Data = [] }));
+
+        var service = new AccountGroupService(ConnectionHandler);
+
+        await service.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<AccountGroup>>(
+            ExpectedPath,
+            null,
+            cts.Token);
+    }
+
+    private static AccountGroup NewAccountGroup(int id) =>
+        new(
+            Id: id,
+            Uuid: $"uuid-{id}",
+            AccountNo: id.ToString(),
+            Name: $"Account Group {id}",
+            ParentFibuAccountGroupId: null,
+            IsActive: true,
+            IsLocked: false);
+}

--- a/tests/BexioApiNet.UnitTests/Accounting/BusinessYearServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/BusinessYearServiceTests.cs
@@ -1,0 +1,202 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Net;
+using BexioApiNet.Abstractions.Models.Accounting.BusinessYears;
+using BexioApiNet.Abstractions.Models.Accounting.BusinessYears.Enums;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.UnitTests.Accounting;
+
+/// <summary>
+///     Offline unit tests for <see cref="BusinessYearService" />. Verifies the connector
+///     builds the right request path, forwards cancellation tokens, and surfaces the
+///     connection handler's <see cref="ApiResult{T}" /> back to the caller unchanged.
+/// </summary>
+[TestFixture]
+public sealed class BusinessYearServiceTests : ServiceTestBase
+{
+    private const string ExpectedListPath = "3.0/accounting/business_years";
+
+    /// <summary>
+    ///     With no parameters the service hits <c>3.0/accounting/business_years</c>
+    ///     exactly once with a <see langword="null" /> query parameter and returns the
+    ///     connection handler's <see cref="ApiResult{T}" /> as-is.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
+    {
+        var expected = new ApiResult<List<BusinessYear>>
+        {
+            IsSuccess = true,
+            Data = [NewBusinessYear(1)]
+        };
+        ConnectionHandler
+            .GetAsync<List<BusinessYear>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new BusinessYearService(ConnectionHandler);
+
+        var result = await service.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<BusinessYear>>(
+            ExpectedListPath,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterBusinessYear" /> is passed, its serialized
+    ///     <see cref="QueryParameter" /> is forwarded to the connection handler.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_ForwardsQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterBusinessYear(20, 0);
+        ConnectionHandler
+            .GetAsync<List<BusinessYear>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<BusinessYear>> { IsSuccess = true, Data = [] }));
+
+        var service = new BusinessYearService(ConnectionHandler);
+
+        await service.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<BusinessYear>>(
+            ExpectedListPath,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     The cancellation token supplied by the caller must be forwarded to the
+    ///     connection handler so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<BusinessYear>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<BusinessYear>> { IsSuccess = true, Data = [] }));
+
+        var service = new BusinessYearService(ConnectionHandler);
+
+        await service.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<BusinessYear>>(
+            ExpectedListPath,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    ///     A failing <see cref="ApiResult{T}" /> from the connection handler must
+    ///     surface to the caller untouched — the service may not swallow errors.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var apiError = new ApiError(500, "boom", new object());
+        var response = new ApiResult<List<BusinessYear>>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = HttpStatusCode.InternalServerError,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<List<BusinessYear>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new BusinessYearService(ConnectionHandler);
+
+        var result = await service.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     <see cref="BusinessYearService.GetById" /> must substitute the id into the
+    ///     path and call <c>GetAsync</c> with a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<BusinessYear>
+        {
+            IsSuccess = true,
+            Data = NewBusinessYear(id)
+        };
+        ConnectionHandler
+            .GetAsync<BusinessYear>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new BusinessYearService(ConnectionHandler);
+
+        var result = await service.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<BusinessYear>(
+            $"{ExpectedListPath}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <see cref="BusinessYearService.GetById" /> forwards the caller's cancellation
+    ///     token to the connection handler.
+    /// </summary>
+    [Test]
+    public async Task GetById_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<BusinessYear>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<BusinessYear> { IsSuccess = true, Data = NewBusinessYear(1) }));
+
+        var service = new BusinessYearService(ConnectionHandler);
+
+        await service.GetById(7, cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<BusinessYear>(
+            $"{ExpectedListPath}/7",
+            null,
+            cts.Token);
+    }
+
+    private static BusinessYear NewBusinessYear(int id)
+    {
+        return new BusinessYear(
+            id,
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            BusinessYearStatus.open,
+            null);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Accounting/CalendarYearServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/CalendarYearServiceTests.cs
@@ -1,0 +1,367 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears;
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Enums;
+using BexioApiNet.Abstractions.Models.Accounting.CalendarYears.Views;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.UnitTests.Accounting;
+
+/// <summary>
+///     Offline unit tests for <see cref="CalendarYearService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+///     returns the handler's result unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class CalendarYearServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="CalendarYearService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new CalendarYearService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "3.0/accounting/calendar_years";
+
+    private CalendarYearService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    ///     the expected endpoint path and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<CalendarYear>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<CalendarYear>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<CalendarYear>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get forwards the <see cref="QueryParameterCalendarYear" /> to the connection handler so
+    ///     limit/offset reach the server.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_ForwardsQueryParameter()
+    {
+        var query = new QueryParameterCalendarYear(Limit: 10, Offset: 5);
+        var response = new ApiResult<List<CalendarYear>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<CalendarYear>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(query);
+
+        await ConnectionHandler.Received(1).GetAsync<List<CalendarYear>?>(
+            ExpectedEndpoint,
+            query.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    ///     the full result set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<CalendarYear> { BuildCalendarYear(1), BuildCalendarYear(2) };
+        var initial = new ApiResult<List<CalendarYear>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<CalendarYear>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<CalendarYear>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<CalendarYear>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    ///     auto-paging is not requested (no additional FetchAll round-trip, result passes through).
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResult()
+    {
+        var response = new ApiResult<List<CalendarYear>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<CalendarYear>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected path
+    ///     containing the id and no query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync()
+    {
+        const int id = 42;
+        var response = new ApiResult<CalendarYear> { IsSuccess = true };
+        ConnectionHandler
+            .GetAsync<CalendarYear>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(id);
+
+        await ConnectionHandler.Received(1).GetAsync<CalendarYear>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    ///     modification.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<CalendarYear> { IsSuccess = true, Data = BuildCalendarYear(1) };
+        ConnectionHandler
+            .GetAsync<CalendarYear>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.GetById(1);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Create forwards the payload and the expected endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<List<CalendarYear>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostAsync<List<CalendarYear>, CalendarYearCreate>(
+                Arg.Any<CalendarYearCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<List<CalendarYear>, CalendarYearCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    ///     modification.
+    /// </summary>
+    [Test]
+    public async Task Create_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<List<CalendarYear>> { IsSuccess = true, Data = [BuildCalendarYear(1)] };
+        ConnectionHandler
+            .PostAsync<List<CalendarYear>, CalendarYearCreate>(
+                Arg.Any<CalendarYearCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria list, the expected <c>/search</c> endpoint and the optional
+    ///     query parameter to <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "start", Value = "2026-01-01", Criteria = "=" }
+        };
+        var response = new ApiResult<List<CalendarYear>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<CalendarYear>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(criteria);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<CalendarYear>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search forwards the <see cref="QueryParameterCalendarYear" /> to the connection handler so
+    ///     limit/offset reach the server alongside the search body.
+    /// </summary>
+    [Test]
+    public async Task Search_WithQueryParameter_ForwardsQueryParameter()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "start", Value = "2026-01-01", Criteria = "=" }
+        };
+        var query = new QueryParameterCalendarYear(Limit: 5, Offset: 0);
+        var response = new ApiResult<List<CalendarYear>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<CalendarYear>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(criteria, query);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<CalendarYear>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            query.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    ///     modification.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsApiResultFromConnectionHandler()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "start", Value = "2026-01-01", Criteria = "=" }
+        };
+        var response = new ApiResult<List<CalendarYear>> { IsSuccess = true, Data = [BuildCalendarYear(1)] };
+        ConnectionHandler
+            .PostSearchAsync<CalendarYear>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Search(criteria);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    private static CalendarYearCreate BuildCreatePayload()
+    {
+        return new CalendarYearCreate(
+            Year: "2026",
+            IsVatSubject: true,
+            IsAnnualReporting: false,
+            VatAccountingMethod: VatAccountingMethod.effective,
+            VatAccountingType: VatAccountingType.agreed,
+            DefaultTaxIncomeId: 1,
+            DefaultTaxExpenseId: 2);
+    }
+
+    private static CalendarYear BuildCalendarYear(int id)
+    {
+        return new CalendarYear(
+            Id: id,
+            Start: new DateOnly(2026, 1, 1),
+            End: new DateOnly(2026, 12, 31),
+            IsVatSubject: true,
+            IsAnnualReporting: false,
+            CreatedAt: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedAt: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            VatAccountingMethod: VatAccountingMethod.effective,
+            VatAccountingType: VatAccountingType.agreed);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Accounting/CurrencyServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/CurrencyServiceTests.cs
@@ -23,7 +23,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using System.Net;
 using BexioApiNet.Abstractions.Models.Accounting.Currencies;
+using BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Models;
 using BexioApiNet.Services.Connectors.Accounting;
@@ -31,19 +33,31 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.UnitTests.Accounting;
 
 /// <summary>
-/// Offline unit tests for <see cref="CurrencyService"/>. Currency is a simple
-/// list endpoint — the connector forwards the request and result, optionally
-/// auto-paging through a <c>X-Total-Count</c> header.
+///     Offline unit tests for <see cref="CurrencyService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+///     returns the handler's <see cref="ApiResult{T}" /> unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class CurrencyServiceTests : ServiceTestBase
 {
+    /// <summary>
+    ///     Creates a fresh <see cref="CurrencyService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new CurrencyService(ConnectionHandler);
+    }
+
     private const string ExpectedPath = "3.0/currencies";
 
+    private CurrencyService _sut = null!;
+
     /// <summary>
-    /// With no parameters the service hits <c>3.0/currencies</c> exactly once
-    /// with a <see langword="null"/> query parameter and returns the connection
-    /// handler's <see cref="ApiResult{T}"/> as-is.
+    ///     With no parameters the service hits <c>3.0/currencies</c> exactly once
+    ///     with a <see langword="null" /> query parameter and returns the connection
+    ///     handler's <see cref="ApiResult{T}" /> as-is.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
@@ -51,15 +65,13 @@ public sealed class CurrencyServiceTests : ServiceTestBase
         var expected = new ApiResult<List<Currency>>
         {
             IsSuccess = true,
-            Data = [new Currency(Id: 1, Name: "CHF", RoundFactor: 0.05)]
+            Data = [new Currency(1, "CHF", 0.05)]
         };
         ConnectionHandler
             .GetAsync<List<Currency>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(expected));
 
-        var service = new CurrencyService(ConnectionHandler);
-
-        var result = await service.Get();
+        var result = await _sut.Get();
 
         Assert.That(result, Is.SameAs(expected));
         await ConnectionHandler.Received(1).GetAsync<List<Currency>>(
@@ -69,8 +81,8 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    /// The cancellation token supplied by the caller must be forwarded to the
-    /// connection handler so cooperative cancellation flows end-to-end.
+    ///     The cancellation token supplied by the caller must be forwarded to the
+    ///     connection handler so cooperative cancellation flows end-to-end.
     /// </summary>
     [Test]
     public async Task Get_ForwardsCancellationTokenToConnectionHandler()
@@ -80,9 +92,7 @@ public sealed class CurrencyServiceTests : ServiceTestBase
             .GetAsync<List<Currency>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new ApiResult<List<Currency>> { IsSuccess = true, Data = [] }));
 
-        var service = new CurrencyService(ConnectionHandler);
-
-        await service.Get(cancellationToken: cts.Token);
+        await _sut.Get(cancellationToken: cts.Token);
 
         await ConnectionHandler.Received(1).GetAsync<List<Currency>>(
             ExpectedPath,
@@ -91,28 +101,234 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    /// A failing <see cref="ApiResult{T}"/> from the connection handler must
-    /// surface to the caller untouched — the service may not swallow errors.
+    ///     A failing <see cref="ApiResult{T}" /> from the connection handler must
+    ///     surface to the caller untouched — the service may not swallow errors.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResultFromConnectionHandlerUnchanged()
     {
-        var apiError = new ApiError(ErrorCode: 401, Message: "unauthorized", Errors: new object());
+        var apiError = new ApiError(401, "unauthorized", new object());
         var response = new ApiResult<List<Currency>>
         {
             IsSuccess = false,
             ApiError = apiError,
-            StatusCode = System.Net.HttpStatusCode.Unauthorized,
+            StatusCode = HttpStatusCode.Unauthorized,
             Data = null
         };
         ConnectionHandler
             .GetAsync<List<Currency>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(response));
 
-        var service = new CurrencyService(ConnectionHandler);
-
-        var result = await service.Get();
+        var result = await _sut.Get();
 
         Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     <c>GetCodes</c> must hit <c>3.0/currencies/codes</c> exactly once
+    ///     with a <see langword="null" /> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetCodes_CallsGetAsyncWithCodesPath()
+    {
+        var response = new ApiResult<List<string>>
+        {
+            IsSuccess = true,
+            Data = ["EUR", "GBP", "PLN"]
+        };
+        ConnectionHandler
+            .GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.GetCodes();
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).GetAsync<List<string>>(
+            $"{ExpectedPath}/codes",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>GetCodes</c> forwards the supplied cancellation token to the connection handler.
+    /// </summary>
+    [Test]
+    public async Task GetCodes_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<string>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<string>> { IsSuccess = true, Data = [] }));
+
+        await _sut.GetCodes(cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<string>>(
+            $"{ExpectedPath}/codes",
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    ///     <c>GetById</c> must build the request path with the currency id appended to the endpoint
+    ///     root and hit the handler exactly once.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<Currency>
+        {
+            IsSuccess = true,
+            Data = new Currency(id, "CHF", 0.05)
+        };
+        ConnectionHandler
+            .GetAsync<Currency>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).GetAsync<Currency>(
+            $"{ExpectedPath}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>GetExchangeRates</c> calls the handler with the nested
+    ///     <c>3.0/currencies/{id}/exchange_rates</c> path and a <see langword="null" /> query parameter
+    ///     when no date filter is supplied.
+    /// </summary>
+    [Test]
+    public async Task GetExchangeRates_WithNoQueryParameter_CallsGetAsyncWithExpectedPath()
+    {
+        const int id = 7;
+        var response = new ApiResult<List<ExchangeRate>>
+        {
+            IsSuccess = true,
+            Data = []
+        };
+        ConnectionHandler
+            .GetAsync<List<ExchangeRate>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.GetExchangeRates(id);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).GetAsync<List<ExchangeRate>>(
+            $"{ExpectedPath}/{id}/exchange_rates",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterExchangeRate" /> is supplied with a date, the wrapped
+    ///     <see cref="QueryParameter" /> must be passed through to the connection handler so the
+    ///     <c>date</c> filter reaches the API.
+    /// </summary>
+    [Test]
+    public async Task GetExchangeRates_WithDateQueryParameter_PassesQueryParameterToHandler()
+    {
+        const int id = 3;
+        var query = new QueryParameterExchangeRate(new DateOnly(2024, 5, 1));
+        var response = new ApiResult<List<ExchangeRate>>
+        {
+            IsSuccess = true,
+            Data = []
+        };
+        ConnectionHandler
+            .GetAsync<List<ExchangeRate>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        await _sut.GetExchangeRates(id, query);
+
+        await ConnectionHandler.Received(1).GetAsync<List<ExchangeRate>>(
+            $"{ExpectedPath}/{id}/exchange_rates",
+            query.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>Create</c> forwards the payload and the <c>3.0/currencies</c> endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithExpectedPath()
+    {
+        var payload = new CurrencyCreate("CHF", 0.05);
+        var response = new ApiResult<Currency>
+        {
+            IsSuccess = true,
+            Data = new Currency(1, "CHF", 0.05)
+        };
+        ConnectionHandler
+            .PostAsync<Currency, CurrencyCreate>(
+                Arg.Any<CurrencyCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).PostAsync<Currency, CurrencyCreate>(
+            payload,
+            ExpectedPath,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>Patch</c> forwards the patch payload and the <c>3.0/currencies/{id}</c> endpoint path
+    ///     to <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}" />.
+    /// </summary>
+    [Test]
+    public async Task Patch_CallsPatchAsyncWithIdInPath()
+    {
+        const int id = 99;
+        var payload = new CurrencyPatch(0.10);
+        var response = new ApiResult<Currency>
+        {
+            IsSuccess = true,
+            Data = new Currency(id, "CHF", 0.10)
+        };
+        ConnectionHandler
+            .PatchAsync<Currency, CurrencyPatch>(
+                Arg.Any<CurrencyPatch>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Patch(id, payload);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).PatchAsync<Currency, CurrencyPatch>(
+            payload,
+            $"{ExpectedPath}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>Delete</c> forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly
+    ///     once, building the path with the currency id.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(id);
+
+        Assert.That(result, Is.SameAs(response));
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedPath}/{id}"));
+        await ConnectionHandler.Received(1).Delete(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/BexioApiNet.UnitTests/Accounting/ManualEntryServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/ManualEntryServiceTests.cs
@@ -287,6 +287,316 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
         Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
     }
 
+    /// <summary>
+    ///     Put forwards the payload and builds the path <c>{endpoint}/{manualEntryId}</c> via
+    ///     <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}" />.
+    /// </summary>
+    [Test]
+    public async Task Put_CallsPutAsyncWithExpectedPath()
+    {
+        const int manualEntryId = 42;
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<ManualEntry> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PutAsync<ManualEntry, ManualEntryUpdate>(
+                Arg.Any<ManualEntryUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Put(manualEntryId, payload);
+
+        await ConnectionHandler.Received(1).PutAsync<ManualEntry, ManualEntryUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{manualEntryId}",
+            Arg.Any<CancellationToken>());
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{manualEntryId}"));
+    }
+
+    /// <summary>
+    ///     Put returns the <see cref="ApiResult{T}" /> produced by the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Put_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<ManualEntry> { IsSuccess = true };
+        ConnectionHandler
+            .PutAsync<ManualEntry, ManualEntryUpdate>(
+                Arg.Any<ManualEntryUpdate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Put(1, payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     GetNextRefNr builds <c>{endpoint}/next_ref_nr</c> and forwards to
+    ///     <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetNextRefNr_CallsGetAsyncWithExpectedPath()
+    {
+        var response = new ApiResult<ManualEntryNextRefNr> { IsSuccess = true };
+        ConnectionHandler
+            .GetAsync<ManualEntryNextRefNr>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetNextRefNr();
+
+        await ConnectionHandler.Received(1).GetAsync<ManualEntryNextRefNr>(
+            $"{ExpectedEndpoint}/next_ref_nr",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetFiles (no auto-page) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once
+    ///     with the expected compound-entry file listing path and does not trigger FetchAll.
+    /// </summary>
+    [Test]
+    public async Task GetFiles_WithoutAutoPage_CallsGetAsyncWithExpectedPath()
+    {
+        const int manualEntryId = 42;
+        var response = new ApiResult<List<ManualEntryFile>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<ManualEntryFile>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetFiles(manualEntryId);
+
+        await ConnectionHandler.Received(1).GetAsync<List<ManualEntryFile>?>(
+            $"{ExpectedEndpoint}/{manualEntryId}/files",
+            null,
+            Arg.Any<CancellationToken>());
+        await ConnectionHandler.DidNotReceive().FetchAll<ManualEntryFile>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetFiles (autoPage = true) triggers
+    ///     <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when the <c>X-Total-Count</c>
+    ///     header is present and the initial response only returned a page.
+    /// </summary>
+    [Test]
+    public async Task GetFiles_WithAutoPage_CallsFetchAll()
+    {
+        const int manualEntryId = 42;
+        const int totalResults = 10;
+        var initialData = new List<ManualEntryFile> { BuildManualEntryFile(1), BuildManualEntryFile(2) };
+        var initial = new ApiResult<List<ManualEntryFile>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<ManualEntryFile>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<ManualEntryFile>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.GetFiles(manualEntryId, autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<ManualEntryFile>(
+            initialData.Count,
+            totalResults,
+            $"{ExpectedEndpoint}/{manualEntryId}/files",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetFileById builds <c>{endpoint}/{manualEntryId}/files/{fileId}</c> and forwards via
+    ///     <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task GetFileById_CallsGetAsyncWithExpectedPath()
+    {
+        const int manualEntryId = 42;
+        const int fileId = 7;
+        var response = new ApiResult<ManualEntryFileDetail> { IsSuccess = true };
+        ConnectionHandler
+            .GetAsync<ManualEntryFileDetail>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetFileById(manualEntryId, fileId);
+
+        await ConnectionHandler.Received(1).GetAsync<ManualEntryFileDetail>(
+            $"{ExpectedEndpoint}/{manualEntryId}/files/{fileId}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetEntryFiles builds <c>{endpoint}/{manualEntryId}/entries/{entryId}/files</c> and forwards
+    ///     via <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task GetEntryFiles_CallsGetAsyncWithExpectedPath()
+    {
+        const int manualEntryId = 42;
+        const int entryId = 7;
+        var response = new ApiResult<List<ManualEntryFile>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<ManualEntryFile>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetEntryFiles(manualEntryId, entryId);
+
+        await ConnectionHandler.Received(1).GetAsync<List<ManualEntryFile>?>(
+            $"{ExpectedEndpoint}/{manualEntryId}/entries/{entryId}/files",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetEntryFiles (autoPage = true) triggers
+    ///     <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> on the entry-files path.
+    /// </summary>
+    [Test]
+    public async Task GetEntryFiles_WithAutoPage_CallsFetchAllOnEntryPath()
+    {
+        const int manualEntryId = 42;
+        const int entryId = 7;
+        const int totalResults = 8;
+        var initialData = new List<ManualEntryFile> { BuildManualEntryFile(1) };
+        var initial = new ApiResult<List<ManualEntryFile>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<ManualEntryFile>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<ManualEntryFile>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.GetEntryFiles(manualEntryId, entryId, autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<ManualEntryFile>(
+            initialData.Count,
+            totalResults,
+            $"{ExpectedEndpoint}/{manualEntryId}/entries/{entryId}/files",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetEntryFileById builds <c>{endpoint}/{manualEntryId}/entries/{entryId}/files/{fileId}</c>
+    ///     and forwards via <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task GetEntryFileById_CallsGetAsyncWithExpectedPath()
+    {
+        const int manualEntryId = 42;
+        const int entryId = 7;
+        const int fileId = 3;
+        var response = new ApiResult<ManualEntryFileDetail> { IsSuccess = true };
+        ConnectionHandler
+            .GetAsync<ManualEntryFileDetail>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetEntryFileById(manualEntryId, entryId, fileId);
+
+        await ConnectionHandler.Received(1).GetAsync<ManualEntryFileDetail>(
+            $"{ExpectedEndpoint}/{manualEntryId}/entries/{entryId}/files/{fileId}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     DeleteFile builds the request path <c>{endpoint}/{manualEntryId}/files/{fileId}</c> and
+    ///     forwards to <see cref="IBexioConnectionHandler.Delete" />.
+    /// </summary>
+    [Test]
+    public async Task DeleteFile_CallsDeleteWithExpectedPath()
+    {
+        const int manualEntryId = 42;
+        const int fileId = 7;
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.DeleteFile(manualEntryId, fileId);
+
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{manualEntryId}/files/{fileId}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     DeleteEntryFile builds the request path
+    ///     <c>{endpoint}/{manualEntryId}/entries/{entryId}/files/{fileId}</c> and forwards to
+    ///     <see cref="IBexioConnectionHandler.Delete" />.
+    /// </summary>
+    [Test]
+    public async Task DeleteEntryFile_CallsDeleteWithExpectedPath()
+    {
+        const int manualEntryId = 42;
+        const int entryId = 7;
+        const int fileId = 3;
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.DeleteEntryFile(manualEntryId, entryId, fileId);
+
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{manualEntryId}/entries/{entryId}/files/{fileId}",
+            Arg.Any<CancellationToken>());
+    }
+
     private static ManualEntryEntryCreate BuildCreatePayload()
     {
         return new ManualEntryEntryCreate(
@@ -294,6 +604,16 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
             new DateOnly(2025, 1, 1),
             "REF-1",
             []);
+    }
+
+    private static ManualEntryUpdate BuildUpdatePayload()
+    {
+        return new ManualEntryUpdate(
+            ManualEntryType.manual_single_entry,
+            new DateOnly(2025, 1, 1),
+            "REF-1",
+            [],
+            null);
     }
 
     private static ManualEntry BuildManualEntry(int id)
@@ -309,5 +629,22 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
             [],
             null,
             string.Empty);
+    }
+
+    private static ManualEntryFile BuildManualEntryFile(int id)
+    {
+        return new ManualEntryFile(
+            id,
+            Guid.NewGuid().ToString(),
+            $"file-{id}.pdf",
+            1024,
+            "pdf",
+            "application/pdf",
+            null,
+            1,
+            false,
+            null,
+            false,
+            DateTime.UtcNow);
     }
 }

--- a/tests/BexioApiNet.UnitTests/Accounting/ReportServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/ReportServiceTests.cs
@@ -1,0 +1,162 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Accounting.Reports;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.UnitTests.Accounting;
+
+/// <summary>
+/// Offline unit tests for <see cref="ReportService"/>. Verifies the connector
+/// builds the right request path, forwards query parameters and cancellation
+/// tokens, and returns the connection handler's <see cref="ApiResult{T}"/>
+/// unchanged.
+/// </summary>
+[TestFixture]
+public sealed class ReportServiceTests : ServiceTestBase
+{
+    private const string ExpectedPath = "3.0/accounting/journal";
+
+    /// <summary>
+    /// With no parameters the service hits <c>3.0/accounting/journal</c> exactly
+    /// once with a <see langword="null"/> query parameter and returns the
+    /// connection handler's <see cref="ApiResult{T}"/> as-is.
+    /// </summary>
+    [Test]
+    public async Task GetJournal_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
+    {
+        var expected = new ApiResult<List<Journal>>
+        {
+            IsSuccess = true,
+            Data = [NewJournal(1)]
+        };
+        ConnectionHandler
+            .GetAsync<List<Journal>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new ReportService(ConnectionHandler);
+
+        var result = await service.GetJournal();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<Journal>>(
+            ExpectedPath,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Supplied query parameters must be forwarded to the connection handler
+    /// so date-range / account-uuid filters reach the Bexio endpoint.
+    /// </summary>
+    [Test]
+    public async Task GetJournal_WithQueryParameters_ForwardsThemToConnectionHandler()
+    {
+        var query = new QueryParameterJournal(
+            From: new DateOnly(2026, 1, 1),
+            To: new DateOnly(2026, 12, 31),
+            AccountUuid: "d591c997-5e88-486b-8fca-48dfd984d45d",
+            Limit: 500,
+            Offset: 0);
+        ConnectionHandler
+            .GetAsync<List<Journal>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Journal>> { IsSuccess = true, Data = [] }));
+
+        var service = new ReportService(ConnectionHandler);
+
+        await service.GetJournal(query);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Journal>>(
+            ExpectedPath,
+            query.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller must be forwarded to the
+    /// connection handler so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task GetJournal_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<Journal>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Journal>> { IsSuccess = true, Data = [] }));
+
+        var service = new ReportService(ConnectionHandler);
+
+        await service.GetJournal(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Journal>>(
+            ExpectedPath,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// A failing <see cref="ApiResult{T}"/> from the connection handler must
+    /// surface to the caller untouched — the service may not swallow errors.
+    /// </summary>
+    [Test]
+    public async Task GetJournal_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var apiError = new ApiError(ErrorCode: 404, Message: "not found", Errors: new object());
+        var response = new ApiResult<List<Journal>>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.NotFound,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<List<Journal>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new ReportService(ConnectionHandler);
+
+        var result = await service.GetJournal();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    private static Journal NewJournal(int id) =>
+        new(
+            Id: id,
+            RefId: 13,
+            RefUuid: $"uuid-{id}",
+            RefClass: "KbInvoice",
+            Date: new DateTime(2026, 2, 17, 0, 0, 0, DateTimeKind.Utc),
+            DebitAccountId: 77,
+            CreditAccountId: 139,
+            Description: "E2E description",
+            Amount: 328.25m,
+            CurrencyId: 1,
+            CurrencyFactor: 1m,
+            BaseCurrencyId: 1,
+            BaseCurrencyAmount: 328.25m);
+}

--- a/tests/BexioApiNet.UnitTests/Accounting/TaxServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/TaxServiceTests.cs
@@ -116,6 +116,156 @@ public sealed class TaxServiceTests : ServiceTestBase
         Assert.That(result, Is.SameAs(response));
     }
 
+    /// <summary>
+    /// GetById builds the request path with the tax id appended to the endpoint
+    /// root and forwards a single <c>GetAsync</c> call to the connection handler
+    /// with a <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithExpectedPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<Tax>
+        {
+            IsSuccess = true,
+            Data = NewTax(id)
+        };
+        ConnectionHandler
+            .GetAsync<Tax>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new TaxService(ConnectionHandler);
+
+        var result = await service.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<Tax>(
+            $"{ExpectedPath}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// GetById forwards the caller-supplied <see cref="CancellationToken"/> so
+    /// cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task GetById_ForwardsCancellationTokenToConnectionHandler()
+    {
+        const int id = 7;
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<Tax>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<Tax> { IsSuccess = true, Data = NewTax(id) }));
+
+        var service = new TaxService(ConnectionHandler);
+
+        await service.GetById(id, cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<Tax>(
+            $"{ExpectedPath}/{id}",
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// A failing <see cref="ApiResult{T}"/> from the connection handler must
+    /// surface to the caller untouched — the service may not swallow errors.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var apiError = new ApiError(ErrorCode: 404, Message: "not found", Errors: new object());
+        var response = new ApiResult<Tax>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.NotFound,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<Tax>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new TaxService(ConnectionHandler);
+
+        var result = await service.GetById(99);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Delete forwards a single call to <see cref="IBexioConnectionHandler.Delete"/>
+    /// with a path built from the endpoint root and the tax id, returning the
+    /// connection handler's <see cref="ApiResult{T}"/> as-is.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithExpectedPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new TaxService(ConnectionHandler);
+
+        var result = await service.Delete(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedPath}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete forwards the caller-supplied <see cref="CancellationToken"/> so
+    /// cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Delete_ForwardsCancellationTokenToConnectionHandler()
+    {
+        const int id = 7;
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<object> { IsSuccess = true }));
+
+        var service = new TaxService(ConnectionHandler);
+
+        await service.Delete(id, cts.Token);
+
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedPath}/{id}",
+            cts.Token);
+    }
+
+    /// <summary>
+    /// A failing <see cref="ApiResult{T}"/> (e.g. a 409 Conflict when the tax is
+    /// referenced elsewhere) must propagate to the caller without mutation.
+    /// </summary>
+    [Test]
+    public async Task Delete_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var apiError = new ApiError(ErrorCode: 409, Message: "Conflict", Errors: new object());
+        var response = new ApiResult<object>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.Conflict,
+            Data = null
+        };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new TaxService(ConnectionHandler);
+
+        var result = await service.Delete(1);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
     private static Tax NewTax(int id) =>
         new(
             Id: id,

--- a/tests/BexioApiNet.UnitTests/Accounting/VatPeriodServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/VatPeriodServiceTests.cs
@@ -1,0 +1,322 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Accounting.VatPeriods;
+using BexioApiNet.Abstractions.Models.Accounting.VatPeriods.Enums;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Accounting;
+
+namespace BexioApiNet.UnitTests.Accounting;
+
+/// <summary>
+/// Offline unit tests for <see cref="VatPeriodService"/>. Verify the connector
+/// builds the right request path (list and by-id), forwards
+/// <see cref="QueryParameter"/>s, and triggers <c>FetchAll</c> only when
+/// <c>autoPage</c> is requested and the response actually carries a
+/// <c>X-Total-Count</c> header.
+/// </summary>
+[TestFixture]
+public sealed class VatPeriodServiceTests : ServiceTestBase
+{
+    private const string ExpectedPath = "3.0/accounting/vat_periods";
+
+    /// <summary>
+    /// With no parameters, the service forwards a single <c>GetAsync</c> call to
+    /// <c>3.0/accounting/vat_periods</c> with a <see langword="null"/> query parameter
+    /// and never touches <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<VatPeriod>>
+        {
+            IsSuccess = true,
+            Data = [NewVatPeriod(1)]
+        };
+        ConnectionHandler
+            .GetAsync<List<VatPeriod>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        var result = await service.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<VatPeriod>>(
+            ExpectedPath,
+            null,
+            Arg.Any<CancellationToken>());
+        await ConnectionHandler.DidNotReceive().FetchAll<VatPeriod>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When a <see cref="QueryParameterVatPeriod"/> is supplied, its inner
+    /// <see cref="QueryParameter"/> instance is forwarded to the connection
+    /// handler verbatim — the service must not rewrap or substitute it.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterVatPeriod(Limit: 50, Offset: 100);
+        ConnectionHandler
+            .GetAsync<List<VatPeriod>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<VatPeriod>> { IsSuccess = true, Data = [] }));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        await service.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<VatPeriod>>(
+            ExpectedPath,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When <c>autoPage</c> is on and the first response advertises a
+    /// <c>X-Total-Count</c> header, the service must call <c>FetchAll</c> with
+    /// the count of already-fetched items, the total, the same path, and the
+    /// same query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
+    {
+        var firstVatPeriod = NewVatPeriod(1);
+        var firstPage = new ApiResult<List<VatPeriod>>
+        {
+            IsSuccess = true,
+            Data = [firstVatPeriod],
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                [ApiHeaderNames.TotalResults] = 3
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<VatPeriod>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(firstPage));
+        var remaining = new List<VatPeriod> { NewVatPeriod(2), NewVatPeriod(3) };
+        ConnectionHandler
+            .FetchAll<VatPeriod>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(remaining));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        var result = await service.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<VatPeriod>(
+            1,
+            3,
+            ExpectedPath,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result.Data, Has.Count.EqualTo(3));
+        Assert.That(result.Data, Is.EquivalentTo(new[] { firstVatPeriod, remaining[0], remaining[1] }));
+    }
+
+    /// <summary>
+    /// When <c>autoPage</c> is requested but the response carries no
+    /// <c>X-Total-Count</c> header, the service must not invoke <c>FetchAll</c>
+    /// — there is nothing more to fetch.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
+    {
+        var response = new ApiResult<List<VatPeriod>>
+        {
+            IsSuccess = true,
+            Data = [NewVatPeriod(1)],
+            ResponseHeaders = new Dictionary<string, int?>()
+        };
+        ConnectionHandler
+            .GetAsync<List<VatPeriod>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        var result = await service.Get(autoPage: true);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.DidNotReceive().FetchAll<VatPeriod>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A failing <see cref="ApiResult{T}"/> from the connection handler must
+    /// surface to the caller untouched — the service may not swallow errors.
+    /// </summary>
+    [Test]
+    public async Task Get_WhenConnectionHandlerReturnsFailure_PropagatesApiResultUnchanged()
+    {
+        var apiError = new ApiError(ErrorCode: 500, Message: "boom", Errors: new object());
+        var response = new ApiResult<List<VatPeriod>>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.InternalServerError,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<List<VatPeriod>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        var result = await service.Get(autoPage: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(response));
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ApiError, Is.SameAs(apiError));
+            Assert.That(result.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.InternalServerError));
+            Assert.That(result.Data, Is.Null);
+        });
+        await ConnectionHandler.DidNotReceive().FetchAll<VatPeriod>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller must be forwarded to the
+    /// connection handler so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<VatPeriod>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<VatPeriod>> { IsSuccess = true, Data = [] }));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        await service.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<VatPeriod>>(
+            ExpectedPath,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// <c>GetById</c> must call <c>GetAsync</c> exactly once at
+    /// <c>3.0/accounting/vat_periods/{id}</c> with a <see langword="null"/> query
+    /// parameter and return the connection handler's <see cref="ApiResult{T}"/>
+    /// as-is.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithExpectedPath()
+    {
+        var expected = new ApiResult<VatPeriod>
+        {
+            IsSuccess = true,
+            Data = NewVatPeriod(42)
+        };
+        ConnectionHandler
+            .GetAsync<VatPeriod>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        var result = await service.GetById(42);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<VatPeriod>(
+            $"{ExpectedPath}/42",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// <c>GetById</c> must forward the caller's cancellation token to the
+    /// connection handler so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task GetById_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<VatPeriod>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<VatPeriod> { IsSuccess = true, Data = NewVatPeriod(7) }));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        await service.GetById(7, cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<VatPeriod>(
+            $"{ExpectedPath}/7",
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// A failing <see cref="ApiResult{T}"/> from the connection handler must
+    /// surface to the <c>GetById</c> caller untouched.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var apiError = new ApiError(ErrorCode: 404, Message: "not found", Errors: new object());
+        var response = new ApiResult<VatPeriod>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.NotFound,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<VatPeriod>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new VatPeriodService(ConnectionHandler);
+
+        var result = await service.GetById(999);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    private static VatPeriod NewVatPeriod(int id) =>
+        new(
+            Id: id,
+            Start: new DateOnly(2018, 1, 1),
+            End: new DateOnly(2018, 3, 31),
+            Type: VatPeriodType.quarter,
+            Status: VatPeriodStatus.closed,
+            ClosedAt: new DateOnly(2018, 4, 28));
+}

--- a/tests/BexioApiNet.UnitTests/Banking/BankAccountServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Banking/BankAccountServiceTests.cs
@@ -168,6 +168,85 @@ public sealed class BankAccountServiceTests : ServiceTestBase
         Assert.That(result, Is.SameAs(response));
     }
 
+    /// <summary>
+    /// <c>GetById</c> hits <c>3.0/banking/accounts/{id}</c> exactly once with a
+    /// <see langword="null"/> query parameter and returns the connection
+    /// handler's <see cref="ApiResult{T}"/> as-is.
+    /// </summary>
+    [Test]
+    public async Task GetById_WithId_CallsGetAsyncOnceWithExpectedPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<BankAccountGet>
+        {
+            IsSuccess = true,
+            Data = NewBankAccount(id)
+        };
+        ConnectionHandler
+            .GetAsync<BankAccountGet>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new BankAccountService(ConnectionHandler);
+
+        var result = await service.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<BankAccountGet>(
+            $"{ExpectedPath}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied to <c>GetById</c> must be forwarded to
+    /// the connection handler so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task GetById_ForwardsCancellationTokenToConnectionHandler()
+    {
+        const int id = 7;
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<BankAccountGet>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<BankAccountGet> { IsSuccess = true, Data = NewBankAccount(id) }));
+
+        var service = new BankAccountService(ConnectionHandler);
+
+        await service.GetById(id, cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<BankAccountGet>(
+            $"{ExpectedPath}/{id}",
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// A failing <see cref="ApiResult{T}"/> from the connection handler must
+    /// surface to the <c>GetById</c> caller untouched.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        const int id = 99;
+        var apiError = new ApiError(ErrorCode: 404, Message: "not found", Errors: new object());
+        var response = new ApiResult<BankAccountGet>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.NotFound,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<BankAccountGet>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new BankAccountService(ConnectionHandler);
+
+        var result = await service.GetById(id);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
     private static BankAccountGet NewBankAccount(int id) =>
         new(
             Id: id,

--- a/tests/BexioApiNet.UnitTests/Banking/OutgoingPaymentServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Banking/OutgoingPaymentServiceTests.cs
@@ -1,0 +1,333 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Enums;
+using BexioApiNet.Abstractions.Models.Banking.OutgoingPayments.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.UnitTests.Banking;
+
+/// <summary>
+/// Offline unit tests for <see cref="OutgoingPaymentService"/>. Each test asserts that the
+/// service forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected
+/// verb, path, payload, and query parameters, and returns the handler's
+/// <see cref="ApiResult{T}"/> unchanged. No network, no filesystem.
+/// </summary>
+[TestFixture]
+public sealed class OutgoingPaymentServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "4.0/purchase/outgoing-payments";
+
+    private OutgoingPaymentService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="OutgoingPaymentService"/> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new OutgoingPaymentService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// Get forwards the caller's <see cref="QueryParameterOutgoingPayment.QueryParameter"/>
+    /// to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> exactly once at the
+    /// <c>4.0/purchase/outgoing-payments</c> path.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsyncWithExpectedPathAndQueryParameter()
+    {
+        var queryParameter = new QueryParameterOutgoingPayment(Guid.NewGuid());
+        var response = new ApiResult<OutgoingPaymentListResponse>
+        {
+            IsSuccess = true,
+            Data = new OutgoingPaymentListResponse([], new OutgoingPaymentPaging(1, 100, 1, 0))
+        };
+        ConnectionHandler
+            .GetAsync<OutgoingPaymentListResponse>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<OutgoingPaymentListResponse>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get returns the <see cref="ApiResult{T}"/> produced by the connection handler
+    /// unchanged — the service may not rewrap or mutate the result.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResultFromConnectionHandler()
+    {
+        var queryParameter = new QueryParameterOutgoingPayment(Guid.NewGuid());
+        var response = new ApiResult<OutgoingPaymentListResponse>
+        {
+            IsSuccess = true,
+            Data = new OutgoingPaymentListResponse([], new OutgoingPaymentPaging(1, 100, 1, 0))
+        };
+        ConnectionHandler
+            .GetAsync<OutgoingPaymentListResponse>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get(queryParameter);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Get forwards the caller-supplied cancellation token to the connection handler so
+    /// cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var queryParameter = new QueryParameterOutgoingPayment(Guid.NewGuid());
+        ConnectionHandler
+            .GetAsync<OutgoingPaymentListResponse>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<OutgoingPaymentListResponse>
+            {
+                IsSuccess = true,
+                Data = new OutgoingPaymentListResponse([], new OutgoingPaymentPaging(1, 100, 1, 0))
+            });
+
+        await _sut.Get(queryParameter, cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<OutgoingPaymentListResponse>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with the
+    /// payment id appended to the endpoint root and a <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<OutgoingPayment>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<OutgoingPayment> { IsSuccess = true });
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).GetAsync<OutgoingPayment>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// GetById returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsApiResultFromConnectionHandler()
+    {
+        var id = Guid.NewGuid();
+        var response = new ApiResult<OutgoingPayment> { IsSuccess = true };
+        ConnectionHandler
+            .GetAsync<OutgoingPayment>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Create forwards the <see cref="OutgoingPaymentCreate"/> payload and endpoint
+    /// path to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithPayloadAndPath()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<OutgoingPayment> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<OutgoingPayment, OutgoingPaymentCreate>(
+                Arg.Any<OutgoingPaymentCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<OutgoingPayment, OutgoingPaymentCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Create_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<OutgoingPayment> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<OutgoingPayment, OutgoingPaymentCreate>(
+                Arg.Any<OutgoingPaymentCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Update calls <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}"/> with the
+    /// <see cref="OutgoingPaymentUpdate"/> payload and the endpoint root. The target payment
+    /// id travels in the request body (<see cref="OutgoingPaymentUpdate.PaymentId"/>) — the
+    /// Bexio v4.0 PUT endpoint has no <c>{id}</c> segment in the URL.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsyncWithPayloadAndRootPath()
+    {
+        var payload = BuildUpdatePayload();
+        string? capturedPath = null;
+        ConnectionHandler
+            .PutAsync<OutgoingPayment, OutgoingPaymentUpdate>(
+                Arg.Any<OutgoingPaymentUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<OutgoingPayment> { IsSuccess = true });
+
+        await _sut.Update(payload);
+
+        Assert.That(capturedPath, Is.EqualTo(ExpectedEndpoint));
+        await ConnectionHandler.Received(1).PutAsync<OutgoingPayment, OutgoingPaymentUpdate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Update returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Update_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<OutgoingPayment> { IsSuccess = true };
+        ConnectionHandler
+            .PutAsync<OutgoingPayment, OutgoingPaymentUpdate>(
+                Arg.Any<OutgoingPaymentUpdate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Update(payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Delete calls <see cref="IBexioConnectionHandler.Delete"/> with the payment id
+    /// appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<object> { IsSuccess = true });
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Delete_ReturnsApiResultFromConnectionHandler()
+    {
+        var id = Guid.NewGuid();
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(id);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    private static OutgoingPaymentCreate BuildCreatePayload() =>
+        new(
+            BillId: Guid.NewGuid(),
+            PaymentType: OutgoingPaymentType.IBAN,
+            ExecutionDate: new DateOnly(2026, 4, 20),
+            Amount: 100.00m,
+            CurrencyCode: "CHF",
+            ExchangeRate: 1m,
+            SenderBankAccountId: 1,
+            IsSalaryPayment: false);
+
+    private static OutgoingPaymentUpdate BuildUpdatePayload() =>
+        new(
+            PaymentId: Guid.NewGuid(),
+            ExecutionDate: new DateOnly(2026, 4, 20),
+            Amount: 150.00m,
+            IsSalaryPayment: false);
+}

--- a/tests/BexioApiNet.UnitTests/Banking/PaymentServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Banking/PaymentServiceTests.cs
@@ -1,0 +1,276 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.Payments;
+using BexioApiNet.Abstractions.Models.Banking.Payments.Enums;
+using BexioApiNet.Abstractions.Models.Banking.Payments.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.UnitTests.Banking;
+
+/// <summary>
+/// Offline unit tests for <see cref="PaymentService"/>. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected verb, path,
+/// and payload, and that the <see cref="ApiResult{T}"/> produced by the handler flows back
+/// to the caller unchanged.
+/// </summary>
+[TestFixture]
+public sealed class PaymentServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "4.0/banking/payments";
+
+    private PaymentService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="PaymentService"/> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new PaymentService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> once
+    /// with the expected endpoint and a <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncWithExpectedPath()
+    {
+        var expected = new ApiResult<List<Payment>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Payment>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<Payment>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get forwards the inner <see cref="QueryParameter"/> from the supplied
+    /// <see cref="QueryParameterPayment"/> to the connection handler verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterThrough()
+    {
+        var queryParameter = new QueryParameterPayment(Page: 2, PerPage: 50, FilterBy: "status=open");
+        ConnectionHandler
+            .GetAsync<List<Payment>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<List<Payment>?> { IsSuccess = true, Data = [] });
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Payment>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get forwards the caller-supplied cancellation token to the connection handler
+    /// so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<Payment>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<List<Payment>?> { IsSuccess = true, Data = [] });
+
+        await _sut.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Payment>?>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with the
+    /// path composed from the endpoint root and the payment UUID.
+    /// </summary>
+    [Test]
+    public async Task GetById_PathContainsPaymentId()
+    {
+        var paymentId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Payment>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Payment> { IsSuccess = true });
+
+        await _sut.GetById(paymentId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{paymentId}"));
+        await ConnectionHandler.Received(1).GetAsync<Payment>(
+            Arg.Any<string>(),
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// GetById returns the <see cref="ApiResult{T}"/> produced by the connection handler
+    /// without any additional processing.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsApiResultFromConnectionHandler()
+    {
+        var paymentId = Guid.NewGuid();
+        var response = new ApiResult<Payment> { IsSuccess = true };
+        ConnectionHandler
+            .GetAsync<Payment>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.GetById(paymentId);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Create forwards the payload and the expected endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<Payment> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Payment, PaymentCreate>(
+                Arg.Any<PaymentCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).PostAsync<Payment, PaymentCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Cancel POSTs to <c>{id}/cancel</c> via
+    /// <see cref="IBexioConnectionHandler.PostActionAsync{TResult}"/> — no request body is sent
+    /// and the endpoint suffix must be <c>cancel</c>.
+    /// </summary>
+    [Test]
+    public async Task Cancel_CallsPostActionAsyncOnCancelPath()
+    {
+        var paymentId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync<Payment>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Payment> { IsSuccess = true });
+
+        await _sut.Cancel(paymentId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{paymentId}/cancel"));
+        await ConnectionHandler.Received(1).PostActionAsync<Payment>(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Update forwards the payload and the expected endpoint path with the payment UUID to
+    /// <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsync()
+    {
+        var paymentId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var payload = new PaymentUpdate(Amount: 42.5m);
+        string? capturedPath = null;
+        ConnectionHandler
+            .PutAsync<Payment, PaymentUpdate>(
+                Arg.Any<PaymentUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Payment> { IsSuccess = true });
+
+        await _sut.Update(paymentId, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{paymentId}"));
+        await ConnectionHandler.Received(1).PutAsync<Payment, PaymentUpdate>(
+            payload,
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete calls <see cref="IBexioConnectionHandler.Delete"/> with the path composed from
+    /// the endpoint root and the payment UUID, and returns the handler's result unchanged.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteOnIdPath()
+    {
+        var paymentId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        string? capturedPath = null;
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(paymentId);
+
+        Assert.That(result, Is.SameAs(response));
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{paymentId}"));
+    }
+
+    private static PaymentCreate BuildCreatePayload() =>
+        new(
+            Type: PaymentType.iban,
+            AccountId: Guid.Parse("55555555-5555-5555-5555-555555555555"),
+            Recipient: new PaymentRecipient(
+                Name: "Alice Example",
+                Iban: "CH9300762011623852957",
+                Address: new PaymentAddress(
+                    StreetName: "Bahnhofstrasse",
+                    HouseNumber: "1",
+                    Zip: "8001",
+                    City: "Zurich",
+                    CountryCode: "CH")),
+            Amount: 100m,
+            Currency: "CHF",
+            ExecutionDate: new DateOnly(2026, 5, 1),
+            IsSalary: false);
+}

--- a/tests/BexioApiNet.UnitTests/Banking/PaymentTypeServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Banking/PaymentTypeServiceTests.cs
@@ -1,0 +1,297 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Net;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Banking.PaymentTypes;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Banking;
+
+namespace BexioApiNet.UnitTests.Banking;
+
+/// <summary>
+///     Offline unit tests for <see cref="PaymentTypeService" />. The service is a
+///     thin pass-through over <see cref="IBexioConnectionHandler.GetAsync{T}" /> and
+///     <see cref="IBexioConnectionHandler.PostSearchAsync{T}" />, so verification
+///     focuses on path, verb, body, query parameter, and pass-through semantics.
+/// </summary>
+[TestFixture]
+public sealed class PaymentTypeServiceTests : ServiceTestBase
+{
+    private const string ExpectedListPath = "2.0/payment_type";
+    private const string ExpectedSearchPath = "2.0/payment_type/search";
+
+    /// <summary>
+    ///     With no parameters the service hits <c>2.0/payment_type</c> exactly once
+    ///     with a <see langword="null" /> query parameter and returns the connection
+    ///     handler's <see cref="ApiResult{T}" /> as-is.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
+    {
+        var expected = new ApiResult<List<PaymentType>>
+        {
+            IsSuccess = true,
+            Data = [new PaymentType(1, "Cash")]
+        };
+        ConnectionHandler
+            .GetAsync<List<PaymentType>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        var result = await service.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<PaymentType>>(
+            ExpectedListPath,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterPaymentType" /> is supplied, its inner
+    ///     <see cref="QueryParameter" /> instance is forwarded to the connection
+    ///     handler verbatim — the service must not rewrap or substitute it.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterPaymentType(20, 40);
+        ConnectionHandler
+            .GetAsync<List<PaymentType>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<PaymentType>> { IsSuccess = true, Data = [] }));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        await service.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<PaymentType>>(
+            ExpectedListPath,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     The service must never invoke <c>FetchAll</c>: <see cref="PaymentTypeService" />
+    ///     does not implement auto-paging even when <c>autoPage</c> is set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_DoesNotCallFetchAll()
+    {
+        var response = new ApiResult<List<PaymentType>>
+        {
+            IsSuccess = true,
+            Data = [new PaymentType(1, "Cash")]
+        };
+        ConnectionHandler
+            .GetAsync<List<PaymentType>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        await service.Get(autoPage: true);
+
+        await ConnectionHandler.DidNotReceive().FetchAll<PaymentType>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     The cancellation token supplied by the caller must be forwarded to the
+    ///     connection handler so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<PaymentType>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<PaymentType>> { IsSuccess = true, Data = [] }));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        await service.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<PaymentType>>(
+            ExpectedListPath,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    ///     A failing <see cref="ApiResult{T}" /> from the connection handler must
+    ///     surface to the caller untouched — the service may not swallow errors.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var apiError = new ApiError(403, "forbidden", new object());
+        var response = new ApiResult<List<PaymentType>>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = HttpStatusCode.Forbidden,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<List<PaymentType>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        var result = await service.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     With a search body and no query parameter, the service POSTs the criteria
+    ///     list to <c>2.0/payment_type/search</c> with a <see langword="null" /> query
+    ///     parameter and returns the connection handler's <see cref="ApiResult{T}" />
+    ///     unchanged.
+    /// </summary>
+    [Test]
+    public async Task Search_WithCriteria_CallsPostSearchAsyncWithExpectedPath()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Cash", Criteria = "=" }
+        };
+        var expected = new ApiResult<List<PaymentType>>
+        {
+            IsSuccess = true,
+            Data = [new PaymentType(1, "Cash")]
+        };
+        ConnectionHandler
+            .PostSearchAsync<PaymentType>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        var result = await service.Search(criteria);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostSearchAsync<PaymentType>(
+            criteria,
+            ExpectedSearchPath,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterPaymentType" /> is supplied to
+    ///     <see cref="PaymentTypeService.Search" />, its inner <see cref="QueryParameter" />
+    ///     must flow to the connection handler verbatim so pagination and sort flags
+    ///     are preserved on the wire.
+    /// </summary>
+    [Test]
+    public async Task Search_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Bank", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterPaymentType(10, 5);
+        ConnectionHandler
+            .PostSearchAsync<PaymentType>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<PaymentType>> { IsSuccess = true, Data = [] }));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        await service.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<PaymentType>(
+            criteria,
+            ExpectedSearchPath,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     The cancellation token supplied by the caller to <see cref="PaymentTypeService.Search" />
+    ///     must be forwarded to the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Search_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Cash", Criteria = "=" }
+        };
+        ConnectionHandler
+            .PostSearchAsync<PaymentType>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<PaymentType>> { IsSuccess = true, Data = [] }));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        await service.Search(criteria, cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<PaymentType>(
+            criteria,
+            ExpectedSearchPath,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    ///     A failing <see cref="ApiResult{T}" /> from the connection handler must
+    ///     surface to the caller untouched — <see cref="PaymentTypeService.Search" />
+    ///     may not swallow or remap errors.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Nope", Criteria = "=" }
+        };
+        var apiError = new ApiError(400, "bad search", new object());
+        var response = new ApiResult<List<PaymentType>>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = HttpStatusCode.BadRequest,
+            Data = null
+        };
+        ConnectionHandler
+            .PostSearchAsync<PaymentType>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        var result = await service.Search(criteria);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Banking/PaymentTypeServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Banking/PaymentTypeServiceTests.cs
@@ -24,6 +24,7 @@ SOFTWARE.
 */
 
 using System.Net;
+using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Abstractions.Models.Banking.PaymentTypes;
 using BexioApiNet.Models;
@@ -95,16 +96,59 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     The service must never invoke <c>FetchAll</c>: <see cref="PaymentTypeService" />
-    ///     does not implement auto-paging even when <c>autoPage</c> is set.
+    ///     When <c>autoPage</c> is on and the first response advertises a
+    ///     <c>X-Total-Count</c> header, the service must call <c>FetchAll</c> with
+    ///     the count of already-fetched items, the total, the same path, and the
+    ///     same query parameter.
     /// </summary>
     [Test]
-    public async Task Get_WithAutoPage_DoesNotCallFetchAll()
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
+    {
+        var firstItem = new PaymentType(1, "Cash");
+        var firstPage = new ApiResult<List<PaymentType>>
+        {
+            IsSuccess = true,
+            Data = [firstItem],
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                [ApiHeaderNames.TotalResults] = 3
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<PaymentType>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(firstPage));
+        var remaining = new List<PaymentType> { new(2, "Bank Transfer"), new(3, "Credit Card") };
+        ConnectionHandler
+            .FetchAll<PaymentType>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(remaining));
+
+        var service = new PaymentTypeService(ConnectionHandler);
+
+        var result = await service.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<PaymentType>(
+            1,
+            3,
+            ExpectedListPath,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result.Data, Has.Count.EqualTo(3));
+        Assert.That(result.Data, Is.EquivalentTo(new[] { firstItem, remaining[0], remaining[1] }));
+    }
+
+    /// <summary>
+    ///     When <c>autoPage</c> is requested but the response carries no
+    ///     <c>X-Total-Count</c> header, the service must not invoke <c>FetchAll</c>
+    ///     — there is nothing more to fetch.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
     {
         var response = new ApiResult<List<PaymentType>>
         {
             IsSuccess = true,
-            Data = [new PaymentType(1, "Cash")]
+            Data = [new PaymentType(1, "Cash")],
+            ResponseHeaders = new Dictionary<string, int?>()
         };
         ConnectionHandler
             .GetAsync<List<PaymentType>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
@@ -112,8 +156,9 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
 
         var service = new PaymentTypeService(ConnectionHandler);
 
-        await service.Get(autoPage: true);
+        var result = await service.Get(autoPage: true);
 
+        Assert.That(result, Is.SameAs(response));
         await ConnectionHandler.DidNotReceive().FetchAll<PaymentType>(
             Arg.Any<int>(),
             Arg.Any<int>(),

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -1,0 +1,94 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Interfaces.Connectors.Accounting;
+using BexioApiNet.Interfaces.Connectors.Banking;
+using BexioApiNet.Interfaces.Connectors.Contacts;
+
+namespace BexioApiNet.UnitTests;
+
+/// <summary>
+/// Wire-up tests for <see cref="BexioApiClient"/>. Verifies that every connector service
+/// accepted by the aggregate constructor is exposed via a non-null property so downstream
+/// consumers can resolve it through dependency injection.
+/// </summary>
+[Category("Unit")]
+public sealed class BexioApiClientWireUpTests
+{
+    /// <summary>
+    /// Constructing <see cref="BexioApiClient"/> with NSubstitute-provided connectors
+    /// must populate every property on the aggregate. A missing assignment in the
+    /// constructor or a missing property on <see cref="IBexioApiClient"/> will surface
+    /// here as a <c>null</c> property.
+    /// </summary>
+    [Test]
+    public void BexioApiClient_Constructor_AllConnectorPropertiesAreNonNull()
+    {
+        var connectionHandler = Substitute.For<IBexioConnectionHandler>();
+
+        var client = new BexioApiClient(
+            connectionHandler,
+            Substitute.For<IBankAccountService>(),
+            Substitute.For<IAccountService>(),
+            Substitute.For<ICurrencyService>(),
+            Substitute.For<IManualEntryService>(),
+            Substitute.For<ITaxService>(),
+            Substitute.For<IAccountGroupService>(),
+            Substitute.For<IBusinessYearService>(),
+            Substitute.For<ICalendarYearService>(),
+            Substitute.For<IVatPeriodService>(),
+            Substitute.For<IReportService>(),
+            Substitute.For<IPaymentTypeService>(),
+            Substitute.For<IPaymentService>(),
+            Substitute.For<IOutgoingPaymentService>(),
+            Substitute.For<IContactService>(),
+            Substitute.For<IContactGroupService>(),
+            Substitute.For<IContactRelationService>(),
+            Substitute.For<IContactSectorService>(),
+            Substitute.For<IAdditionalAddressService>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.BankingBankAccounts, Is.Not.Null);
+            Assert.That(client.Accounts, Is.Not.Null);
+            Assert.That(client.Currencies, Is.Not.Null);
+            Assert.That(client.AccountingManualEntries, Is.Not.Null);
+            Assert.That(client.Taxes, Is.Not.Null);
+            Assert.That(client.AccountGroups, Is.Not.Null);
+            Assert.That(client.AccountingBusinessYears, Is.Not.Null);
+            Assert.That(client.AccountingCalendarYears, Is.Not.Null);
+            Assert.That(client.AccountingVatPeriods, Is.Not.Null);
+            Assert.That(client.AccountingReports, Is.Not.Null);
+            Assert.That(client.PaymentTypes, Is.Not.Null);
+            Assert.That(client.BankingPayments, Is.Not.Null);
+            Assert.That(client.PurchaseOutgoingPayments, Is.Not.Null);
+            Assert.That(client.Contacts, Is.Not.Null);
+            Assert.That(client.ContactGroups, Is.Not.Null);
+            Assert.That(client.ContactRelations, Is.Not.Null);
+            Assert.That(client.ContactSectors, Is.Not.Null);
+            Assert.That(client.ContactAdditionalAddresses, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Contacts/AdditionalAddressServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Contacts/AdditionalAddressServiceTests.cs
@@ -1,0 +1,322 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses;
+using BexioApiNet.Abstractions.Models.Contacts.AdditionalAddresses.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.UnitTests.Contacts;
+
+/// <summary>
+///     Offline unit tests for <see cref="AdditionalAddressService" />. Each test verifies that the
+///     service forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected
+///     arguments (including the nested <c>contact_id</c> segment) and returns the handler's
+///     result unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class AdditionalAddressServiceTests : ServiceTestBase
+{
+    private const int ContactId = 42;
+    private const int AdditionalAddressId = 7;
+    private const string EndpointRoot = "2.0/contact/42/additional_address";
+
+    private AdditionalAddressService _sut = null!;
+
+    /// <summary>
+    ///     Creates a fresh <see cref="AdditionalAddressService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new AdditionalAddressService(ConnectionHandler);
+    }
+
+    /// <summary>
+    ///     Get forwards the expected nested path to <see cref="IBexioConnectionHandler.GetAsync{T}" />
+    ///     and returns the handler's <see cref="ApiResult{T}" /> unchanged.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsyncWithExpectedPath()
+    {
+        var response = new ApiResult<List<AdditionalAddress>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<AdditionalAddress>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get(ContactId);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).GetAsync<List<AdditionalAddress>?>(
+            EndpointRoot,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get forwards the inner <see cref="QueryParameter" /> from the typed wrapper verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_ForwardsInnerQueryParameter()
+    {
+        var queryParameter = new QueryParameterAdditionalAddress(Limit: 25, Offset: 50);
+        ConnectionHandler
+            .GetAsync<List<AdditionalAddress>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<List<AdditionalAddress>?> { IsSuccess = true, Data = [] });
+
+        await _sut.Get(ContactId, queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<AdditionalAddress>?>(
+            EndpointRoot,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get with <c>autoPage=true</c> triggers <see cref="IBexioConnectionHandler.FetchAll{T}" />
+    ///     when the response carries a non-null <c>X-Total-Count</c> header.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<AdditionalAddress> { BuildAddress(1), BuildAddress(2) };
+        var initial = new ApiResult<List<AdditionalAddress>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<AdditionalAddress>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<AdditionalAddress>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(ContactId, autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<AdditionalAddress>(
+            initialData.Count,
+            totalResults,
+            EndpointRoot,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetById hits the single-resource path with both the contact id and the address id.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithExpectedPath()
+    {
+        var response = new ApiResult<AdditionalAddress> { IsSuccess = true, Data = BuildAddress(AdditionalAddressId) };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<AdditionalAddress>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.GetById(ContactId, AdditionalAddressId);
+
+        Assert.That(result, Is.SameAs(response));
+        Assert.That(capturedPath, Is.EqualTo($"{EndpointRoot}/{AdditionalAddressId}"));
+    }
+
+    /// <summary>
+    ///     Create forwards the payload to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />
+    ///     against the collection path.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithExpectedPathAndPayload()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<AdditionalAddress> { IsSuccess = true, Data = BuildAddress(1) };
+        ConnectionHandler
+            .PostAsync<AdditionalAddress, AdditionalAddressCreate>(
+                Arg.Any<AdditionalAddressCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(ContactId, payload);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).PostAsync<AdditionalAddress, AdditionalAddressCreate>(
+            payload,
+            EndpointRoot,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search hits the nested <c>/search</c> path via
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> with the provided criteria.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsyncWithExpectedPathAndCriteria()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Acme", Criteria = "like" }
+        };
+        var response = new ApiResult<List<AdditionalAddress>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<AdditionalAddress>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Search(ContactId, criteria);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).PostSearchAsync<AdditionalAddress>(
+            criteria,
+            $"{EndpointRoot}/search",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search forwards the optional typed query parameter to the handler (for limit/offset).
+    /// </summary>
+    [Test]
+    public async Task Search_WithQueryParameter_ForwardsInnerQueryParameter()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "city", Value = "Zurich", Criteria = "=" }
+        };
+        var queryParameter = new QueryParameterAdditionalAddress(Limit: 100, Offset: 0);
+        ConnectionHandler
+            .PostSearchAsync<AdditionalAddress>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<List<AdditionalAddress>> { IsSuccess = true, Data = [] });
+
+        await _sut.Search(ContactId, criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<AdditionalAddress>(
+            criteria,
+            $"{EndpointRoot}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update forwards the payload to the single-resource path via the connection handler's
+    ///     update hook. The Bexio edit endpoint uses HTTP <c>POST</c> rather than <c>PUT</c>.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsUpdateWithExpectedPathAndPayload()
+    {
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<AdditionalAddress> { IsSuccess = true, Data = BuildAddress(AdditionalAddressId) };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<AdditionalAddress, AdditionalAddressUpdate>(
+                Arg.Any<AdditionalAddressUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Update(ContactId, AdditionalAddressId, payload);
+
+        Assert.That(result, Is.SameAs(response));
+        Assert.That(capturedPath, Is.EqualTo($"{EndpointRoot}/{AdditionalAddressId}"));
+        await ConnectionHandler.Received(1).PostAsync<AdditionalAddress, AdditionalAddressUpdate>(
+            payload,
+            $"{EndpointRoot}/{AdditionalAddressId}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with both
+    ///     the parent contact id and the address id in the path.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete()
+    {
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(Arg.Do<string>(path => capturedPath = path), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(ContactId, AdditionalAddressId);
+
+        Assert.That(result, Is.SameAs(response));
+        Assert.That(capturedPath, Is.EqualTo($"{EndpointRoot}/{AdditionalAddressId}"));
+    }
+
+    private static AdditionalAddressCreate BuildCreatePayload() => new(
+        Name: "Head Office",
+        NameAddition: "Reception",
+        StreetName: "Walter Street",
+        HouseNumber: "22",
+        AddressAddition: "Building C",
+        Postcode: "9000",
+        City: "St. Gallen",
+        CountryId: 1,
+        Subject: "Additional address",
+        Description: "Internal description");
+
+    private static AdditionalAddressUpdate BuildUpdatePayload() => new(
+        Name: "Head Office",
+        NameAddition: "Reception",
+        StreetName: "Walter Street",
+        HouseNumber: "22",
+        AddressAddition: "Building C",
+        Postcode: "9000",
+        City: "St. Gallen",
+        CountryId: 1,
+        Subject: "Additional address",
+        Description: "Internal description");
+
+    private static AdditionalAddress BuildAddress(int id) => new(
+        Id: id,
+        Name: "Head Office",
+        NameAddition: null,
+        Address: "Walter Street 22",
+        StreetName: "Walter Street",
+        HouseNumber: "22",
+        AddressAddition: null,
+        Postcode: "9000",
+        City: "St. Gallen",
+        CountryId: 1,
+        Subject: "Additional address",
+        Description: null);
+}

--- a/tests/BexioApiNet.UnitTests/Contacts/ContactGroupServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Contacts/ContactGroupServiceTests.cs
@@ -1,0 +1,356 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups;
+using BexioApiNet.Abstractions.Models.Contacts.ContactGroups.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.UnitTests.Contacts;
+
+/// <summary>
+/// Offline unit tests for <see cref="ContactGroupService"/>. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected verb and path,
+/// propagates the response unchanged, and honours the canonical <c>autoPage</c> + <c>X-Total-Count</c>
+/// pagination contract. No network access.
+/// </summary>
+[TestFixture]
+public sealed class ContactGroupServiceTests : ServiceTestBase
+{
+    /// <summary>
+    /// Creates a fresh <see cref="ContactGroupService"/> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute for every test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new ContactGroupService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/contact_group";
+
+    private ContactGroupService _sut = null!;
+
+    /// <summary>
+    /// Get (no parameters) performs a single <c>GetAsync</c> against <c>2.0/contact_group</c>
+    /// with a null query parameter and never triggers <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<ContactGroup>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<ContactGroup>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<ContactGroup>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        await ConnectionHandler.DidNotReceive().FetchAll<ContactGroup>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When a <see cref="QueryParameterContactGroup"/> is supplied, its inner
+    /// <see cref="QueryParameter"/> instance is forwarded to the connection
+    /// handler verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterContactGroup(Limit: 50, Offset: 100);
+        ConnectionHandler
+            .GetAsync<List<ContactGroup>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<ContactGroup>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<ContactGroup>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When <c>autoPage</c> is on and the first response advertises a
+    /// <c>X-Total-Count</c> header, the service calls <c>FetchAll</c> with the
+    /// count of already-fetched items, the total, the same path, and the
+    /// same query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
+    {
+        var firstGroup = NewContactGroup(1);
+        var firstPage = new ApiResult<List<ContactGroup>?>
+        {
+            IsSuccess = true,
+            Data = [firstGroup],
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                [ApiHeaderNames.TotalResults] = 3
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<ContactGroup>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(firstPage));
+        var remaining = new List<ContactGroup> { NewContactGroup(2), NewContactGroup(3) };
+        ConnectionHandler
+            .FetchAll<ContactGroup>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(remaining));
+
+        var result = await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<ContactGroup>(
+            1,
+            3,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result.Data, Has.Count.EqualTo(3));
+        Assert.That(result.Data, Is.EquivalentTo(new[] { firstGroup, remaining[0], remaining[1] }));
+    }
+
+    /// <summary>
+    /// When <c>autoPage</c> is requested but the response carries no
+    /// <c>X-Total-Count</c> header, the service does not invoke <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
+    {
+        var response = new ApiResult<List<ContactGroup>?>
+        {
+            IsSuccess = true,
+            Data = [NewContactGroup(1)],
+            ResponseHeaders = new Dictionary<string, int?>()
+        };
+        ConnectionHandler
+            .GetAsync<List<ContactGroup>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get(autoPage: true);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.DidNotReceive().FetchAll<ContactGroup>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> once
+    /// with the path <c>2.0/contact_group/{id}</c> and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<ContactGroup?>
+        {
+            IsSuccess = true,
+            Data = NewContactGroup(id)
+        };
+        ConnectionHandler
+            .GetAsync<ContactGroup?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<ContactGroup?>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create forwards the create view to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>
+    /// against the endpoint root (no id suffix).
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithEndpointRoot()
+    {
+        var payload = new ContactGroupCreate("Suppliers");
+        var expected = new ApiResult<ContactGroup> { IsSuccess = true, Data = NewContactGroup(1) };
+        ConnectionHandler
+            .PostAsync<ContactGroup, ContactGroupCreate>(
+                Arg.Any<ContactGroupCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostAsync<ContactGroup, ContactGroupCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Search forwards the criteria list and optional pagination parameters to
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}"/> against
+    /// the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsyncWithSearchPath()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Suppliers", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterContactGroup(Limit: 10, Offset: 0);
+        var expected = new ApiResult<List<ContactGroup>>
+        {
+            IsSuccess = true,
+            Data = [NewContactGroup(1)]
+        };
+        ConnectionHandler
+            .PostSearchAsync<ContactGroup>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Search(criteria, queryParameter);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostSearchAsync<ContactGroup>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Search without a query parameter passes <see langword="null"/> pagination to
+    /// the connection handler and still targets the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_WithoutQueryParameter_PassesNullPagination()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Suppliers", Criteria = "=" }
+        };
+        ConnectionHandler
+            .PostSearchAsync<ContactGroup>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<ContactGroup>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<ContactGroup>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Update forwards the update view to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>
+    /// against the per-id sub-path (the Bexio API uses POST to edit, not PUT).
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPostAsyncWithIdInPath()
+    {
+        const int id = 7;
+        var payload = new ContactGroupUpdate("Suppliers Updated");
+        var expected = new ApiResult<ContactGroup> { IsSuccess = true, Data = NewContactGroup(id) };
+        ConnectionHandler
+            .PostAsync<ContactGroup, ContactGroupUpdate>(
+                Arg.Any<ContactGroupUpdate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Update(id, payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostAsync<ContactGroup, ContactGroupUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete forwards to <see cref="IBexioConnectionHandler.Delete"/> with the
+    /// per-id path exactly once.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Delete(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller must be forwarded to the
+    /// connection handler on <c>Get</c> so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<ContactGroup>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<ContactGroup>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<ContactGroup>?>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+
+    private static ContactGroup NewContactGroup(int id) => new(Id: id, Name: $"Group {id}");
+}

--- a/tests/BexioApiNet.UnitTests/Contacts/ContactRelationServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Contacts/ContactRelationServiceTests.cs
@@ -1,0 +1,413 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactRelations;
+using BexioApiNet.Abstractions.Models.Contacts.ContactRelations.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.UnitTests.Contacts;
+
+/// <summary>
+///     Offline unit tests for <see cref="ContactRelationService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+///     returns the handler's result unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class ContactRelationServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "2.0/contact_relation";
+
+    private ContactRelationService _sut = null!;
+
+    /// <summary>
+    ///     Creates a fresh <see cref="ContactRelationService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new ContactRelationService(ConnectionHandler);
+    }
+
+    /// <summary>
+    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    ///     the expected endpoint path and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<ContactRelation>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<ContactRelation>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<ContactRelation>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get forwards the wrapped <see cref="QueryParameter"/> from a typed
+    ///     <see cref="QueryParameterContactRelation"/> to the connection handler.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_ForwardsQueryParameter()
+    {
+        var queryParameter = new QueryParameterContactRelation(25, 50);
+        var response = new ApiResult<List<ContactRelation>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<ContactRelation>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<ContactRelation>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    ///     the full result set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<ContactRelation> { BuildContactRelation(1), BuildContactRelation(2) };
+        var initial = new ApiResult<List<ContactRelation>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<ContactRelation>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<ContactRelation>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<ContactRelation>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    ///     auto-paging is not requested.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResult()
+    {
+        var response = new ApiResult<List<ContactRelation>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<ContactRelation>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     GetById forwards the call to <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with
+    ///     the endpoint path that includes the supplied id.
+    /// </summary>
+    [Test]
+    public async Task GetById_PathContainsId()
+    {
+        const int id = 42;
+        var response = new ApiResult<ContactRelation> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<ContactRelation>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    ///     modification.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<ContactRelation>
+        {
+            IsSuccess = true,
+            Data = BuildContactRelation(1)
+        };
+        ConnectionHandler
+            .GetAsync<ContactRelation>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.GetById(1);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Create forwards the payload and the expected endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<ContactRelation> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<ContactRelation, ContactRelationCreate>(
+                Arg.Any<ContactRelationCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<ContactRelation, ContactRelationCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    ///     modification.
+    /// </summary>
+    [Test]
+    public async Task Create_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<ContactRelation> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<ContactRelation, ContactRelationCreate>(
+                Arg.Any<ContactRelationCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Search forwards the provided criteria list to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> with the search endpoint path.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "contact_id", Value = "1", Criteria = "=" }
+        };
+        var response = new ApiResult<List<ContactRelation>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<ContactRelation>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(criteria);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<ContactRelation>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search forwards the optional <see cref="QueryParameterContactRelation"/> through to the
+    ///     connection handler as a <see cref="QueryParameter"/>.
+    /// </summary>
+    [Test]
+    public async Task Search_WithQueryParameter_ForwardsQueryParameter()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "contact_id", Value = "1", Criteria = "=" }
+        };
+        var queryParameter = new QueryParameterContactRelation(10, 0);
+        var response = new ApiResult<List<ContactRelation>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<ContactRelation>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<ContactRelation>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update forwards the payload and the id-scoped endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />. Bexio v2.0 endpoints
+    ///     use HTTP POST on the resource URL to perform an edit.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPostAsync_WithIdInPath()
+    {
+        const int id = 7;
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<ContactRelation> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<ContactRelation, ContactRelationUpdate>(
+                Arg.Any<ContactRelationUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Update(id, payload);
+
+        await ConnectionHandler.Received(1).PostAsync<ContactRelation, ContactRelationUpdate>(
+            payload,
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     Update returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    ///     modification.
+    /// </summary>
+    [Test]
+    public async Task Update_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<ContactRelation> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<ContactRelation, ContactRelationUpdate>(
+                Arg.Any<ContactRelationUpdate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Update(1, payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly once.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete()
+    {
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Delete(42);
+
+        await ConnectionHandler.Received(1).Delete(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Delete builds the request path with the contact-relation id appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_PathContainsId()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    private static ContactRelationCreate BuildCreatePayload()
+        => new(ContactId: 1, ContactSubId: 2, Description: "managed by");
+
+    private static ContactRelationUpdate BuildUpdatePayload()
+        => new(ContactId: 1, ContactSubId: 2, Description: "updated");
+
+    private static ContactRelation BuildContactRelation(int id)
+        => new(id, ContactId: 1, ContactSubId: 2, Description: string.Empty, UpdatedAt: null);
+}

--- a/tests/BexioApiNet.UnitTests/Contacts/ContactSectorServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Contacts/ContactSectorServiceTests.cs
@@ -1,0 +1,290 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.ContactSectors;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.UnitTests.Contacts;
+
+/// <summary>
+/// Offline unit tests for <see cref="ContactSectorService"/>. Each test verifies that the
+/// service forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected
+/// arguments and returns the handler's result unchanged. No network access.
+/// </summary>
+[TestFixture]
+public sealed class ContactSectorServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "2.0/contact_branch";
+    private const string ExpectedSearchEndpoint = "2.0/contact_branch/search";
+
+    private ContactSectorService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="ContactSectorService"/> per test bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute from the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new ContactSectorService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// With no parameters <c>Get</c> hits <c>2.0/contact_branch</c> exactly once with a
+    /// <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
+    {
+        var response = new ApiResult<List<ContactSector>?>
+        {
+            IsSuccess = true,
+            Data = [new ContactSector(Id: 1, Name: "Photography")]
+        };
+        ConnectionHandler
+            .GetAsync<List<ContactSector>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).GetAsync<List<ContactSector>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When a <see cref="QueryParameterContactSector"/> is supplied, its inner
+    /// <see cref="QueryParameter"/> instance is forwarded verbatim — the service must
+    /// not rewrap or substitute it.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterContactSector(Limit: 50, Offset: 25);
+        ConnectionHandler
+            .GetAsync<List<ContactSector>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<ContactSector>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<ContactSector>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// <c>Get(autoPage: true)</c> triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}"/>
+    /// when the <c>X-Total-Count</c> header is present and the first response only returned a page.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 8;
+        var initialData = new List<ContactSector>
+        {
+            new(Id: 1, Name: "Photography"),
+            new(Id: 2, Name: "Design")
+        };
+        var initial = new ApiResult<List<ContactSector>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<ContactSector>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(initial));
+        ConnectionHandler
+            .FetchAll<ContactSector>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<ContactSector>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller of <c>Get</c> must be forwarded to the
+    /// connection handler so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<ContactSector>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<ContactSector>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<ContactSector>?>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// A failing <see cref="ApiResult{T}"/> from the connection handler must surface to the
+    /// caller untouched — the service may not swallow errors.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var apiError = new ApiError(ErrorCode: 401, Message: "unauthorized", Errors: new object());
+        var response = new ApiResult<List<ContactSector>?>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.Unauthorized,
+            Data = null
+        };
+        ConnectionHandler
+            .GetAsync<List<ContactSector>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// <c>Search</c> posts the supplied <see cref="SearchCriteria"/> list to
+    /// <c>2.0/contact_branch/search</c> via <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}"/>.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsyncWithExpectedPathAndBody()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Photo", Criteria = "like" }
+        };
+        var response = new ApiResult<List<ContactSector>>
+        {
+            IsSuccess = true,
+            Data = [new ContactSector(Id: 1, Name: "Photography")]
+        };
+        ConnectionHandler
+            .PostSearchAsync<ContactSector>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Search(criteria);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).PostSearchAsync<ContactSector>(
+            criteria,
+            ExpectedSearchEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When a <see cref="QueryParameterContactSector"/> is supplied to <c>Search</c>, the
+    /// inner <see cref="QueryParameter"/> is forwarded to the handler so pagination /
+    /// ordering parameters reach the URI.
+    /// </summary>
+    [Test]
+    public async Task Search_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Design", Criteria = "=" }
+        };
+        var queryParameter = new QueryParameterContactSector(Limit: 10, Offset: 0);
+        ConnectionHandler
+            .PostSearchAsync<ContactSector>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<ContactSector>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<ContactSector>(
+            criteria,
+            ExpectedSearchEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller of <c>Search</c> must be forwarded to
+    /// the connection handler.
+    /// </summary>
+    [Test]
+    public async Task Search_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Foo", Criteria = "=" }
+        };
+        ConnectionHandler
+            .PostSearchAsync<ContactSector>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<ContactSector>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria, cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<ContactSector>(
+            criteria,
+            ExpectedSearchEndpoint,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    /// A failing <see cref="ApiResult{T}"/> returned by <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}"/>
+    /// must surface to the caller of <c>Search</c> untouched.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsApiResultFromConnectionHandlerUnchanged()
+    {
+        var apiError = new ApiError(ErrorCode: 422, Message: "invalid search", Errors: new object());
+        var response = new ApiResult<List<ContactSector>>
+        {
+            IsSuccess = false,
+            ApiError = apiError,
+            StatusCode = System.Net.HttpStatusCode.UnprocessableEntity,
+            Data = null
+        };
+        ConnectionHandler
+            .PostSearchAsync<ContactSector>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Search([]);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Contacts/ContactServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Contacts/ContactServiceTests.cs
@@ -1,0 +1,436 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Contacts.Contacts;
+using BexioApiNet.Abstractions.Models.Contacts.Contacts.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Contacts;
+
+namespace BexioApiNet.UnitTests.Contacts;
+
+/// <summary>
+///     Offline unit tests for <see cref="ContactService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+///     returns the handler's result unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class ContactServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="ContactService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new ContactService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/contact";
+
+    private ContactService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    ///     the expected endpoint path and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<Contact>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Contact>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<Contact>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get forwards the <see cref="QueryParameterContact" />'s underlying <see cref="QueryParameter" />
+    ///     to the connection handler so the caller's filters (limit/offset/order_by/show_archived) reach the API.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterContact(Limit: 100, Offset: 50);
+        var response = new ApiResult<List<Contact>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Contact>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Contact>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    ///     the full result set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<Contact> { BuildContact(1), BuildContact(2) };
+        var initial = new ApiResult<List<Contact>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Contact>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<Contact>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Contact>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    ///     auto-paging is not requested (no additional FetchAll round-trip, result passes through).
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResult()
+    {
+        var response = new ApiResult<List<Contact>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Contact>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    ///     endpoint path including the contact id.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<Contact> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Contact>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without modification.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<Contact> { IsSuccess = true };
+        ConnectionHandler
+            .GetAsync<Contact>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.GetById(1);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Create forwards the payload and the expected endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<Contact> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Contact, ContactCreate>(
+                Arg.Any<ContactCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<Contact, ContactCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without modification.
+    /// </summary>
+    [Test]
+    public async Task Create_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<Contact> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Contact, ContactCreate>(
+                Arg.Any<ContactCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     BulkCreate forwards the list of payloads and the <c>/_bulk_create</c> path to
+    ///     <see cref="IBexioConnectionHandler.PostBulkAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task BulkCreate_CallsPostBulkAsync()
+    {
+        var payloads = new List<ContactCreate> { BuildCreatePayload(), BuildCreatePayload() };
+        var response = new ApiResult<List<Contact>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostBulkAsync<Contact, ContactCreate>(
+                Arg.Any<List<ContactCreate>>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.BulkCreate(payloads);
+
+        await ConnectionHandler.Received(1).PostBulkAsync<Contact, ContactCreate>(
+            payloads,
+            $"{ExpectedEndpoint}/_bulk_create",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name_1", Value = "Acme", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterContact(Limit: 50);
+        var response = new ApiResult<List<Contact>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<Contact>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Contact>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
+    ///     <c>/2.0/contact/{id}</c> — Bexio edits contacts via POST on this resource.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPostAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<Contact> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Contact, ContactUpdate>(
+                Arg.Any<ContactUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Update(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).PostAsync<Contact, ContactUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Restore calls <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}" /> at
+    ///     <c>/2.0/contact/{id}/restore</c> with a <see langword="null" /> payload (no request body).
+    /// </summary>
+    [Test]
+    public async Task Restore_CallsPatchAsync_WithRestoreInPath_AndNullPayload()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PatchAsync<object, object?>(
+                Arg.Any<object?>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Restore(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/restore"));
+        await ConnectionHandler.Received(1).PatchAsync<object, object?>(
+            null,
+            $"{ExpectedEndpoint}/{id}/restore",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the contact id
+    ///     appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    private static ContactCreate BuildCreatePayload()
+    {
+        return new ContactCreate(
+            ContactTypeId: 1,
+            Name1: "Acme AG",
+            UserId: 1,
+            OwnerId: 1);
+    }
+
+    private static ContactUpdate BuildUpdatePayload()
+    {
+        return new ContactUpdate(
+            ContactTypeId: 1,
+            Name1: "Acme AG",
+            UserId: 1,
+            OwnerId: 1);
+    }
+
+    private static Contact BuildContact(int id)
+    {
+        return new Contact(
+            Id: id,
+            Nr: null,
+            ContactTypeId: 1,
+            Name1: $"Contact {id}",
+            Name2: null,
+            SalutationId: null,
+            SalutationForm: null,
+            TitleId: null,
+            Birthday: null,
+            Address: null,
+            StreetName: null,
+            HouseNumber: null,
+            AddressAddition: null,
+            Postcode: null,
+            City: null,
+            CountryId: null,
+            Mail: null,
+            MailSecond: null,
+            PhoneFixed: null,
+            PhoneFixedSecond: null,
+            PhoneMobile: null,
+            Fax: null,
+            Url: null,
+            SkypeName: null,
+            Remarks: null,
+            LanguageId: null,
+            IsLead: null,
+            ContactGroupIds: null,
+            ContactBranchIds: null,
+            UserId: 1,
+            OwnerId: 1,
+            UpdatedAt: null,
+            ProfileImage: null);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Wave 1 of Epic #22 (100% API Coverage Roadmap), adding 13 new connector services and 68 endpoint methods across the Accounting, Banking, and Contacts &amp; CRM domains.

Closes #24. Delivered via 18 sub-issues (#32–#49) run in parallel Docker workers.

## Services Added / Expanded

### Accounting
| Service | Methods | Status |
|---------|---------|--------|
| `CurrencyService` | `GetCodes`, `GetById`, `GetExchangeRates`, `Create`, `Patch`, `Delete` | Expanded (#32) |
| `ManualEntryService` | `GetNextRefNr`, `GetFiles`, `GetFileById`, `GetEntryFiles`, `GetEntryFileById`, `Put`, `DeleteFile`, `DeleteEntryFile` | Expanded (#33) |
| `TaxService` | `GetById`, `Delete` | Expanded (#34) |
| `AccountGroupService` | `Get` | **New** (#35) |
| `BusinessYearService` | `Get`, `GetById` | **New** (#36) |
| `CalendarYearService` | `Get`, `GetById`, `Create`, `Search` | **New** (#37) |
| `VatPeriodService` | `Get`, `GetById` | **New** (#38) |
| `ReportService` | `GetJournal` | **New** (#39) |

### Banking
| Service | Methods | Status |
|---------|---------|--------|
| `BankAccountService` | `GetById` | Expanded (#40) |
| `PaymentTypeService` | `Get`, `Search` | **New** (#41) |
| `PaymentService` | `Get`, `GetById`, `Create`, `Cancel`, `Update`, `Delete` | **New** (#42) |
| `OutgoingPaymentService` | `Get`, `GetById`, `Create`, `Update`, `Delete` | **New** (#43) |

### Contacts &amp; CRM
| Service | Methods | Status |
|---------|---------|--------|
| `ContactService` | `Get`, `GetById`, `Create`, `BulkCreate`, `Search`, `Update`, `Restore`, `Delete` | **New** (#44) |
| `ContactGroupService` | `Get`, `GetById`, `Create`, `Search`, `Update`, `Delete` | **New** (#45) |
| `ContactRelationService` | `Get`, `GetById`, `Create`, `Search`, `Update`, `Delete` | **New** (#46) |
| `ContactSectorService` | `Get`, `Search` | **New** (#47) |
| `AdditionalAddressService` | `Get`, `GetById`, `Create`, `Search`, `Update`, `Delete` | **New** (#48) |

Wire-up (#49): all 13 new services registered in `IBexioApiClient`, `BexioApiClient`, `BexioServiceCollection`, and `BexioE2eTestBase`.

## Test Plan

- [x] All 17 service sub-issues: TDD (RED→GREEN) per service, NUnit + NSubstitute + Shouldly
- [x] `dotnet build /warnaserror` → 0 warnings, 0 errors
- [x] `dotnet test --filter "TestCategory!=E2E"` → **200 unit + 100 integration tests, all passing**
- [x] WireMock smoke tests for all 18 services (13 new + 5 pre-existing)
- [x] Integration build verification on merged `feature/issue-24` passed
- [x] `doc/api-completeness-audit.md` updated: 68 Wave 1 endpoints → DONE (83 total implemented, 226 remaining)
- [x] One integration regression fixed: namespace collision between `PaymentType` E2E folder and `PaymentType` enum (renamed folder to `PaymentTypes`)
- [x] Pre-merge review fixes: TaxService inheritdoc corrected, PaymentTypeService autoPage implemented, formatting normalized

## Notes

- Verbs follow Bexio OpenAPI spec, not task brief hints (e.g. Contact Update = POST, Restore = PATCH)
- All methods return `Task&lt;ApiResult&lt;T&gt;&gt;` per repo convention
- All services are `public sealed class` (not `internal`) to support DI in `BexioApiNet.AspNetCore`
- `AdditionalAddressService` uses nested routes `/2.0/contact/{contactId}/additional_address` — `contactId` is a per-call parameter
- E2E tests skip cleanly when credentials are absent (`Assert.Ignore`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)