### PR TITLE
feat(wave2): Wave 2 Sales Documents — Invoices, Quotes, Orders, Deliveries (58 endpoints)

### DIFF
--- a/doc/ai-readiness.md
+++ b/doc/ai-readiness.md
@@ -67,7 +67,7 @@ Three-tier testing strategy now in place: offline unit tests, offline integratio
 ### 3. Incomplete API Coverage (Known Debt)
 - **Status**: Ongoing
 - **Location**: `README.md` and `src/BexioApiNet/Interfaces/Connectors/`
-- **Why it's noted**: Many Bexio domains (Contacts, Projects, Invoices, Items, ...) are not implemented.
+- **Why it's noted**: Many Bexio domains (Items, Projects, etc.) are not implemented.
 - **Precautions**: When implementing a new domain, follow [`doc/development/feature-addition-guide.md`](./development/feature-addition-guide.md) verbatim. Ship unit tests with every new method.
 
 ## Section 4: Backlog Ideas
@@ -90,3 +90,4 @@ Three-tier testing strategy now in place: offline unit tests, offline integratio
 | Scaffold three-tier test architecture | Issue #7 — UnitTests, IntegrationTests, and E2eTests projects. |
 | Add comprehensive offline Unit and Integration coverage | Issue #7 — comprehensive Unit tests and WireMock.Net integration tests added. |
 | Vendor Bexio OpenAPI Spec | Issue #8 — `doc/openapi/bexio-v3.json` committed (OpenAPI 3.0.2, API v3.0.0, 355 paths, retrieved 2026-04-18). Refresh procedure in `doc/openapi/README.md`. |
+cedure in `doc/openapi/README.md`. |

--- a/doc/analysis/api-completeness-audit.md
+++ b/doc/analysis/api-completeness-audit.md
@@ -22,9 +22,9 @@ Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implement
 | 1 | Accounting (Extended) | 8 | 35 | 35 | 0 | 1 |
 | 2 | Banking & Payments | 4 | 15 | 15 | 0 | 1 |
 | 3 | Contacts & CRM | 5 | 28 | 28 | 0 | 1 |
-| 4 | Sales — Invoices | 1 | 26 | 0 | 26 | 2 |
-| 5 | Sales — Quotes | 1 | 17 | 0 | 17 | 2 |
-| 6 | Sales — Orders & Deliveries | 2 | 15 | 0 | 15 | 2 |
+| 4 | Sales — Invoices | 1 | 26 | 26 | 0 | 2 |
+| 5 | Sales — Quotes | 1 | 17 | 17 | 0 | 2 |
+| 6 | Sales — Orders & Deliveries | 2 | 15 | 15 | 0 | 2 |
 | 7 | Items & Inventory | 4 | 16 | 0 | 16 | 3 |
 | 8 | Document Positions | 7 | 35 | 0 | 35 | 3 |
 | 9 | Projects | 1 | 20 | 0 | 20 | 4 |
@@ -33,7 +33,7 @@ Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implement
 | 12 | Payroll | 3 | 10 | 0 | 10 | 5 |
 | 13 | Files & Documents | 3 | 11 | 0 | 11 | 6 |
 | 14 | Master Data & Settings | 9 | 42 | 0 | 42 | 6 |
-| | **TOTAL** | **56** | **309** | **83** | **226** | |
+| | **TOTAL** | **56** | **309** | **141** | **168** | |
 
 ---
 
@@ -217,93 +217,93 @@ Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implement
 
 ---
 
-## Domain Group 4: Sales — Invoices — Wave 2
+## Domain Group 4: Sales — Invoices — Wave 2 — DONE
 
-### Tag: Invoices (26 endpoints)
+### Tag: Invoices (26 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/2.0/kb_invoice` | TODO | InvoiceService |
-| GET | `/2.0/kb_invoice/{invoice_id}` | TODO | InvoiceService |
-| GET | `/2.0/kb_invoice/{invoice_id}/pdf` | TODO | InvoiceService |
-| GET | `/2.0/kb_invoice/{invoice_id}/payment` | TODO | InvoiceService |
-| GET | `/2.0/kb_invoice/{invoice_id}/payment/{payment_id}` | TODO | InvoiceService |
-| GET | `/2.0/kb_invoice/{invoice_id}/kb_reminder` | TODO | InvoiceReminderService |
-| GET | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}` | TODO | InvoiceReminderService |
-| GET | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}/pdf` | TODO | InvoiceReminderService |
-| POST | `/2.0/kb_invoice` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/search` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}/issue` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}/cancel` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}/copy` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}/send` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}/mark_as_sent` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}/revert_issue` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}/payment` | TODO | InvoiceService |
-| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder` | TODO | InvoiceReminderService |
-| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder/search` | TODO | InvoiceReminderService |
-| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{id}/send` | TODO | InvoiceReminderService |
-| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{id}/mark_as_sent` | TODO | InvoiceReminderService |
-| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{id}/mark_as_unsent` | TODO | InvoiceReminderService |
-| DELETE | `/2.0/kb_invoice/{invoice_id}` | TODO | InvoiceService |
-| DELETE | `/2.0/kb_invoice/{invoice_id}/payment/{payment_id}` | TODO | InvoiceService |
-| DELETE | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}` | TODO | InvoiceReminderService |
+| GET | `/2.0/kb_invoice` | DONE | InvoiceService |
+| GET | `/2.0/kb_invoice/{invoice_id}` | DONE | InvoiceService |
+| GET | `/2.0/kb_invoice/{invoice_id}/pdf` | DONE | InvoiceService |
+| GET | `/2.0/kb_invoice/{invoice_id}/payment` | DONE | InvoiceService |
+| GET | `/2.0/kb_invoice/{invoice_id}/payment/{payment_id}` | DONE | InvoiceService |
+| GET | `/2.0/kb_invoice/{invoice_id}/kb_reminder` | DONE | InvoiceReminderService |
+| GET | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}` | DONE | InvoiceReminderService |
+| GET | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}/pdf` | DONE | InvoiceReminderService |
+| POST | `/2.0/kb_invoice` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/search` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}/issue` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}/cancel` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}/copy` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}/send` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}/mark_as_sent` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}/revert_issue` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}/payment` | DONE | InvoiceService |
+| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder` | DONE | InvoiceReminderService |
+| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder/search` | DONE | InvoiceReminderService |
+| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{id}/send` | DONE | InvoiceReminderService |
+| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{id}/mark_as_sent` | DONE | InvoiceReminderService |
+| POST | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{id}/mark_as_unsent` | DONE | InvoiceReminderService |
+| DELETE | `/2.0/kb_invoice/{invoice_id}` | DONE | InvoiceService |
+| DELETE | `/2.0/kb_invoice/{invoice_id}/payment/{payment_id}` | DONE | InvoiceService |
+| DELETE | `/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}` | DONE | InvoiceReminderService |
 
 ---
 
-## Domain Group 5: Sales — Quotes — Wave 2
+## Domain Group 5: Sales — Quotes — Wave 2 — DONE
 
-### Tag: Quotes (17 endpoints)
+### Tag: Quotes (17 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/2.0/kb_offer` | TODO | QuoteService |
-| GET | `/2.0/kb_offer/{quote_id}` | TODO | QuoteService |
-| GET | `/2.0/kb_offer/{quote_id}/pdf` | TODO | QuoteService |
-| POST | `/2.0/kb_offer` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/search` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/issue` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/reissue` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/revertIssue` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/accept` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/reject` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/copy` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/invoice` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/order` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/mark_as_sent` | TODO | QuoteService |
-| POST | `/2.0/kb_offer/{quote_id}/send` | TODO | QuoteService |
-| DELETE | `/2.0/kb_offer/{quote_id}` | TODO | QuoteService |
+| GET | `/2.0/kb_offer` | DONE | QuoteService |
+| GET | `/2.0/kb_offer/{quote_id}` | DONE | QuoteService |
+| GET | `/2.0/kb_offer/{quote_id}/pdf` | DONE | QuoteService |
+| POST | `/2.0/kb_offer` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/search` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/issue` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/reissue` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/revertIssue` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/accept` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/reject` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/copy` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/invoice` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/order` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/mark_as_sent` | DONE | QuoteService |
+| POST | `/2.0/kb_offer/{quote_id}/send` | DONE | QuoteService |
+| DELETE | `/2.0/kb_offer/{quote_id}` | DONE | QuoteService |
 
 ---
 
-## Domain Group 6: Sales — Orders & Deliveries — Wave 2
+## Domain Group 6: Sales — Orders & Deliveries — Wave 2 — DONE
 
-### Tag: Orders (12 endpoints)
-
-| Method | Path | Status | Service |
-|--------|------|--------|---------|
-| GET | `/2.0/kb_order` | TODO | OrderService |
-| GET | `/2.0/kb_order/{order_id}` | TODO | OrderService |
-| GET | `/2.0/kb_order/{order_id}/pdf` | TODO | OrderService |
-| GET | `/2.0/kb_order/{order_id}/repetition` | TODO | OrderService |
-| POST | `/2.0/kb_order` | TODO | OrderService |
-| POST | `/2.0/kb_order/search` | TODO | OrderService |
-| POST | `/2.0/kb_order/{order_id}` | TODO | OrderService |
-| POST | `/2.0/kb_order/{order_id}/delivery` | TODO | OrderService |
-| POST | `/2.0/kb_order/{order_id}/invoice` | TODO | OrderService |
-| POST | `/2.0/kb_order/{order_id}/repetition` | TODO | OrderService |
-| DELETE | `/2.0/kb_order/{order_id}` | TODO | OrderService |
-| DELETE | `/2.0/kb_order/{order_id}/repetition` | TODO | OrderService |
-
-### Tag: Deliveries (3 endpoints)
+### Tag: Orders (12 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/2.0/kb_delivery` | TODO | DeliveryService |
-| GET | `/2.0/kb_delivery/{delivery_id}` | TODO | DeliveryService |
-| POST | `/2.0/kb_delivery/{delivery_id}/issue` | TODO | DeliveryService |
+| GET | `/2.0/kb_order` | DONE | OrderService |
+| GET | `/2.0/kb_order/{order_id}` | DONE | OrderService |
+| GET | `/2.0/kb_order/{order_id}/pdf` | DONE | OrderService |
+| GET | `/2.0/kb_order/{order_id}/repetition` | DONE | OrderService |
+| POST | `/2.0/kb_order` | DONE | OrderService |
+| POST | `/2.0/kb_order/search` | DONE | OrderService |
+| POST | `/2.0/kb_order/{order_id}` | DONE | OrderService |
+| POST | `/2.0/kb_order/{order_id}/delivery` | DONE | OrderService |
+| POST | `/2.0/kb_order/{order_id}/invoice` | DONE | OrderService |
+| POST | `/2.0/kb_order/{order_id}/repetition` | DONE | OrderService |
+| DELETE | `/2.0/kb_order/{order_id}` | DONE | OrderService |
+| DELETE | `/2.0/kb_order/{order_id}/repetition` | DONE | OrderService |
+
+### Tag: Deliveries (3 endpoints) — DONE
+
+| Method | Path | Status | Service |
+|--------|------|--------|---------|
+| GET | `/2.0/kb_delivery` | DONE | DeliveryService |
+| GET | `/2.0/kb_delivery/{delivery_id}` | DONE | DeliveryService |
+| POST | `/2.0/kb_delivery/{delivery_id}/issue` | DONE | DeliveryService |
 
 ---
 
@@ -733,3 +733,4 @@ When an endpoint is implemented:
 1. Change its status from `TODO` to `DONE` in this document.
 2. Update the summary table counts.
 3. Update `doc/ai-readiness.md` coverage percentages.
+entages.

--- a/doc/architecture/components/library.md
+++ b/doc/architecture/components/library.md
@@ -18,6 +18,7 @@ C4Component
     
     Component(accountingConnectors, "Accounting Services", "ConnectorService", "Handles ManualEntries, Accounts, Currencies, Taxes.")
     Component(bankingConnectors, "Banking Services", "ConnectorService", "Handles BankAccounts.")
+    Component(salesConnectors, "Sales Services", "ConnectorService", "Handles Invoices, Quotes, Orders, Deliveries.")
     
     Component(connectionHandler, "BexioConnectionHandler", "HTTP execution", "Manages HttpClient, Bearer token injection, request building, pagination, and response deserialization.")
   }
@@ -27,9 +28,11 @@ C4Component
 
   Rel(bexioApiClient, accountingConnectors, "Delegates to")
   Rel(bexioApiClient, bankingConnectors, "Delegates to")
+  Rel(bexioApiClient, salesConnectors, "Delegates to")
   
   Rel(accountingConnectors, connectionHandler, "Uses for HTTP")
   Rel(bankingConnectors, connectionHandler, "Uses for HTTP")
+  Rel(salesConnectors, connectionHandler, "Uses for HTTP")
   
   Rel(connectionHandler, bexioApi, "Executes HTTP requests")
   Rel(connectionHandler, abstractions, "Deserializes into models")

--- a/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/Delivery.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/Delivery.cs
@@ -1,0 +1,127 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Deliveries;
+
+/// <summary>
+///     Delivery as returned by the Bexio <c>/2.0/kb_delivery</c> endpoint. Covers both the plain
+///     <c>Delivery</c> schema returned by list and the <c>DeliveryWithDetails</c> variant returned by
+///     show (which additionally populates <see cref="Positions" />).
+///     <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ListDeliveries" />
+/// </summary>
+/// <param name="Id">Unique delivery identifier (read-only).</param>
+/// <param name="DocumentNr">Delivery number (read-only, e.g. <c>LS-00001</c>).</param>
+/// <param name="Title">Delivery title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="UserId">References the user that owns the delivery.</param>
+/// <param name="LogopaperId">References a logo-paper object.</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="Header">Free-text header printed on top of the delivery.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="TotalGross">Gross total as a formatted decimal string (read-only).</param>
+/// <param name="TotalNet">Net total as a formatted decimal string (read-only).</param>
+/// <param name="TotalTaxes">Total of applicable taxes as a formatted decimal string (read-only).</param>
+/// <param name="Total">Grand total as a formatted decimal string (read-only).</param>
+/// <param name="TotalRoundingDifference">Rounding difference applied to the total (read-only).</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">
+///     When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
+///     net.
+/// </param>
+/// <param name="IsValidFrom">Delivery validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddress">Composed contact address string (read-only).</param>
+/// <param name="DeliveryAddressType">
+///     Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
+///     address.
+/// </param>
+/// <param name="DeliveryAddress">Composed delivery address string (read-only).</param>
+/// <param name="KbItemStatusId">Read-only delivery status id (10 Draft, 18 Done, 20 Canceled).</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="ViewedByClientAt">Timestamp when the delivery was first opened by the recipient (read-only).</param>
+/// <param name="UpdatedAt">Timestamp of the last update in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format (read-only).</param>
+/// <param name="Taxs">Read-only aggregated tax summary lines.</param>
+/// <param name="Positions">
+///     Optional polymorphic positions array populated on show responses. Kept as raw
+///     <see cref="JsonElement" /> values since Bexio returns a union of several position types.
+/// </param>
+public sealed record Delivery(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("document_nr")]
+    string? DocumentNr,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("contact_id")]
+    int? ContactId,
+    [property: JsonPropertyName("contact_sub_id")]
+    int? ContactSubId,
+    [property: JsonPropertyName("user_id")]
+    int UserId,
+    [property: JsonPropertyName("logopaper_id")]
+    int? LogopaperId,
+    [property: JsonPropertyName("language_id")]
+    int? LanguageId,
+    [property: JsonPropertyName("bank_account_id")]
+    int? BankAccountId,
+    [property: JsonPropertyName("currency_id")]
+    int? CurrencyId,
+    [property: JsonPropertyName("header")] string? Header,
+    [property: JsonPropertyName("footer")] string? Footer,
+    [property: JsonPropertyName("total_gross")]
+    string? TotalGross,
+    [property: JsonPropertyName("total_net")]
+    string? TotalNet,
+    [property: JsonPropertyName("total_taxes")]
+    string? TotalTaxes,
+    [property: JsonPropertyName("total")] string? Total,
+    [property: JsonPropertyName("total_rounding_difference")]
+    decimal? TotalRoundingDifference,
+    [property: JsonPropertyName("mwst_type")]
+    int? MwstType,
+    [property: JsonPropertyName("mwst_is_net")]
+    bool? MwstIsNet,
+    [property: JsonPropertyName("is_valid_from")]
+    string? IsValidFrom,
+    [property: JsonPropertyName("contact_address")]
+    string? ContactAddress,
+    [property: JsonPropertyName("delivery_address_type")]
+    int? DeliveryAddressType,
+    [property: JsonPropertyName("delivery_address")]
+    string? DeliveryAddress,
+    [property: JsonPropertyName("kb_item_status_id")]
+    int? KbItemStatusId,
+    [property: JsonPropertyName("api_reference")]
+    string? ApiReference,
+    [property: JsonPropertyName("viewed_by_client_at")]
+    string? ViewedByClientAt,
+    [property: JsonPropertyName("updated_at")]
+    string? UpdatedAt,
+    [property: JsonPropertyName("taxs")] IReadOnlyList<DeliveryTax>? Taxs,
+    [property: JsonPropertyName("positions")]
+    IReadOnlyList<JsonElement>? Positions
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/DeliveryTax.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/DeliveryTax.cs
@@ -1,0 +1,38 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Deliveries;
+
+/// <summary>
+///     Read-only tax summary line aggregated onto a <see cref="Delivery" /> by the Bexio API.
+///     Exposed as the items of <see cref="Delivery.Taxs" />.
+/// </summary>
+/// <param name="Percentage">Tax percentage as a formatted decimal string (e.g. <c>"7.70"</c>).</param>
+/// <param name="Value">Amount of tax applied at the given percentage as a formatted decimal string.</param>
+public sealed record DeliveryTax(
+    [property: JsonPropertyName("percentage")]
+    string? Percentage,
+    [property: JsonPropertyName("value")] string? Value
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/InvoiceReminders/InvoiceReminder.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/InvoiceReminders/InvoiceReminder.cs
@@ -1,0 +1,60 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.InvoiceReminders;
+
+/// <summary>
+/// Invoice reminder as returned by the Bexio <c>/2.0/kb_invoice/{invoice_id}/kb_reminder</c>
+/// endpoints. A reminder represents a dunning notice attached to an invoice.
+/// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2ListInvoiceReminders"/>
+/// </summary>
+/// <param name="Id">Unique reminder identifier (read-only).</param>
+/// <param name="KbInvoiceId">References an invoice object (read-only).</param>
+/// <param name="Title">Reminder title/subject.</param>
+/// <param name="IsValidFrom">Reminder validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidTo">Reminder due date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ReminderPeriodInDays">Number of days the reminder period spans.</param>
+/// <param name="ReminderLevel">Dunning level computed by Bexio (read-only).</param>
+/// <param name="ShowPositions">When <see langword="true"/>, positions from the source invoice are reprinted on the reminder.</param>
+/// <param name="RemainingPrice">Remaining open balance as a formatted decimal string (read-only).</param>
+/// <param name="ReceivedTotal">Sum of received payments as a formatted decimal string (read-only).</param>
+/// <param name="IsSent">Flag indicating whether the reminder has been sent.</param>
+/// <param name="Header">Free-text header printed on top of the reminder.</param>
+/// <param name="Footer">Free-text footer printed below the reminder body.</param>
+public sealed record InvoiceReminder(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("kb_invoice_id")] int KbInvoiceId,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom,
+    [property: JsonPropertyName("is_valid_to")] string? IsValidTo,
+    [property: JsonPropertyName("reminder_period_in_days")] int? ReminderPeriodInDays,
+    [property: JsonPropertyName("reminder_level")] int? ReminderLevel,
+    [property: JsonPropertyName("show_positions")] bool? ShowPositions,
+    [property: JsonPropertyName("remaining_price")] string? RemainingPrice,
+    [property: JsonPropertyName("received_total")] string? ReceivedTotal,
+    [property: JsonPropertyName("is_sent")] bool? IsSent,
+    [property: JsonPropertyName("header")] string? Header,
+    [property: JsonPropertyName("footer")] string? Footer
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/InvoiceReminders/Views/InvoiceReminderCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/InvoiceReminders/Views/InvoiceReminderCreate.cs
@@ -1,0 +1,51 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.InvoiceReminders.Views;
+
+/// <summary>
+/// Create view for an invoice reminder — body of
+/// <c>POST /2.0/kb_invoice/{invoice_id}/kb_reminder</c>. Read-only fields (id, kb_invoice_id,
+/// reminder_level, remaining_price, received_total) are intentionally omitted.
+/// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2CreateInvoiceReminder"/>
+/// </summary>
+/// <param name="Title">Reminder title/subject.</param>
+/// <param name="IsValidFrom">Reminder validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidTo">Reminder due date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ReminderPeriodInDays">Number of days the reminder period spans.</param>
+/// <param name="ShowPositions">When <see langword="true"/>, positions from the source invoice are reprinted on the reminder.</param>
+/// <param name="IsSent">Flag indicating whether the reminder should be created as already sent.</param>
+/// <param name="Header">Free-text header printed on top of the reminder.</param>
+/// <param name="Footer">Free-text footer printed below the reminder body.</param>
+public sealed record InvoiceReminderCreate(
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("is_valid_to")] string? IsValidTo = null,
+    [property: JsonPropertyName("reminder_period_in_days")] int? ReminderPeriodInDays = null,
+    [property: JsonPropertyName("show_positions")] bool? ShowPositions = null,
+    [property: JsonPropertyName("is_sent")] bool? IsSent = null,
+    [property: JsonPropertyName("header")] string? Header = null,
+    [property: JsonPropertyName("footer")] string? Footer = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/InvoiceReminders/Views/InvoiceReminderSendRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/InvoiceReminders/Views/InvoiceReminderSendRequest.cs
@@ -1,0 +1,41 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.InvoiceReminders.Views;
+
+/// <summary>
+/// Body for <c>POST /2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}/send</c>. Sends the
+/// reminder via Bexio's network mail service. The <c>[Network Link]</c> placeholder must be
+/// present in <see cref="Message"/>.
+/// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2SendInvoiceReminder"/>
+/// </summary>
+/// <param name="RecipientEmail">Recipient email address (required). During trial the recipient is limited to the token owner.</param>
+/// <param name="Subject">Email subject (required).</param>
+/// <param name="Message">Email body (required). Must contain the <c>[Network Link]</c> placeholder.</param>
+public sealed record InvoiceReminderSendRequest(
+    [property: JsonPropertyName("recipient_email")] string RecipientEmail,
+    [property: JsonPropertyName("subject")] string Subject,
+    [property: JsonPropertyName("message")] string Message
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Invoice.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Invoice.cs
@@ -1,0 +1,119 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Invoices;
+
+/// <summary>
+/// Invoice as returned by the Bexio <c>/2.0/kb_invoice</c> endpoint. Covers both the plain
+/// <c>Invoice</c> schema returned by list and the <c>InvoiceWithDetails</c> variant returned by
+/// show/create/update (which additionally populates <see cref="Positions"/>).
+/// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2ListInvoices"/>
+/// </summary>
+/// <param name="Id">Unique invoice identifier (read-only).</param>
+/// <param name="DocumentNr">Invoice number. Must be omitted when automatic numbering is enabled, required otherwise.</param>
+/// <param name="Title">Invoice title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="UserId">References the user that owns the invoice.</param>
+/// <param name="ProjectId">Read-only reference to a project object.</param>
+/// <param name="PrProjectId">Write-only reference to a project object, accepted on create/update.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the invoice.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="TotalGross">Gross total as a formatted decimal string (read-only).</param>
+/// <param name="TotalNet">Net total as a formatted decimal string (read-only).</param>
+/// <param name="TotalTaxes">Total of applicable taxes as a formatted decimal string (read-only).</param>
+/// <param name="TotalReceivedPayments">Sum of applied payments as a formatted decimal string (read-only).</param>
+/// <param name="TotalCreditVouchers">Sum of applied credit vouchers as a formatted decimal string (read-only).</param>
+/// <param name="TotalRemainingPayments">Remaining open balance as a formatted decimal string (read-only).</param>
+/// <param name="Total">Grand total as a formatted decimal string (read-only).</param>
+/// <param name="TotalRoundingDifference">Rounding difference applied to the total (read-only).</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">When <see langword="true"/> and <see cref="MwstType"/> is <c>0</c>, totals are interpreted as net.</param>
+/// <param name="ShowPositionTaxes">When <see langword="true"/>, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Invoice validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidTo">Invoice due date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddress">Composed contact address string (read-only).</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="KbItemStatusId">Read-only invoice status id (7 Draft, 8 Pending, 9 Paid, 15 Partial, 16 Cancelled, 17 Unpaid).</param>
+/// <param name="Reference">Free-text reference displayed on the invoice.</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="ViewedByClientAt">Timestamp when the invoice was first opened by the recipient (read-only).</param>
+/// <param name="UpdatedAt">Timestamp of the last update in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format (read-only).</param>
+/// <param name="EsrId">Read-only reference to an ESR id.</param>
+/// <param name="QrInvoiceId">Read-only reference to a QR invoice id.</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+/// <param name="Taxs">Read-only aggregated tax summary lines.</param>
+/// <param name="NetworkLink">Read-only network link used by the Bexio document viewer.</param>
+/// <param name="Positions">Optional polymorphic positions array populated on show/create/update responses. Kept as raw <see cref="JsonElement"/> values since Bexio returns a union of several position types.</param>
+public sealed record Invoice(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("document_nr")] string? DocumentNr,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("contact_id")] int? ContactId,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("project_id")] int? ProjectId,
+    [property: JsonPropertyName("pr_project_id")] int? PrProjectId,
+    [property: JsonPropertyName("logopaper_id")] int? LogopaperId,
+    [property: JsonPropertyName("language_id")] int? LanguageId,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId,
+    [property: JsonPropertyName("currency_id")] int? CurrencyId,
+    [property: JsonPropertyName("payment_type_id")] int? PaymentTypeId,
+    [property: JsonPropertyName("header")] string? Header,
+    [property: JsonPropertyName("footer")] string? Footer,
+    [property: JsonPropertyName("total_gross")] string? TotalGross,
+    [property: JsonPropertyName("total_net")] string? TotalNet,
+    [property: JsonPropertyName("total_taxes")] string? TotalTaxes,
+    [property: JsonPropertyName("total_received_payments")] string? TotalReceivedPayments,
+    [property: JsonPropertyName("total_credit_vouchers")] string? TotalCreditVouchers,
+    [property: JsonPropertyName("total_remaining_payments")] string? TotalRemainingPayments,
+    [property: JsonPropertyName("total")] string? Total,
+    [property: JsonPropertyName("total_rounding_difference")] decimal? TotalRoundingDifference,
+    [property: JsonPropertyName("mwst_type")] int? MwstType,
+    [property: JsonPropertyName("mwst_is_net")] bool? MwstIsNet,
+    [property: JsonPropertyName("show_position_taxes")] bool? ShowPositionTaxes,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom,
+    [property: JsonPropertyName("is_valid_to")] string? IsValidTo,
+    [property: JsonPropertyName("contact_address")] string? ContactAddress,
+    [property: JsonPropertyName("contact_address_manual")] string? ContactAddressManual,
+    [property: JsonPropertyName("kb_item_status_id")] int? KbItemStatusId,
+    [property: JsonPropertyName("reference")] string? Reference,
+    [property: JsonPropertyName("api_reference")] string? ApiReference,
+    [property: JsonPropertyName("viewed_by_client_at")] string? ViewedByClientAt,
+    [property: JsonPropertyName("updated_at")] string? UpdatedAt,
+    [property: JsonPropertyName("esr_id")] int? EsrId,
+    [property: JsonPropertyName("qr_invoice_id")] int? QrInvoiceId,
+    [property: JsonPropertyName("template_slug")] string? TemplateSlug,
+    [property: JsonPropertyName("taxs")] IReadOnlyList<InvoiceTax>? Taxs,
+    [property: JsonPropertyName("network_link")] string? NetworkLink,
+    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/InvoicePayment.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/InvoicePayment.cs
@@ -1,0 +1,57 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Invoices;
+
+/// <summary>
+/// Payment applied to an <see cref="Invoice"/> via <c>/2.0/kb_invoice/{invoice_id}/payment</c>.
+/// <see href="https://docs.bexio.com/#tag/Invoice-Payments/operation/v2ListInvoicePayments"/>
+/// </summary>
+/// <param name="Id">Unique payment identifier (read-only).</param>
+/// <param name="Date">Payment value date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="Value">Payment amount as a formatted decimal string (required).</param>
+/// <param name="BankAccountId">Optional reference to a bank account object.</param>
+/// <param name="Title">Read-only payment title (e.g. <c>Received Payment</c>).</param>
+/// <param name="PaymentServiceId">External payment service used: <c>1</c> PayPal, <c>2</c> Stripe, <c>3</c> SIX Payments.</param>
+/// <param name="IsClientAccountRedemption">Read-only flag — <see langword="true"/> when the payment redeems a client account balance.</param>
+/// <param name="IsCashDiscount">Read-only flag — <see langword="true"/> when the payment represents a cash discount.</param>
+/// <param name="KbInvoiceId">Read-only reference to the invoice the payment belongs to.</param>
+/// <param name="KbCreditVoucherId">Read-only reference to a credit voucher if the payment originates from one.</param>
+/// <param name="KbBillId">Read-only reference to a bill if the payment originates from one.</param>
+/// <param name="KbCreditVoucherText">Read-only credit voucher description text.</param>
+public sealed record InvoicePayment(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("date")] DateOnly? Date,
+    [property: JsonPropertyName("value")] string Value,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("payment_service_id")] int? PaymentServiceId,
+    [property: JsonPropertyName("is_client_account_redemption")] bool? IsClientAccountRedemption,
+    [property: JsonPropertyName("is_cash_discount")] bool? IsCashDiscount,
+    [property: JsonPropertyName("kb_invoice_id")] int? KbInvoiceId,
+    [property: JsonPropertyName("kb_credit_voucher_id")] int? KbCreditVoucherId,
+    [property: JsonPropertyName("kb_bill_id")] int? KbBillId,
+    [property: JsonPropertyName("kb_credit_voucher_text")] string? KbCreditVoucherText
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/InvoiceTax.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/InvoiceTax.cs
@@ -1,0 +1,37 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Invoices;
+
+/// <summary>
+/// Read-only tax summary line aggregated onto an <see cref="Invoice"/> by the Bexio API.
+/// Exposed as the items of <see cref="Invoice.Taxs"/>.
+/// </summary>
+/// <param name="Percentage">Tax percentage as a formatted decimal string (e.g. <c>"7.70"</c>).</param>
+/// <param name="Value">Amount of tax applied at the given percentage as a formatted decimal string.</param>
+public sealed record InvoiceTax(
+    [property: JsonPropertyName("percentage")] string? Percentage,
+    [property: JsonPropertyName("value")] string? Value
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceCopyRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceCopyRequest.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+
+/// <summary>
+/// Body for <c>POST /2.0/kb_invoice/{invoice_id}/copy</c>. Copies an existing invoice into a
+/// new draft invoice, optionally overriding the contact, validity date and title.
+/// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2CopyInvoice"/>
+/// </summary>
+/// <param name="ContactId">References a contact object (required by Bexio).</param>
+/// <param name="ContactSubId">Optional additional contact reference.</param>
+/// <param name="IsValidFrom">Optional validity-from override in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="Title">Optional invoice title override.</param>
+public sealed record InvoiceCopyRequest(
+    [property: JsonPropertyName("contact_id")] int ContactId,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("title")] string? Title = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceCreate.cs
@@ -1,0 +1,83 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+
+/// <summary>
+/// Create view for an invoice — body of <c>POST /2.0/kb_invoice</c>. Read-only fields (id, totals,
+/// contact_address, kb_item_status_id, updated_at, esr_id, qr_invoice_id, taxs, network_link,
+/// project_id, viewed_by_client_at) are intentionally omitted.
+/// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2CreateInvoice"/>
+/// </summary>
+/// <param name="UserId">References the user that owns the invoice.</param>
+/// <param name="DocumentNr">Invoice number. Must be omitted when automatic numbering is enabled.</param>
+/// <param name="Title">Invoice title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="PrProjectId">Write-only reference to a project object.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the invoice.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">When <see langword="true"/> and <see cref="MwstType"/> is <c>0</c>, totals are interpreted as net.</param>
+/// <param name="ShowPositionTaxes">When <see langword="true"/>, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Invoice validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidTo">Invoice due date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="Reference">Free-text reference displayed on the invoice.</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+/// <param name="Positions">Polymorphic list of positions to create. Bexio accepts a union of several position types, so they are accepted as raw <see cref="JsonElement"/> values.</param>
+public sealed record InvoiceCreate(
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("document_nr")] string? DocumentNr = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_id")] int? ContactId = null,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("pr_project_id")] int? PrProjectId = null,
+    [property: JsonPropertyName("logopaper_id")] int? LogopaperId = null,
+    [property: JsonPropertyName("language_id")] int? LanguageId = null,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId = null,
+    [property: JsonPropertyName("currency_id")] int? CurrencyId = null,
+    [property: JsonPropertyName("payment_type_id")] int? PaymentTypeId = null,
+    [property: JsonPropertyName("header")] string? Header = null,
+    [property: JsonPropertyName("footer")] string? Footer = null,
+    [property: JsonPropertyName("mwst_type")] int? MwstType = null,
+    [property: JsonPropertyName("mwst_is_net")] bool? MwstIsNet = null,
+    [property: JsonPropertyName("show_position_taxes")] bool? ShowPositionTaxes = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("is_valid_to")] string? IsValidTo = null,
+    [property: JsonPropertyName("contact_address_manual")] string? ContactAddressManual = null,
+    [property: JsonPropertyName("reference")] string? Reference = null,
+    [property: JsonPropertyName("api_reference")] string? ApiReference = null,
+    [property: JsonPropertyName("template_slug")] string? TemplateSlug = null,
+    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoicePaymentCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoicePaymentCreate.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+
+/// <summary>
+/// Create view for an invoice payment — body of <c>POST /2.0/kb_invoice/{invoice_id}/payment</c>.
+/// Read-only fields (id, title, kb_invoice_id, kb_credit_voucher_id, kb_bill_id,
+/// kb_credit_voucher_text, is_client_account_redemption, is_cash_discount) are intentionally
+/// omitted.
+/// <see href="https://docs.bexio.com/#tag/Invoice-Payments/operation/v2CreateInvoicePayment"/>
+/// </summary>
+/// <param name="Value">Payment amount as a formatted decimal string (required).</param>
+/// <param name="Date">Payment value date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="BankAccountId">Optional reference to a bank account object.</param>
+/// <param name="PaymentServiceId">External payment service used: <c>1</c> PayPal, <c>2</c> Stripe, <c>3</c> SIX Payments.</param>
+public sealed record InvoicePaymentCreate(
+    [property: JsonPropertyName("value")] string Value,
+    [property: JsonPropertyName("date")] DateOnly? Date = null,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId = null,
+    [property: JsonPropertyName("payment_service_id")] int? PaymentServiceId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceSendRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceSendRequest.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+
+/// <summary>
+/// Body for <c>POST /2.0/kb_invoice/{invoice_id}/send</c>. Sends the invoice via Bexio's network
+/// mail service. The <c>[Network Link]</c> placeholder must be present in <see cref="Message"/>.
+/// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2SendInvoice"/>
+/// </summary>
+/// <param name="RecipientEmail">Recipient email address (required). During trial the recipient is limited to the token owner.</param>
+/// <param name="Subject">Email subject (required).</param>
+/// <param name="Message">Email body (required). Must contain the <c>[Network Link]</c> placeholder.</param>
+/// <param name="MarkAsOpen">When <see langword="true"/>, marks the invoice as open after sending.</param>
+/// <param name="AttachPdf">When <see langword="true"/>, attaches the PDF directly to the email.</param>
+public sealed record InvoiceSendRequest(
+    [property: JsonPropertyName("recipient_email")] string RecipientEmail,
+    [property: JsonPropertyName("subject")] string Subject,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("mark_as_open")] bool? MarkAsOpen = null,
+    [property: JsonPropertyName("attach_pdf")] bool? AttachPdf = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceUpdate.cs
@@ -1,0 +1,82 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+
+/// <summary>
+/// Update view for an invoice — body of <c>POST /2.0/kb_invoice/{invoice_id}</c>. Bexio uses
+/// <c>POST</c> (not <c>PUT</c>) for full-replacement edits on this resource. Read-only fields
+/// (id, totals, contact_address, kb_item_status_id, updated_at, esr_id, qr_invoice_id, taxs,
+/// network_link, project_id, viewed_by_client_at) are intentionally omitted — the Bexio API
+/// rejects payloads containing <c>positions</c> on this endpoint, so positions live only on
+/// <see cref="InvoiceCreate"/>.
+/// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2EditInvoice"/>
+/// </summary>
+/// <param name="UserId">References the user that owns the invoice.</param>
+/// <param name="DocumentNr">Invoice number. Must be omitted when automatic numbering is enabled.</param>
+/// <param name="Title">Invoice title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="PrProjectId">Write-only reference to a project object.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the invoice.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">When <see langword="true"/> and <see cref="MwstType"/> is <c>0</c>, totals are interpreted as net.</param>
+/// <param name="ShowPositionTaxes">When <see langword="true"/>, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Invoice validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidTo">Invoice due date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="Reference">Free-text reference displayed on the invoice.</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+public sealed record InvoiceUpdate(
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("document_nr")] string? DocumentNr = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_id")] int? ContactId = null,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("pr_project_id")] int? PrProjectId = null,
+    [property: JsonPropertyName("logopaper_id")] int? LogopaperId = null,
+    [property: JsonPropertyName("language_id")] int? LanguageId = null,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId = null,
+    [property: JsonPropertyName("currency_id")] int? CurrencyId = null,
+    [property: JsonPropertyName("payment_type_id")] int? PaymentTypeId = null,
+    [property: JsonPropertyName("header")] string? Header = null,
+    [property: JsonPropertyName("footer")] string? Footer = null,
+    [property: JsonPropertyName("mwst_type")] int? MwstType = null,
+    [property: JsonPropertyName("mwst_is_net")] bool? MwstIsNet = null,
+    [property: JsonPropertyName("show_position_taxes")] bool? ShowPositionTaxes = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("is_valid_to")] string? IsValidTo = null,
+    [property: JsonPropertyName("contact_address_manual")] string? ContactAddressManual = null,
+    [property: JsonPropertyName("reference")] string? Reference = null,
+    [property: JsonPropertyName("api_reference")] string? ApiReference = null,
+    [property: JsonPropertyName("template_slug")] string? TemplateSlug = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Order.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Order.cs
@@ -1,0 +1,157 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Orders;
+
+/// <summary>
+///     Order as returned by the Bexio <c>/2.0/kb_order</c> endpoint. Covers both the plain
+///     <c>Order</c> schema returned by list and the <c>OrderWithDetails</c> variant returned by
+///     show/create/update (which additionally populates <see cref="Positions" />).
+///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ListOrders" />
+/// </summary>
+/// <param name="Id">Unique order identifier (read-only).</param>
+/// <param name="DocumentNr">Order number. Must be omitted when automatic numbering is enabled, required otherwise.</param>
+/// <param name="Title">Order title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="UserId">References the user that owns the order.</param>
+/// <param name="ProjectId">Read-only reference to a project object.</param>
+/// <param name="PrProjectId">Write-only reference to a project object, accepted on create/update.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the order.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="TotalGross">Gross total as a formatted decimal string (read-only).</param>
+/// <param name="TotalNet">Net total as a formatted decimal string (read-only).</param>
+/// <param name="TotalTaxes">Total of applicable taxes as a formatted decimal string (read-only).</param>
+/// <param name="Total">Grand total as a formatted decimal string (read-only).</param>
+/// <param name="TotalRoundingDifference">Rounding difference applied to the total (read-only).</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">
+///     When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
+///     net.
+/// </param>
+/// <param name="ShowPositionTaxes">When <see langword="true" />, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddress">Composed contact address string (read-only).</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="DeliveryAddressType">
+///     Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
+///     address.
+/// </param>
+/// <param name="DeliveryAddress">Composed delivery address string (read-only).</param>
+/// <param name="DeliveryAddressManual">
+///     Manually overridden delivery address (write-only, used when
+///     <see cref="DeliveryAddressType" /> is <c>1</c>).
+/// </param>
+/// <param name="KbItemStatusId">Read-only order status id (5 Pending, 6 Done, 15 Partial, 21 Canceled).</param>
+/// <param name="IsRecurring">When <see langword="true" />, the order has a repetition schedule attached (read-only).</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="ViewedByClientAt">Timestamp when the order was first opened by the recipient (read-only).</param>
+/// <param name="UpdatedAt">Timestamp of the last update in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format (read-only).</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+/// <param name="Taxs">Read-only aggregated tax summary lines.</param>
+/// <param name="NetworkLink">Read-only network link used by the Bexio document viewer.</param>
+/// <param name="Positions">
+///     Optional polymorphic positions array populated on show/create/update responses. Kept as raw
+///     <see cref="JsonElement" /> values since Bexio returns a union of several position types.
+/// </param>
+public sealed record Order(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("document_nr")]
+    string? DocumentNr,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("contact_id")]
+    int? ContactId,
+    [property: JsonPropertyName("contact_sub_id")]
+    int? ContactSubId,
+    [property: JsonPropertyName("user_id")]
+    int UserId,
+    [property: JsonPropertyName("project_id")]
+    int? ProjectId,
+    [property: JsonPropertyName("pr_project_id")]
+    int? PrProjectId,
+    [property: JsonPropertyName("logopaper_id")]
+    int? LogopaperId,
+    [property: JsonPropertyName("language_id")]
+    int? LanguageId,
+    [property: JsonPropertyName("bank_account_id")]
+    int? BankAccountId,
+    [property: JsonPropertyName("currency_id")]
+    int? CurrencyId,
+    [property: JsonPropertyName("payment_type_id")]
+    int? PaymentTypeId,
+    [property: JsonPropertyName("header")] string? Header,
+    [property: JsonPropertyName("footer")] string? Footer,
+    [property: JsonPropertyName("total_gross")]
+    string? TotalGross,
+    [property: JsonPropertyName("total_net")]
+    string? TotalNet,
+    [property: JsonPropertyName("total_taxes")]
+    string? TotalTaxes,
+    [property: JsonPropertyName("total")] string? Total,
+    [property: JsonPropertyName("total_rounding_difference")]
+    decimal? TotalRoundingDifference,
+    [property: JsonPropertyName("mwst_type")]
+    int? MwstType,
+    [property: JsonPropertyName("mwst_is_net")]
+    bool? MwstIsNet,
+    [property: JsonPropertyName("show_position_taxes")]
+    bool? ShowPositionTaxes,
+    [property: JsonPropertyName("is_valid_from")]
+    string? IsValidFrom,
+    [property: JsonPropertyName("contact_address")]
+    string? ContactAddress,
+    [property: JsonPropertyName("contact_address_manual")]
+    string? ContactAddressManual,
+    [property: JsonPropertyName("delivery_address_type")]
+    int? DeliveryAddressType,
+    [property: JsonPropertyName("delivery_address")]
+    string? DeliveryAddress,
+    [property: JsonPropertyName("delivery_address_manual")]
+    string? DeliveryAddressManual,
+    [property: JsonPropertyName("kb_item_status_id")]
+    int? KbItemStatusId,
+    [property: JsonPropertyName("is_recurring")]
+    bool? IsRecurring,
+    [property: JsonPropertyName("api_reference")]
+    string? ApiReference,
+    [property: JsonPropertyName("viewed_by_client_at")]
+    string? ViewedByClientAt,
+    [property: JsonPropertyName("updated_at")]
+    string? UpdatedAt,
+    [property: JsonPropertyName("template_slug")]
+    string? TemplateSlug,
+    [property: JsonPropertyName("taxs")] IReadOnlyList<OrderTax>? Taxs,
+    [property: JsonPropertyName("network_link")]
+    string? NetworkLink,
+    [property: JsonPropertyName("positions")]
+    IReadOnlyList<JsonElement>? Positions
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetition.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetition.cs
@@ -1,0 +1,52 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Orders;
+
+/// <summary>
+///     Order repetition payload returned by (and accepted by) the Bexio
+///     <c>/2.0/kb_order/{order_id}/repetition</c> endpoints. The <see cref="Repetition" /> field is
+///     a polymorphic <c>oneOf</c> union of <c>OrderRepetitionDaily</c>, <c>OrderRepetitionWeekly</c>,
+///     <c>OrderRepetitionMonthly</c> and <c>OrderRepetitionYearly</c>, so it is surfaced as a raw
+///     <see cref="JsonElement" /> to preserve fidelity without prescribing a specific subtype.
+///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition" />
+/// </summary>
+/// <param name="Start">Repetition start date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="End">
+///     Repetition end date in Bexio's <c>yyyy-MM-dd</c> format; <see langword="null" /> for indefinite
+///     repetitions.
+/// </param>
+/// <param name="Repetition">
+///     Polymorphic repetition descriptor carrying the <c>type</c> discriminator (<c>daily</c>,
+///     <c>weekly</c>, <c>monthly</c>, <c>yearly</c>) and the schedule fields for that type.
+/// </param>
+public sealed record OrderRepetition(
+    [property: JsonPropertyName("start")] string? Start,
+    [property: JsonPropertyName("end")] string? End,
+    [property: JsonPropertyName("repetition")]
+    JsonElement? Repetition
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderTax.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderTax.cs
@@ -1,0 +1,38 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Orders;
+
+/// <summary>
+///     Read-only tax summary line aggregated onto an <see cref="Order" /> by the Bexio API.
+///     Exposed as the items of <see cref="Order.Taxs" />.
+/// </summary>
+/// <param name="Percentage">Tax percentage as a formatted decimal string (e.g. <c>"7.70"</c>).</param>
+/// <param name="Value">Amount of tax applied at the given percentage as a formatted decimal string.</param>
+public sealed record OrderTax(
+    [property: JsonPropertyName("percentage")]
+    string? Percentage,
+    [property: JsonPropertyName("value")] string? Value
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderConvertRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderConvertRequest.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
+
+/// <summary>
+///     Body for <c>POST /2.0/kb_order/{order_id}/delivery</c> and <c>POST /2.0/kb_order/{order_id}/invoice</c>.
+///     When <see cref="Positions" /> is <see langword="null" />, Bexio copies every position from the source
+///     order; otherwise the supplied subset is used. Positions are a polymorphic union of Bexio's
+///     <c>KbPosition*</c> types, so they are accepted as raw <see cref="JsonElement" /> values.
+///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateDeliveryFromOrder" />
+///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateInvoiceFromOrder" />
+/// </summary>
+/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
+public sealed record OrderConvertRequest(
+    [property: JsonPropertyName("positions")]
+    IReadOnlyList<JsonElement>? Positions = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderCreate.cs
@@ -1,0 +1,115 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
+
+/// <summary>
+///     Create view for an order — body of <c>POST /2.0/kb_order</c>. Read-only fields (id, totals,
+///     contact_address, delivery_address, kb_item_status_id, is_recurring, updated_at, taxs,
+///     network_link, project_id, viewed_by_client_at) are intentionally omitted.
+///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateOrder" />
+/// </summary>
+/// <param name="UserId">References the user that owns the order.</param>
+/// <param name="DocumentNr">Order number. Must be omitted when automatic numbering is enabled.</param>
+/// <param name="Title">Order title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="PrProjectId">Write-only reference to a project object.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the order.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">
+///     When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
+///     net.
+/// </param>
+/// <param name="ShowPositionTaxes">When <see langword="true" />, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="DeliveryAddressType">
+///     Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
+///     address.
+/// </param>
+/// <param name="DeliveryAddressManual">
+///     Manually overridden delivery address (write-only, used when
+///     <see cref="DeliveryAddressType" /> is <c>1</c>).
+/// </param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+/// <param name="Positions">
+///     Polymorphic list of positions to create. Bexio accepts a union of several position types, so
+///     they are accepted as raw <see cref="JsonElement" /> values.
+/// </param>
+public sealed record OrderCreate(
+    [property: JsonPropertyName("user_id")]
+    int UserId,
+    [property: JsonPropertyName("document_nr")]
+    string? DocumentNr = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_id")]
+    int? ContactId = null,
+    [property: JsonPropertyName("contact_sub_id")]
+    int? ContactSubId = null,
+    [property: JsonPropertyName("pr_project_id")]
+    int? PrProjectId = null,
+    [property: JsonPropertyName("logopaper_id")]
+    int? LogopaperId = null,
+    [property: JsonPropertyName("language_id")]
+    int? LanguageId = null,
+    [property: JsonPropertyName("bank_account_id")]
+    int? BankAccountId = null,
+    [property: JsonPropertyName("currency_id")]
+    int? CurrencyId = null,
+    [property: JsonPropertyName("payment_type_id")]
+    int? PaymentTypeId = null,
+    [property: JsonPropertyName("header")] string? Header = null,
+    [property: JsonPropertyName("footer")] string? Footer = null,
+    [property: JsonPropertyName("mwst_type")]
+    int? MwstType = null,
+    [property: JsonPropertyName("mwst_is_net")]
+    bool? MwstIsNet = null,
+    [property: JsonPropertyName("show_position_taxes")]
+    bool? ShowPositionTaxes = null,
+    [property: JsonPropertyName("is_valid_from")]
+    string? IsValidFrom = null,
+    [property: JsonPropertyName("contact_address_manual")]
+    string? ContactAddressManual = null,
+    [property: JsonPropertyName("delivery_address_type")]
+    int? DeliveryAddressType = null,
+    [property: JsonPropertyName("delivery_address_manual")]
+    string? DeliveryAddressManual = null,
+    [property: JsonPropertyName("api_reference")]
+    string? ApiReference = null,
+    [property: JsonPropertyName("template_slug")]
+    string? TemplateSlug = null,
+    [property: JsonPropertyName("positions")]
+    IReadOnlyList<JsonElement>? Positions = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderRepetitionCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderRepetitionCreate.cs
@@ -1,0 +1,52 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
+
+/// <summary>
+///     Create/edit view for an order repetition — body of <c>POST /2.0/kb_order/{order_id}/repetition</c>.
+///     Bexio exposes the same <c>OrderRepetition</c> schema on the way in and out, and uses the same
+///     endpoint for both creating a fresh repetition and replacing an existing one (there is no
+///     dedicated PUT).
+///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrderRepetition" />
+/// </summary>
+/// <param name="Start">Repetition start date in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="Repetition">
+///     Polymorphic repetition descriptor (<c>daily</c>, <c>weekly</c>, <c>monthly</c> or
+///     <c>yearly</c>). Accepted as a raw <see cref="JsonElement" /> so callers can build the appropriate subtype without
+///     the library prescribing a schema.
+/// </param>
+/// <param name="End">
+///     Optional repetition end date in Bexio's <c>yyyy-MM-dd</c> format. When <see langword="null" /> the
+///     repetition runs indefinitely.
+/// </param>
+public sealed record OrderRepetitionCreate(
+    [property: JsonPropertyName("start")] string Start,
+    [property: JsonPropertyName("repetition")]
+    JsonElement Repetition,
+    [property: JsonPropertyName("end")] string? End = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderUpdate.cs
@@ -1,0 +1,110 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
+
+/// <summary>
+///     Update view for an order — body of <c>POST /2.0/kb_order/{order_id}</c>. Bexio uses
+///     <c>POST</c> (not <c>PUT</c>) for full-replacement edits on this resource. Read-only fields
+///     (id, totals, contact_address, delivery_address, kb_item_status_id, is_recurring, updated_at,
+///     taxs, network_link, project_id, viewed_by_client_at) are intentionally omitted — positions
+///     are managed via the dedicated position sub-resources, so they live only on
+///     <see cref="OrderCreate" />.
+///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrder" />
+/// </summary>
+/// <param name="UserId">References the user that owns the order.</param>
+/// <param name="DocumentNr">Order number. Must be omitted when automatic numbering is enabled.</param>
+/// <param name="Title">Order title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="PrProjectId">Write-only reference to a project object.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the order.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">
+///     When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
+///     net.
+/// </param>
+/// <param name="ShowPositionTaxes">When <see langword="true" />, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="DeliveryAddressType">
+///     Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
+///     address.
+/// </param>
+/// <param name="DeliveryAddressManual">
+///     Manually overridden delivery address (write-only, used when
+///     <see cref="DeliveryAddressType" /> is <c>1</c>).
+/// </param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+public sealed record OrderUpdate(
+    [property: JsonPropertyName("user_id")]
+    int UserId,
+    [property: JsonPropertyName("document_nr")]
+    string? DocumentNr = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_id")]
+    int? ContactId = null,
+    [property: JsonPropertyName("contact_sub_id")]
+    int? ContactSubId = null,
+    [property: JsonPropertyName("pr_project_id")]
+    int? PrProjectId = null,
+    [property: JsonPropertyName("logopaper_id")]
+    int? LogopaperId = null,
+    [property: JsonPropertyName("language_id")]
+    int? LanguageId = null,
+    [property: JsonPropertyName("bank_account_id")]
+    int? BankAccountId = null,
+    [property: JsonPropertyName("currency_id")]
+    int? CurrencyId = null,
+    [property: JsonPropertyName("payment_type_id")]
+    int? PaymentTypeId = null,
+    [property: JsonPropertyName("header")] string? Header = null,
+    [property: JsonPropertyName("footer")] string? Footer = null,
+    [property: JsonPropertyName("mwst_type")]
+    int? MwstType = null,
+    [property: JsonPropertyName("mwst_is_net")]
+    bool? MwstIsNet = null,
+    [property: JsonPropertyName("show_position_taxes")]
+    bool? ShowPositionTaxes = null,
+    [property: JsonPropertyName("is_valid_from")]
+    string? IsValidFrom = null,
+    [property: JsonPropertyName("contact_address_manual")]
+    string? ContactAddressManual = null,
+    [property: JsonPropertyName("delivery_address_type")]
+    int? DeliveryAddressType = null,
+    [property: JsonPropertyName("delivery_address_manual")]
+    string? DeliveryAddressManual = null,
+    [property: JsonPropertyName("api_reference")]
+    string? ApiReference = null,
+    [property: JsonPropertyName("template_slug")]
+    string? TemplateSlug = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Quote.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Quote.cs
@@ -1,0 +1,117 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Quotes;
+
+/// <summary>
+/// Quote (Offer) as returned by the Bexio <c>/2.0/kb_offer</c> endpoint. Covers both the plain
+/// <c>Quote</c> schema returned by list and the <c>QuoteWithDetails</c> variant returned by
+/// show/create/update (which additionally populates <see cref="Positions"/>).
+/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2ListQuotes"/>
+/// </summary>
+/// <param name="Id">Unique quote identifier (read-only).</param>
+/// <param name="DocumentNr">Quote number. Must be omitted when automatic numbering is enabled, required otherwise.</param>
+/// <param name="Title">Quote title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="UserId">References the user that owns the quote.</param>
+/// <param name="ProjectId">Read-only reference to a project object.</param>
+/// <param name="PrProjectId">Write-only reference to a project object, accepted on create/update.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the quote.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="TotalGross">Gross total as a formatted decimal string (read-only).</param>
+/// <param name="TotalNet">Net total as a formatted decimal string (read-only).</param>
+/// <param name="TotalTaxes">Total of applicable taxes as a formatted decimal string (read-only).</param>
+/// <param name="Total">Grand total as a formatted decimal string (read-only).</param>
+/// <param name="TotalRoundingDifference">Rounding difference applied to the total (read-only).</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">When <see langword="true"/> and <see cref="MwstType"/> is <c>0</c>, totals are interpreted as net.</param>
+/// <param name="ShowPositionTaxes">When <see langword="true"/>, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Quote validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidUntil">Quote validity end in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddress">Composed contact address string (read-only).</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="DeliveryAddressType">Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery address.</param>
+/// <param name="DeliveryAddress">Composed delivery address string (read-only).</param>
+/// <param name="DeliveryAddressManual">Manually overridden delivery address (write-only, used when <see cref="DeliveryAddressType"/> is <c>1</c>).</param>
+/// <param name="KbItemStatusId">Read-only quote status id (1 Draft, 2 Pending, 3 Confirmed, 4 Declined).</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="ViewedByClientAt">Timestamp when the quote was first opened by the recipient (read-only).</param>
+/// <param name="KbTermsOfPaymentTemplateId">Optional reference to a terms-of-payment template.</param>
+/// <param name="ShowTotal">When <see langword="true"/>, the total is shown on the printed document (read-only).</param>
+/// <param name="UpdatedAt">Timestamp of the last update in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format (read-only).</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+/// <param name="Taxs">Read-only aggregated tax summary lines.</param>
+/// <param name="NetworkLink">Read-only network link used by the Bexio document viewer.</param>
+/// <param name="Positions">Optional polymorphic positions array populated on show/create/update responses. Kept as raw <see cref="JsonElement"/> values since Bexio returns a union of several position types.</param>
+public sealed record Quote(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("document_nr")] string? DocumentNr,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("contact_id")] int? ContactId,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("project_id")] int? ProjectId,
+    [property: JsonPropertyName("pr_project_id")] int? PrProjectId,
+    [property: JsonPropertyName("logopaper_id")] int? LogopaperId,
+    [property: JsonPropertyName("language_id")] int? LanguageId,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId,
+    [property: JsonPropertyName("currency_id")] int? CurrencyId,
+    [property: JsonPropertyName("payment_type_id")] int? PaymentTypeId,
+    [property: JsonPropertyName("header")] string? Header,
+    [property: JsonPropertyName("footer")] string? Footer,
+    [property: JsonPropertyName("total_gross")] string? TotalGross,
+    [property: JsonPropertyName("total_net")] string? TotalNet,
+    [property: JsonPropertyName("total_taxes")] string? TotalTaxes,
+    [property: JsonPropertyName("total")] string? Total,
+    [property: JsonPropertyName("total_rounding_difference")] decimal? TotalRoundingDifference,
+    [property: JsonPropertyName("mwst_type")] int? MwstType,
+    [property: JsonPropertyName("mwst_is_net")] bool? MwstIsNet,
+    [property: JsonPropertyName("show_position_taxes")] bool? ShowPositionTaxes,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom,
+    [property: JsonPropertyName("is_valid_until")] string? IsValidUntil,
+    [property: JsonPropertyName("contact_address")] string? ContactAddress,
+    [property: JsonPropertyName("contact_address_manual")] string? ContactAddressManual,
+    [property: JsonPropertyName("delivery_address_type")] int? DeliveryAddressType,
+    [property: JsonPropertyName("delivery_address")] string? DeliveryAddress,
+    [property: JsonPropertyName("delivery_address_manual")] string? DeliveryAddressManual,
+    [property: JsonPropertyName("kb_item_status_id")] int? KbItemStatusId,
+    [property: JsonPropertyName("api_reference")] string? ApiReference,
+    [property: JsonPropertyName("viewed_by_client_at")] string? ViewedByClientAt,
+    [property: JsonPropertyName("kb_terms_of_payment_template_id")] int? KbTermsOfPaymentTemplateId,
+    [property: JsonPropertyName("show_total")] bool? ShowTotal,
+    [property: JsonPropertyName("updated_at")] string? UpdatedAt,
+    [property: JsonPropertyName("template_slug")] string? TemplateSlug,
+    [property: JsonPropertyName("taxs")] IReadOnlyList<QuoteTax>? Taxs,
+    [property: JsonPropertyName("network_link")] string? NetworkLink,
+    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/QuoteTax.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/QuoteTax.cs
@@ -1,0 +1,37 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Quotes;
+
+/// <summary>
+/// Read-only tax summary line aggregated onto a <see cref="Quote"/> by the Bexio API.
+/// Exposed as the items of <see cref="Quote.Taxs"/>.
+/// </summary>
+/// <param name="Percentage">Tax percentage as a formatted decimal string (e.g. <c>"7.70"</c>).</param>
+/// <param name="Value">Amount of tax applied at the given percentage as a formatted decimal string.</param>
+public sealed record QuoteTax(
+    [property: JsonPropertyName("percentage")] string? Percentage,
+    [property: JsonPropertyName("value")] string? Value
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteConvertRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteConvertRequest.cs
@@ -1,0 +1,41 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+
+/// <summary>
+/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
+/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
+/// quote; otherwise the supplied subset is used. Positions are a polymorphic union of Bexio's
+/// <c>KbPosition*</c> types, so they are accepted as raw <see cref="JsonElement"/> values.
+/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
+/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+/// </summary>
+/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
+public sealed record QuoteConvertRequest(
+    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteCopyRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteCopyRequest.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+
+/// <summary>
+/// Body for <c>POST /2.0/kb_offer/{quote_id}/copy</c>. Copies an existing quote into a new
+/// draft quote, optionally overriding the contact, validity start, project link and title.
+/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CopyQuote"/>
+/// </summary>
+/// <param name="ContactId">References a contact object (required by Bexio).</param>
+/// <param name="ContactSubId">Optional additional contact reference.</param>
+/// <param name="IsValidFrom">Optional validity-from override in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="PrProjectId">Optional write-only project reference to associate with the new quote.</param>
+/// <param name="Title">Optional quote title override.</param>
+public sealed record QuoteCopyRequest(
+    [property: JsonPropertyName("contact_id")] int ContactId,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("pr_project_id")] int? PrProjectId = null,
+    [property: JsonPropertyName("title")] string? Title = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteCreate.cs
@@ -1,0 +1,87 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+
+/// <summary>
+/// Create view for a quote — body of <c>POST /2.0/kb_offer</c>. Read-only fields (id, totals,
+/// contact_address, delivery_address, kb_item_status_id, show_total, updated_at, taxs,
+/// network_link, project_id, viewed_by_client_at) are intentionally omitted.
+/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateQuote"/>
+/// </summary>
+/// <param name="UserId">References the user that owns the quote.</param>
+/// <param name="DocumentNr">Quote number. Must be omitted when automatic numbering is enabled.</param>
+/// <param name="Title">Quote title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="PrProjectId">Write-only reference to a project object.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the quote.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">When <see langword="true"/> and <see cref="MwstType"/> is <c>0</c>, totals are interpreted as net.</param>
+/// <param name="ShowPositionTaxes">When <see langword="true"/>, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Quote validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidUntil">Quote validity end in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="DeliveryAddressType">Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery address.</param>
+/// <param name="DeliveryAddressManual">Manually overridden delivery address (write-only, used when <see cref="DeliveryAddressType"/> is <c>1</c>).</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="KbTermsOfPaymentTemplateId">Optional reference to a terms-of-payment template.</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+/// <param name="Positions">Polymorphic list of positions to create. Bexio accepts a union of several position types, so they are accepted as raw <see cref="JsonElement"/> values.</param>
+public sealed record QuoteCreate(
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("document_nr")] string? DocumentNr = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_id")] int? ContactId = null,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("pr_project_id")] int? PrProjectId = null,
+    [property: JsonPropertyName("logopaper_id")] int? LogopaperId = null,
+    [property: JsonPropertyName("language_id")] int? LanguageId = null,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId = null,
+    [property: JsonPropertyName("currency_id")] int? CurrencyId = null,
+    [property: JsonPropertyName("payment_type_id")] int? PaymentTypeId = null,
+    [property: JsonPropertyName("header")] string? Header = null,
+    [property: JsonPropertyName("footer")] string? Footer = null,
+    [property: JsonPropertyName("mwst_type")] int? MwstType = null,
+    [property: JsonPropertyName("mwst_is_net")] bool? MwstIsNet = null,
+    [property: JsonPropertyName("show_position_taxes")] bool? ShowPositionTaxes = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("is_valid_until")] string? IsValidUntil = null,
+    [property: JsonPropertyName("contact_address_manual")] string? ContactAddressManual = null,
+    [property: JsonPropertyName("delivery_address_type")] int? DeliveryAddressType = null,
+    [property: JsonPropertyName("delivery_address_manual")] string? DeliveryAddressManual = null,
+    [property: JsonPropertyName("api_reference")] string? ApiReference = null,
+    [property: JsonPropertyName("kb_terms_of_payment_template_id")] int? KbTermsOfPaymentTemplateId = null,
+    [property: JsonPropertyName("template_slug")] string? TemplateSlug = null,
+    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteSendRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteSendRequest.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+
+/// <summary>
+/// Body for <c>POST /2.0/kb_offer/{quote_id}/send</c>. Sends the quote via Bexio's network
+/// mail service. The <c>[Network Link]</c> placeholder must be present in <see cref="Message"/>.
+/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2SendQuote"/>
+/// </summary>
+/// <param name="RecipientEmail">Recipient email address (required). During trial the recipient is limited to the token owner.</param>
+/// <param name="Subject">Email subject (required).</param>
+/// <param name="Message">Email body (required). Must contain the <c>[Network Link]</c> placeholder.</param>
+/// <param name="MarkAsOpen">When <see langword="true"/>, marks the quote as pending after sending.</param>
+/// <param name="AttachPdf">When <see langword="true"/>, attaches the PDF directly to the email.</param>
+public sealed record QuoteSendRequest(
+    [property: JsonPropertyName("recipient_email")] string RecipientEmail,
+    [property: JsonPropertyName("subject")] string Subject,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("mark_as_open")] bool? MarkAsOpen = null,
+    [property: JsonPropertyName("attach_pdf")] bool? AttachPdf = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteUpdate.cs
@@ -1,0 +1,86 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+
+/// <summary>
+/// Update view for a quote — body of <c>POST /2.0/kb_offer/{quote_id}</c>. Bexio uses
+/// <c>POST</c> (not <c>PUT</c>) for full-replacement edits on this resource. Read-only fields
+/// (id, totals, contact_address, delivery_address, kb_item_status_id, show_total, updated_at,
+/// taxs, network_link, project_id, viewed_by_client_at) are intentionally omitted — positions
+/// are managed via the dedicated position sub-resources, so they live only on
+/// <see cref="QuoteCreate"/>.
+/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2EditQuote"/>
+/// </summary>
+/// <param name="UserId">References the user that owns the quote.</param>
+/// <param name="DocumentNr">Quote number. Must be omitted when automatic numbering is enabled.</param>
+/// <param name="Title">Quote title/subject.</param>
+/// <param name="ContactId">References a contact object.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within a company).</param>
+/// <param name="PrProjectId">Write-only reference to a project object.</param>
+/// <param name="LogopaperId">References a logo-paper object (deprecated by Bexio but still accepted).</param>
+/// <param name="LanguageId">References a language object.</param>
+/// <param name="BankAccountId">References a bank account object.</param>
+/// <param name="CurrencyId">References a currency object.</param>
+/// <param name="PaymentTypeId">References a payment type object.</param>
+/// <param name="Header">Free-text header printed on top of the quote.</param>
+/// <param name="Footer">Free-text footer printed below the positions.</param>
+/// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
+/// <param name="MwstIsNet">When <see langword="true"/> and <see cref="MwstType"/> is <c>0</c>, totals are interpreted as net.</param>
+/// <param name="ShowPositionTaxes">When <see langword="true"/>, per-position taxes are shown on the printed document.</param>
+/// <param name="IsValidFrom">Quote validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidUntil">Quote validity end in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
+/// <param name="DeliveryAddressType">Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery address.</param>
+/// <param name="DeliveryAddressManual">Manually overridden delivery address (write-only, used when <see cref="DeliveryAddressType"/> is <c>1</c>).</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="KbTermsOfPaymentTemplateId">Optional reference to a terms-of-payment template.</param>
+/// <param name="TemplateSlug">References a document template slug.</param>
+public sealed record QuoteUpdate(
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("document_nr")] string? DocumentNr = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_id")] int? ContactId = null,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("pr_project_id")] int? PrProjectId = null,
+    [property: JsonPropertyName("logopaper_id")] int? LogopaperId = null,
+    [property: JsonPropertyName("language_id")] int? LanguageId = null,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId = null,
+    [property: JsonPropertyName("currency_id")] int? CurrencyId = null,
+    [property: JsonPropertyName("payment_type_id")] int? PaymentTypeId = null,
+    [property: JsonPropertyName("header")] string? Header = null,
+    [property: JsonPropertyName("footer")] string? Footer = null,
+    [property: JsonPropertyName("mwst_type")] int? MwstType = null,
+    [property: JsonPropertyName("mwst_is_net")] bool? MwstIsNet = null,
+    [property: JsonPropertyName("show_position_taxes")] bool? ShowPositionTaxes = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("is_valid_until")] string? IsValidUntil = null,
+    [property: JsonPropertyName("contact_address_manual")] string? ContactAddressManual = null,
+    [property: JsonPropertyName("delivery_address_type")] int? DeliveryAddressType = null,
+    [property: JsonPropertyName("delivery_address_manual")] string? DeliveryAddressManual = null,
+    [property: JsonPropertyName("api_reference")] string? ApiReference = null,
+    [property: JsonPropertyName("kb_terms_of_payment_template_id")] int? KbTermsOfPaymentTemplateId = null,
+    [property: JsonPropertyName("template_slug")] string? TemplateSlug = null
+);

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -30,10 +30,12 @@ using BexioApiNet.Interfaces;
 using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Interfaces.Connectors.Sales;
 using BexioApiNet.Services;
 using BexioApiNet.Services.Connectors.Accounting;
 using BexioApiNet.Services.Connectors.Banking;
 using BexioApiNet.Services.Connectors.Contacts;
+using BexioApiNet.Services.Connectors.Sales;
 
 namespace BexioApiNet.AspNetCore;
 
@@ -104,6 +106,7 @@ public static class BexioServiceCollection
         services.AddScoped<IContactRelationService, ContactRelationService>();
         services.AddScoped<IContactSectorService, ContactSectorService>();
         services.AddScoped<IAdditionalAddressService, AdditionalAddressService>();
+        services.AddScoped<IInvoiceService, InvoiceService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -110,6 +110,7 @@ public static class BexioServiceCollection
         services.AddScoped<IInvoiceReminderService, InvoiceReminderService>();
         services.AddScoped<IQuoteService, QuoteService>();
         services.AddScoped<IOrderService, OrderService>();
+        services.AddScoped<IDeliveryService, DeliveryService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -109,6 +109,7 @@ public static class BexioServiceCollection
         services.AddScoped<IInvoiceService, InvoiceService>();
         services.AddScoped<IInvoiceReminderService, InvoiceReminderService>();
         services.AddScoped<IQuoteService, QuoteService>();
+        services.AddScoped<IOrderService, OrderService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -108,6 +108,7 @@ public static class BexioServiceCollection
         services.AddScoped<IAdditionalAddressService, AdditionalAddressService>();
         services.AddScoped<IInvoiceService, InvoiceService>();
         services.AddScoped<IInvoiceReminderService, InvoiceReminderService>();
+        services.AddScoped<IQuoteService, QuoteService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -107,6 +107,7 @@ public static class BexioServiceCollection
         services.AddScoped<IContactSectorService, ContactSectorService>();
         services.AddScoped<IAdditionalAddressService, AdditionalAddressService>();
         services.AddScoped<IInvoiceService, InvoiceService>();
+        services.AddScoped<IInvoiceReminderService, InvoiceReminderService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet/Interfaces/Connectors/Sales/IDeliveryService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Sales/IDeliveryService.cs
@@ -1,0 +1,69 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Deliveries;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Sales;
+
+/// <summary>
+///     Service for the Bexio delivery endpoints. <see href="https://docs.bexio.com/#tag/Deliveries">Deliveries</see>
+/// </summary>
+public interface IDeliveryService
+{
+    /// <summary>
+    ///     List all deliveries.
+    ///     <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ListDeliveries">List Deliveries</see>
+    /// </summary>
+    /// <param name="queryParameterDelivery">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="autoPage">
+    ///     When <see langword="true" />, transparently pages through all remaining results via
+    ///     <c>X-Total-Count</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> with the full page (or all pages) of deliveries.</returns>
+    public Task<ApiResult<List<Delivery>?>> Get([Optional] QueryParameterDelivery? queryParameterDelivery,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single delivery by id.
+    ///     <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ShowDelivery">Show Delivery</see>
+    /// </summary>
+    /// <param name="id">The delivery id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The delivery including the <c>DeliveryWithDetails</c> fields when present.</returns>
+    public Task<ApiResult<Delivery>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Issue a delivery. The delivery must be in the draft status.
+    ///     <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2IssueDelivery">Issue Delivery</see>
+    /// </summary>
+    /// <param name="id">The delivery id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Issue(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Sales/IInvoiceReminderService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Sales/IInvoiceReminderService.cs
@@ -1,0 +1,131 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.InvoiceReminders;
+using BexioApiNet.Abstractions.Models.Sales.InvoiceReminders.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Sales;
+
+/// <summary>
+/// Service for the Bexio invoice reminder endpoints nested under
+/// <c>/2.0/kb_invoice/{invoice_id}/kb_reminder</c>. All methods require the owning invoice id
+/// as their first parameter because reminders are scoped to a single invoice.
+/// <see href="https://docs.bexio.com/#tag/Invoices">Invoices</see>
+/// </summary>
+public interface IInvoiceReminderService
+{
+    /// <summary>
+    /// List all reminders attached to a given invoice.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2ListInvoiceReminders">List Invoice Reminders</see>
+    /// </summary>
+    /// <param name="invoiceId">The invoice id whose reminders should be listed.</param>
+    /// <param name="queryParameterInvoiceReminder">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> with the reminders attached to the invoice.</returns>
+    public Task<ApiResult<List<InvoiceReminder>?>> Get(int invoiceId, [Optional] QueryParameterInvoiceReminder? queryParameterInvoiceReminder, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single reminder by id.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2ShowInvoiceReminder">Show Invoice Reminder</see>
+    /// </summary>
+    /// <param name="invoiceId">The owning invoice id.</param>
+    /// <param name="reminderId">The reminder id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The reminder.</returns>
+    public Task<ApiResult<InvoiceReminder>> GetById(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Download the reminder as PDF.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2ShowInvoiceReminderPDF">Get Invoice Reminder PDF</see>
+    /// </summary>
+    /// <param name="invoiceId">The owning invoice id.</param>
+    /// <param name="reminderId">The reminder id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> whose <c>Data</c> is the PDF byte payload.</returns>
+    public Task<ApiResult<byte[]>> GetPdf(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a reminder for the given invoice.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2CreateInvoiceReminder">Create Invoice Reminder</see>
+    /// </summary>
+    /// <param name="invoiceId">The owning invoice id.</param>
+    /// <param name="reminder">The reminder create view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created reminder as returned by Bexio.</returns>
+    public Task<ApiResult<InvoiceReminder>> Create(int invoiceId, InvoiceReminderCreate reminder, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search reminders by criteria.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2SearchReminders">Search Invoice Reminders</see>
+    /// </summary>
+    /// <param name="invoiceId">The owning invoice id.</param>
+    /// <param name="searchCriteria">Search criteria submitted as the JSON array body. Supported fields: <c>title</c>, <c>reminder_level</c>, <c>is_sent</c>, <c>is_valid_from</c>, <c>is_valid_to</c>.</param>
+    /// <param name="queryParameterInvoiceReminder">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching reminders.</returns>
+    public Task<ApiResult<List<InvoiceReminder>>> Search(int invoiceId, List<SearchCriteria> searchCriteria, [Optional] QueryParameterInvoiceReminder? queryParameterInvoiceReminder, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Send a reminder via Bexio's network mail service.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2SendInvoiceReminder">Send Invoice Reminder</see>
+    /// </summary>
+    /// <param name="invoiceId">The owning invoice id.</param>
+    /// <param name="reminderId">The reminder id.</param>
+    /// <param name="request">Send request body (recipient, subject, message).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Send(int invoiceId, int reminderId, InvoiceReminderSendRequest request, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Mark a reminder as sent (without triggering an actual email dispatch).
+    /// </summary>
+    /// <param name="invoiceId">The owning invoice id.</param>
+    /// <param name="reminderId">The reminder id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> MarkAsSent(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Mark a reminder as not-sent, reversing a previous <see cref="MarkAsSent"/>.
+    /// </summary>
+    /// <param name="invoiceId">The owning invoice id.</param>
+    /// <param name="reminderId">The reminder id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> MarkAsUnsent(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a reminder.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2DeleteInvoiceReminder">Delete Invoice Reminder</see>
+    /// </summary>
+    /// <param name="invoiceId">The owning invoice id.</param>
+    /// <param name="reminderId">The reminder id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Delete(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Sales/IInvoiceService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Sales/IInvoiceService.cs
@@ -1,0 +1,193 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Sales;
+
+/// <summary>
+/// Service for the Bexio invoice endpoints. <see href="https://docs.bexio.com/#tag/Invoices">Invoices</see>
+/// </summary>
+public interface IInvoiceService
+{
+    /// <summary>
+    /// List all invoices. <see href="https://docs.bexio.com/#tag/Invoices/operation/v2ListInvoices">List Invoices</see>
+    /// </summary>
+    /// <param name="queryParameterInvoice">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="autoPage">When <see langword="true"/>, transparently pages through all remaining results via <c>X-Total-Count</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> with the full page (or all pages) of invoices.</returns>
+    public Task<ApiResult<List<Invoice>?>> Get([Optional] QueryParameterInvoice? queryParameterInvoice, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single invoice by id. <see href="https://docs.bexio.com/#tag/Invoices/operation/v2ShowInvoice">Show Invoice</see>
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The invoice including the <c>InvoiceWithDetails</c> fields when present.</returns>
+    public Task<ApiResult<Invoice>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Download the invoice as PDF. <see href="https://docs.bexio.com/#tag/Invoices/operation/v2InvoicePDF">Get Invoice PDF</see>
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> whose <c>Data</c> is the PDF byte payload.</returns>
+    public Task<ApiResult<byte[]>> GetPdf(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a single invoice. <see href="https://docs.bexio.com/#tag/Invoices/operation/v2CreateInvoice">Create Invoice</see>
+    /// </summary>
+    /// <param name="invoice">The invoice create view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created invoice as returned by Bexio.</returns>
+    public Task<ApiResult<Invoice>> Create(InvoiceCreate invoice, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Edit an existing invoice. Bexio uses <c>POST /2.0/kb_invoice/{id}</c> (not <c>PUT</c>) for
+    /// full-replacement updates — see <see href="https://docs.bexio.com/#tag/Invoices/operation/v2EditInvoice">Edit Invoice</see>.
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="invoice">The invoice update view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated invoice as returned by Bexio.</returns>
+    public Task<ApiResult<Invoice>> Update(int id, InvoiceUpdate invoice, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete an invoice. <see href="https://docs.bexio.com/#tag/Invoices/operation/v2DeleteInvoice">Delete Invoice</see>
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search invoices by criteria. <see href="https://docs.bexio.com/#tag/Invoices/operation/v2SearchInvoices">Search Invoices</see>
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria submitted as the JSON array body.</param>
+    /// <param name="queryParameterInvoice">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching invoices.</returns>
+    public Task<ApiResult<List<Invoice>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterInvoice? queryParameterInvoice, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Issue an invoice (move from <c>Draft</c> to <c>Pending</c>).
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2IssueInvoice">Issue Invoice</see>
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Issue(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Revert a previously issued invoice back to <c>Draft</c>.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2RevertIssueInvoice">Revert Issue Invoice</see>
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> RevertIssue(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Cancel an invoice. <see href="https://docs.bexio.com/#tag/Invoices/operation/v2CancelInvoice">Cancel Invoice</see>
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Cancel(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Mark an invoice as sent (without triggering an actual email dispatch).
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2MarkInvoiceAsSent">Mark Invoice as Sent</see>
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> MarkAsSent(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Copy an existing invoice into a new draft.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2CopyInvoice">Copy Invoice</see>
+    /// </summary>
+    /// <param name="id">The source invoice id.</param>
+    /// <param name="request">Copy request body (required <c>contact_id</c> plus optional overrides).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The newly created invoice.</returns>
+    public Task<ApiResult<Invoice>> Copy(int id, InvoiceCopyRequest request, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Send an invoice via Bexio's network mail service.
+    /// <see href="https://docs.bexio.com/#tag/Invoices/operation/v2SendInvoice">Send Invoice</see>
+    /// </summary>
+    /// <param name="id">The invoice id.</param>
+    /// <param name="request">Send request body (recipient, subject, message and optional flags).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Send(int id, InvoiceSendRequest request, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// List all payments registered against a given invoice.
+    /// <see href="https://docs.bexio.com/#tag/Invoice-Payments/operation/v2ListInvoicePayments">List Invoice Payments</see>
+    /// </summary>
+    /// <param name="invoiceId">The invoice id.</param>
+    /// <param name="queryParameterInvoice">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The payments attached to the invoice.</returns>
+    public Task<ApiResult<List<InvoicePayment>?>> GetPayments(int invoiceId, [Optional] QueryParameterInvoice? queryParameterInvoice, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single invoice payment by id.
+    /// <see href="https://docs.bexio.com/#tag/Invoice-Payments/operation/v2ShowInvoicePayment">Show Invoice Payment</see>
+    /// </summary>
+    /// <param name="invoiceId">The invoice id.</param>
+    /// <param name="paymentId">The payment id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The invoice payment.</returns>
+    public Task<ApiResult<InvoicePayment>> GetPaymentById(int invoiceId, int paymentId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Register a payment against an invoice.
+    /// <see href="https://docs.bexio.com/#tag/Invoice-Payments/operation/v2CreateInvoicePayment">Create Invoice Payment</see>
+    /// </summary>
+    /// <param name="invoiceId">The invoice id.</param>
+    /// <param name="payment">The payment create view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created invoice payment.</returns>
+    public Task<ApiResult<InvoicePayment>> CreatePayment(int invoiceId, InvoicePaymentCreate payment, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a previously registered invoice payment.
+    /// <see href="https://docs.bexio.com/#tag/Invoice-Payments/operation/v2DeleteInvoicePayment">Delete Invoice Payment</see>
+    /// </summary>
+    /// <param name="invoiceId">The invoice id.</param>
+    /// <param name="paymentId">The payment id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> DeletePayment(int invoiceId, int paymentId, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Sales/IOrderService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Sales/IOrderService.cs
@@ -25,6 +25,7 @@ SOFTWARE.
 
 using System.Runtime.InteropServices;
 using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Deliveries;
 using BexioApiNet.Abstractions.Models.Sales.Invoices;
 using BexioApiNet.Abstractions.Models.Sales.Orders;
 using BexioApiNet.Abstractions.Models.Sales.Orders.Views;
@@ -33,25 +34,21 @@ using BexioApiNet.Models;
 namespace BexioApiNet.Interfaces.Connectors.Sales;
 
 /// <summary>
-///     Service for the Bexio order endpoints. <see href="https://docs.bexio.com/#tag/Orders">Orders</see>
+/// Service for the Bexio order endpoints. <see href="https://docs.bexio.com/#tag/Orders">Orders</see>
 /// </summary>
 public interface IOrderService
 {
     /// <summary>
-    ///     List all orders. <see href="https://docs.bexio.com/#tag/Orders/operation/v2ListOrders">List Orders</see>
+    /// List all orders. <see href="https://docs.bexio.com/#tag/Orders/operation/v2ListOrders">List Orders</see>
     /// </summary>
     /// <param name="queryParameterOrder">Optional query parameters (limit/offset/order_by).</param>
-    /// <param name="autoPage">
-    ///     When <see langword="true" />, transparently pages through all remaining results via
-    ///     <c>X-Total-Count</c>.
-    /// </param>
+    /// <param name="autoPage">When <see langword="true"/>, transparently pages through all remaining results via <c>X-Total-Count</c>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>An <see cref="ApiResult{T}" /> with the full page (or all pages) of orders.</returns>
-    public Task<ApiResult<List<Order>?>> Get([Optional] QueryParameterOrder? queryParameterOrder,
-        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+    /// <returns>An <see cref="ApiResult{T}"/> with the full page (or all pages) of orders.</returns>
+    public Task<ApiResult<List<Order>?>> Get([Optional] QueryParameterOrder? queryParameterOrder, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Fetch a single order by id. <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrder">Show Order</see>
+    /// Fetch a single order by id. <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrder">Show Order</see>
     /// </summary>
     /// <param name="id">The order id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -59,17 +56,16 @@ public interface IOrderService
     public Task<ApiResult<Order>> GetById(int id, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Download the order as PDF.
-    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderPDF">Get Order PDF</see>
+    /// Download the order as PDF. <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderPDF">Get Order PDF</see>
     /// </summary>
     /// <param name="id">The order id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>An <see cref="ApiResult{T}" /> whose <c>Data</c> is the PDF byte payload.</returns>
+    /// <returns>An <see cref="ApiResult{T}"/> whose <c>Data</c> is the PDF byte payload.</returns>
     public Task<ApiResult<byte[]>> GetPdf(int id, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Fetch the repetition schedule attached to an order.
-    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition">Show Order Repetition</see>
+    /// Fetch the repetition schedule attached to an order.
+    /// <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition">Show Order Repetition</see>
     /// </summary>
     /// <param name="id">The order id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -77,7 +73,7 @@ public interface IOrderService
     public Task<ApiResult<OrderRepetition>> GetRepetition(int id, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Create a single order. <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateOrder">Create Order</see>
+    /// Create a single order. <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateOrder">Create Order</see>
     /// </summary>
     /// <param name="order">The order create view.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -85,9 +81,8 @@ public interface IOrderService
     public Task<ApiResult<Order>> Create(OrderCreate order, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Edit an existing order. Bexio uses <c>POST /2.0/kb_order/{id}</c> (not <c>PUT</c>) for
-    ///     full-replacement updates — see
-    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrder">Edit Order</see>.
+    /// Edit an existing order. Bexio uses <c>POST /2.0/kb_order/{id}</c> (not <c>PUT</c>) for
+    /// full-replacement updates — see <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrder">Edit Order</see>.
     /// </summary>
     /// <param name="id">The order id.</param>
     /// <param name="order">The order update view.</param>
@@ -96,65 +91,58 @@ public interface IOrderService
     public Task<ApiResult<Order>> Update(int id, OrderUpdate order, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Delete an order. <see href="https://docs.bexio.com/#tag/Orders/operation/DeleteOrder">Delete Order</see>
+    /// Delete an order. <see href="https://docs.bexio.com/#tag/Orders/operation/DeleteOrder">Delete Order</see>
     /// </summary>
     /// <param name="id">The order id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>An <see cref="ApiResult{T}" /> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
     public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Search orders by criteria.
-    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2SearchOrders">Search Orders</see>
+    /// Search orders by criteria. <see href="https://docs.bexio.com/#tag/Orders/operation/v2SearchOrders">Search Orders</see>
     /// </summary>
     /// <param name="searchCriteria">Search criteria submitted as the JSON array body.</param>
     /// <param name="queryParameterOrder">Optional query parameters (limit/offset/order_by).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The matching orders.</returns>
-    public Task<ApiResult<List<Order>>> Search(List<SearchCriteria> searchCriteria,
-        [Optional] QueryParameterOrder? queryParameterOrder, [Optional] CancellationToken cancellationToken);
+    public Task<ApiResult<List<Order>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterOrder? queryParameterOrder, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Create a delivery from an existing order. The response is the newly created delivery, but
-    ///     the <c>Delivery</c> domain model is added in a later sub-issue — for now the payload is
-    ///     returned as a generic <see cref="object" /> carrying the raw Bexio JSON.
-    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateDeliveryFromOrder">Create Delivery From Order</see>
+    /// Create a delivery from an existing order.
+    /// <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateDeliveryFromOrder">Create Delivery From Order</see>
     /// </summary>
     /// <param name="id">The source order id.</param>
     /// <param name="request">Optional subset of positions to carry over. When omitted, all positions are copied.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The newly created delivery payload (typed as <see cref="object" /> until <c>Delivery</c> lands).</returns>
-    public Task<ApiResult<object>> CreateDeliveryFromOrder(int id, OrderConvertRequest request,
-        [Optional] CancellationToken cancellationToken);
+    /// <returns>The newly created delivery.</returns>
+    public Task<ApiResult<Delivery>> CreateDeliveryFromOrder(int id, OrderConvertRequest request, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Create an invoice from an existing order.
-    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateInvoiceFromOrder">Create Invoice From Order</see>
+    /// Create an invoice from an existing order.
+    /// <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateInvoiceFromOrder">Create Invoice From Order</see>
     /// </summary>
     /// <param name="id">The source order id.</param>
     /// <param name="request">Optional subset of positions to carry over. When omitted, all positions are copied.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The newly created invoice.</returns>
-    public Task<ApiResult<Invoice>> CreateInvoiceFromOrder(int id, OrderConvertRequest request,
-        [Optional] CancellationToken cancellationToken);
+    public Task<ApiResult<Invoice>> CreateInvoiceFromOrder(int id, OrderConvertRequest request, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Create (or replace) a repetition schedule on an order.
-    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrderRepetition">Edit Order Repetition</see>
+    /// Create (or replace) a repetition schedule on an order.
+    /// <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrderRepetition">Edit Order Repetition</see>
     /// </summary>
     /// <param name="id">The order id.</param>
     /// <param name="repetition">The repetition payload (start/end plus the polymorphic repetition descriptor).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The resulting repetition as returned by Bexio.</returns>
-    public Task<ApiResult<OrderRepetition>> CreateRepetition(int id, OrderRepetitionCreate repetition,
-        [Optional] CancellationToken cancellationToken);
+    public Task<ApiResult<OrderRepetition>> CreateRepetition(int id, OrderRepetitionCreate repetition, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Delete the repetition schedule attached to an order.
-    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2DeleteOrderRepetition">Delete Order Repetition</see>
+    /// Delete the repetition schedule attached to an order.
+    /// <see href="https://docs.bexio.com/#tag/Orders/operation/v2DeleteOrderRepetition">Delete Order Repetition</see>
     /// </summary>
     /// <param name="id">The order id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>An <see cref="ApiResult{T}" /> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
     public Task<ApiResult<object>> DeleteRepetition(int id, [Optional] CancellationToken cancellationToken);
 }

--- a/src/BexioApiNet/Interfaces/Connectors/Sales/IOrderService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Sales/IOrderService.cs
@@ -1,0 +1,160 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
+using BexioApiNet.Abstractions.Models.Sales.Orders.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Sales;
+
+/// <summary>
+///     Service for the Bexio order endpoints. <see href="https://docs.bexio.com/#tag/Orders">Orders</see>
+/// </summary>
+public interface IOrderService
+{
+    /// <summary>
+    ///     List all orders. <see href="https://docs.bexio.com/#tag/Orders/operation/v2ListOrders">List Orders</see>
+    /// </summary>
+    /// <param name="queryParameterOrder">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="autoPage">
+    ///     When <see langword="true" />, transparently pages through all remaining results via
+    ///     <c>X-Total-Count</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> with the full page (or all pages) of orders.</returns>
+    public Task<ApiResult<List<Order>?>> Get([Optional] QueryParameterOrder? queryParameterOrder,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single order by id. <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrder">Show Order</see>
+    /// </summary>
+    /// <param name="id">The order id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The order including the <c>OrderWithDetails</c> fields when present.</returns>
+    public Task<ApiResult<Order>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Download the order as PDF.
+    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderPDF">Get Order PDF</see>
+    /// </summary>
+    /// <param name="id">The order id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> whose <c>Data</c> is the PDF byte payload.</returns>
+    public Task<ApiResult<byte[]>> GetPdf(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch the repetition schedule attached to an order.
+    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition">Show Order Repetition</see>
+    /// </summary>
+    /// <param name="id">The order id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The repetition payload for the order. Returns a 404 when no repetition is configured.</returns>
+    public Task<ApiResult<OrderRepetition>> GetRepetition(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create a single order. <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateOrder">Create Order</see>
+    /// </summary>
+    /// <param name="order">The order create view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created order as returned by Bexio.</returns>
+    public Task<ApiResult<Order>> Create(OrderCreate order, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Edit an existing order. Bexio uses <c>POST /2.0/kb_order/{id}</c> (not <c>PUT</c>) for
+    ///     full-replacement updates — see
+    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrder">Edit Order</see>.
+    /// </summary>
+    /// <param name="id">The order id.</param>
+    /// <param name="order">The order update view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated order as returned by Bexio.</returns>
+    public Task<ApiResult<Order>> Update(int id, OrderUpdate order, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Delete an order. <see href="https://docs.bexio.com/#tag/Orders/operation/DeleteOrder">Delete Order</see>
+    /// </summary>
+    /// <param name="id">The order id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Search orders by criteria.
+    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2SearchOrders">Search Orders</see>
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria submitted as the JSON array body.</param>
+    /// <param name="queryParameterOrder">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching orders.</returns>
+    public Task<ApiResult<List<Order>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterOrder? queryParameterOrder, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create a delivery from an existing order. The response is the newly created delivery, but
+    ///     the <c>Delivery</c> domain model is added in a later sub-issue — for now the payload is
+    ///     returned as a generic <see cref="object" /> carrying the raw Bexio JSON.
+    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateDeliveryFromOrder">Create Delivery From Order</see>
+    /// </summary>
+    /// <param name="id">The source order id.</param>
+    /// <param name="request">Optional subset of positions to carry over. When omitted, all positions are copied.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The newly created delivery payload (typed as <see cref="object" /> until <c>Delivery</c> lands).</returns>
+    public Task<ApiResult<object>> CreateDeliveryFromOrder(int id, OrderConvertRequest request,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create an invoice from an existing order.
+    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateInvoiceFromOrder">Create Invoice From Order</see>
+    /// </summary>
+    /// <param name="id">The source order id.</param>
+    /// <param name="request">Optional subset of positions to carry over. When omitted, all positions are copied.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The newly created invoice.</returns>
+    public Task<ApiResult<Invoice>> CreateInvoiceFromOrder(int id, OrderConvertRequest request,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create (or replace) a repetition schedule on an order.
+    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrderRepetition">Edit Order Repetition</see>
+    /// </summary>
+    /// <param name="id">The order id.</param>
+    /// <param name="repetition">The repetition payload (start/end plus the polymorphic repetition descriptor).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resulting repetition as returned by Bexio.</returns>
+    public Task<ApiResult<OrderRepetition>> CreateRepetition(int id, OrderRepetitionCreate repetition,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Delete the repetition schedule attached to an order.
+    ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2DeleteOrderRepetition">Delete Order Repetition</see>
+    /// </summary>
+    /// <param name="id">The order id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> DeleteRepetition(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Sales/IQuoteService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Sales/IQuoteService.cs
@@ -26,6 +26,7 @@ SOFTWARE.
 using System.Runtime.InteropServices;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
 using BexioApiNet.Abstractions.Models.Sales.Quotes;
 using BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
 using BexioApiNet.Models;
@@ -172,16 +173,14 @@ public interface IQuoteService
     public Task<ApiResult<Quote>> Copy(int id, QuoteCopyRequest request, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    /// Create an order from an existing quote. The response is the newly created order, but the
-    /// <c>Order</c> domain model is added in a later sub-issue — for now the payload is returned
-    /// as a generic <see cref="object"/> carrying the raw Bexio JSON.
+    /// Create an order from an existing quote.
     /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote">Create Order From Quote</see>
     /// </summary>
     /// <param name="id">The source quote id.</param>
     /// <param name="request">Optional subset of positions to carry over. When omitted, all positions are copied.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The newly created order payload (typed as <see cref="object"/> until <c>Order</c> lands).</returns>
-    public Task<ApiResult<object>> CreateOrderFromQuote(int id, QuoteConvertRequest request, [Optional] CancellationToken cancellationToken);
+    /// <returns>The newly created order.</returns>
+    public Task<ApiResult<Order>> CreateOrderFromQuote(int id, QuoteConvertRequest request, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
     /// Create an invoice from an existing quote.

--- a/src/BexioApiNet/Interfaces/Connectors/Sales/IQuoteService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Sales/IQuoteService.cs
@@ -1,0 +1,195 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Quotes;
+using BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Sales;
+
+/// <summary>
+/// Service for the Bexio quote (offer) endpoints. <see href="https://docs.bexio.com/#tag/Quotes">Quotes</see>
+/// </summary>
+public interface IQuoteService
+{
+    /// <summary>
+    /// List all quotes. <see href="https://docs.bexio.com/#tag/Quotes/operation/v2ListQuotes">List Quotes</see>
+    /// </summary>
+    /// <param name="queryParameterQuote">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="autoPage">When <see langword="true"/>, transparently pages through all remaining results via <c>X-Total-Count</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> with the full page (or all pages) of quotes.</returns>
+    public Task<ApiResult<List<Quote>?>> Get([Optional] QueryParameterQuote? queryParameterQuote, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single quote by id. <see href="https://docs.bexio.com/#tag/Quotes/operation/v2ShowQuote">Show Quote</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The quote including the <c>QuoteWithDetails</c> fields when present.</returns>
+    public Task<ApiResult<Quote>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Download the quote as PDF. <see href="https://docs.bexio.com/#tag/Quotes/operation/v2ShowQuotePDF">Get Quote PDF</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> whose <c>Data</c> is the PDF byte payload.</returns>
+    public Task<ApiResult<byte[]>> GetPdf(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a single quote. <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateQuote">Create Quote</see>
+    /// </summary>
+    /// <param name="quote">The quote create view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created quote as returned by Bexio.</returns>
+    public Task<ApiResult<Quote>> Create(QuoteCreate quote, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Edit an existing quote. Bexio uses <c>POST /2.0/kb_offer/{id}</c> (not <c>PUT</c>) for
+    /// full-replacement updates — see <see href="https://docs.bexio.com/#tag/Quotes/operation/v2EditQuote">Edit Quote</see>.
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="quote">The quote update view.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated quote as returned by Bexio.</returns>
+    public Task<ApiResult<Quote>> Update(int id, QuoteUpdate quote, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a quote. <see href="https://docs.bexio.com/#tag/Quotes/operation/DeleteQuote">Delete Quote</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search quotes by criteria. <see href="https://docs.bexio.com/#tag/Quotes/operation/v2SearchQuotes">Search Quotes</see>
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria submitted as the JSON array body.</param>
+    /// <param name="queryParameterQuote">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching quotes.</returns>
+    public Task<ApiResult<List<Quote>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterQuote? queryParameterQuote, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Issue a quote (move from <c>Draft</c> to <c>Pending</c>).
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2IssueQuote">Issue Quote</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Issue(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Revert a previously issued quote back to <c>Draft</c>.
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2RevertIssueQuote">Revert Issue Quote</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> RevertIssue(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Accept a quote (move to <c>Confirmed</c>).
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2AcceptQuote">Accept Quote</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Accept(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reject (decline) a quote (move to <c>Declined</c>). Bexio routes this under <c>/reject</c>.
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2DeclineQuote">Decline Quote</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Reject(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reissue a previously accepted or declined quote back to <c>Pending</c>.
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2ReissueQuote">Reissue Quote</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Reissue(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Mark a quote as sent (without triggering an actual email dispatch).
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2RMarkAsSentQuote">Mark Quote as Sent</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> MarkAsSent(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Send a quote via Bexio's network mail service.
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2SendQuote">Send Quote</see>
+    /// </summary>
+    /// <param name="id">The quote id.</param>
+    /// <param name="request">Send request body (recipient, subject, message and optional flags).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Send(int id, QuoteSendRequest request, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Copy an existing quote into a new draft.
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CopyQuote">Copy Quote</see>
+    /// </summary>
+    /// <param name="id">The source quote id.</param>
+    /// <param name="request">Copy request body (required <c>contact_id</c> plus optional overrides).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The newly created quote.</returns>
+    public Task<ApiResult<Quote>> Copy(int id, QuoteCopyRequest request, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create an order from an existing quote. The response is the newly created order, but the
+    /// <c>Order</c> domain model is added in a later sub-issue — for now the payload is returned
+    /// as a generic <see cref="object"/> carrying the raw Bexio JSON.
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote">Create Order From Quote</see>
+    /// </summary>
+    /// <param name="id">The source quote id.</param>
+    /// <param name="request">Optional subset of positions to carry over. When omitted, all positions are copied.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The newly created order payload (typed as <see cref="object"/> until <c>Order</c> lands).</returns>
+    public Task<ApiResult<object>> CreateOrderFromQuote(int id, QuoteConvertRequest request, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create an invoice from an existing quote.
+    /// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote">Create Invoice From Quote</see>
+    /// </summary>
+    /// <param name="id">The source quote id.</param>
+    /// <param name="request">Optional subset of positions to carry over. When omitted, all positions are copied.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The newly created invoice.</returns>
+    public Task<ApiResult<Invoice>> CreateInvoiceFromQuote(int id, QuoteConvertRequest request, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -140,4 +140,9 @@ public interface IBexioApiClient : IDisposable
     /// Bexio quotes (offers) connector. <see href="https://docs.bexio.com/#tag/Quotes">Quotes</see>
     /// </summary>
     public IQuoteService Quotes { get; set; }
+
+    /// <summary>
+    /// Bexio orders (customer confirmations) connector. <see href="https://docs.bexio.com/#tag/Orders">Orders</see>
+    /// </summary>
+    public IOrderService Orders { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -26,6 +26,7 @@ SOFTWARE.
 using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Interfaces.Connectors.Sales;
 
 namespace BexioApiNet.Interfaces;
 
@@ -123,4 +124,9 @@ public interface IBexioApiClient : IDisposable
     /// Bexio additional addresses connector, nested under contacts. <see href="https://docs.bexio.com/#tag/Additional-Addresses">Additional Addresses</see>
     /// </summary>
     public IAdditionalAddressService ContactAdditionalAddresses { get; set; }
+
+    /// <summary>
+    /// Bexio invoices connector. <see href="https://docs.bexio.com/#tag/Invoices">Invoices</see>
+    /// </summary>
+    public IInvoiceService Invoices { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -145,4 +145,9 @@ public interface IBexioApiClient : IDisposable
     /// Bexio orders (customer confirmations) connector. <see href="https://docs.bexio.com/#tag/Orders">Orders</see>
     /// </summary>
     public IOrderService Orders { get; set; }
+
+    /// <summary>
+    /// Bexio deliveries connector. <see href="https://docs.bexio.com/#tag/Deliveries">Deliveries</see>
+    /// </summary>
+    public IDeliveryService Deliveries { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -129,4 +129,10 @@ public interface IBexioApiClient : IDisposable
     /// Bexio invoices connector. <see href="https://docs.bexio.com/#tag/Invoices">Invoices</see>
     /// </summary>
     public IInvoiceService Invoices { get; set; }
+
+    /// <summary>
+    /// Bexio invoice reminders connector, nested under invoices.
+    /// <see href="https://docs.bexio.com/#tag/Invoices">Invoices</see>
+    /// </summary>
+    public IInvoiceReminderService InvoiceReminders { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -135,4 +135,9 @@ public interface IBexioApiClient : IDisposable
     /// <see href="https://docs.bexio.com/#tag/Invoices">Invoices</see>
     /// </summary>
     public IInvoiceReminderService InvoiceReminders { get; set; }
+
+    /// <summary>
+    /// Bexio quotes (offers) connector. <see href="https://docs.bexio.com/#tag/Quotes">Quotes</see>
+    /// </summary>
+    public IQuoteService Quotes { get; set; }
 }

--- a/src/BexioApiNet/Models/QueryParameterDelivery.cs
+++ b/src/BexioApiNet/Models/QueryParameterDelivery.cs
@@ -1,0 +1,67 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Typed query parameter wrapper for the Bexio delivery list endpoint
+///     (<c>GET /2.0/kb_delivery</c>). Each constructor argument is optional so callers can supply
+///     only the parameters they need; <see langword="null" /> values are skipped and not
+///     serialized onto the URL.
+/// </summary>
+/// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+/// <param name="OrderBy">
+///     Sort clause — one of <c>id</c>, <c>total</c>, <c>total_net</c>, <c>total_gross</c>,
+///     <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.
+/// </param>
+public sealed record QueryParameterDelivery(
+    int? Limit = null,
+    int? Offset = null,
+    string? OrderBy = null
+)
+{
+    /// <summary>
+    ///     The underlying <see cref="Models.QueryParameter" /> passed to <see cref="Interfaces.IBexioConnectionHandler" />.
+    ///     <see langword="null" /> when every input is <see langword="null" /> so the handler appends no query string.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy);
+
+    private static QueryParameter? BuildQueryParameter(int? limit, int? offset, string? orderBy)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l)
+            parameters["limit"] = l;
+
+        if (offset is { } o)
+            parameters["offset"] = o;
+
+        if (!string.IsNullOrWhiteSpace(orderBy))
+            parameters["order_by"] = orderBy;
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+}

--- a/src/BexioApiNet/Models/QueryParameterInvoice.cs
+++ b/src/BexioApiNet/Models/QueryParameterInvoice.cs
@@ -1,0 +1,65 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Typed query parameter wrapper for the Bexio invoice endpoints
+/// (<c>GET /2.0/kb_invoice</c>, <c>GET /2.0/kb_invoice/{id}</c>, <c>POST /2.0/kb_invoice/search</c>
+/// and the nested <c>/payment</c> endpoints). Each constructor argument is optional so callers
+/// can supply only the parameters they need; <see langword="null"/> values are skipped and not
+/// serialized onto the URL.
+/// </summary>
+/// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+/// <param name="OrderBy">Sort clause — one of <c>id</c>, <c>total</c>, <c>total_net</c>, <c>total_gross</c>, <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.</param>
+public sealed record QueryParameterInvoice(
+    int? Limit = null,
+    int? Offset = null,
+    string? OrderBy = null
+)
+{
+    /// <summary>
+    /// The underlying <see cref="Models.QueryParameter"/> passed to <see cref="Interfaces.IBexioConnectionHandler"/>.
+    /// <see langword="null"/> when every input is <see langword="null"/> so the handler appends no query string.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy);
+
+    private static QueryParameter? BuildQueryParameter(int? limit, int? offset, string? orderBy)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l)
+            parameters["limit"] = l;
+
+        if (offset is { } o)
+            parameters["offset"] = o;
+
+        if (!string.IsNullOrWhiteSpace(orderBy))
+            parameters["order_by"] = orderBy;
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+};

--- a/src/BexioApiNet/Models/QueryParameterInvoiceReminder.cs
+++ b/src/BexioApiNet/Models/QueryParameterInvoiceReminder.cs
@@ -1,0 +1,65 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Typed query parameter wrapper for the Bexio invoice reminder endpoints
+/// (<c>GET /2.0/kb_invoice/{invoice_id}/kb_reminder</c> and
+/// <c>POST /2.0/kb_invoice/{invoice_id}/kb_reminder/search</c>). Each constructor argument is
+/// optional so callers can supply only the parameters they need; <see langword="null"/> values
+/// are skipped and not serialized onto the URL.
+/// </summary>
+/// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+/// <param name="OrderBy">Sort clause — one of <c>id</c>, <c>reminder_level</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.</param>
+public sealed record QueryParameterInvoiceReminder(
+    int? Limit = null,
+    int? Offset = null,
+    string? OrderBy = null
+)
+{
+    /// <summary>
+    /// The underlying <see cref="Models.QueryParameter"/> passed to <see cref="Interfaces.IBexioConnectionHandler"/>.
+    /// <see langword="null"/> when every input is <see langword="null"/> so the handler appends no query string.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy);
+
+    private static QueryParameter? BuildQueryParameter(int? limit, int? offset, string? orderBy)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l)
+            parameters["limit"] = l;
+
+        if (offset is { } o)
+            parameters["offset"] = o;
+
+        if (!string.IsNullOrWhiteSpace(orderBy))
+            parameters["order_by"] = orderBy;
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+};

--- a/src/BexioApiNet/Models/QueryParameterOrder.cs
+++ b/src/BexioApiNet/Models/QueryParameterOrder.cs
@@ -1,0 +1,67 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Typed query parameter wrapper for the Bexio order endpoints
+///     (<c>GET /2.0/kb_order</c>, <c>GET /2.0/kb_order/{id}</c> and <c>POST /2.0/kb_order/search</c>).
+///     Each constructor argument is optional so callers can supply only the parameters they need;
+///     <see langword="null" /> values are skipped and not serialized onto the URL.
+/// </summary>
+/// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+/// <param name="OrderBy">
+///     Sort clause — one of <c>id</c>, <c>total</c>, <c>total_net</c>, <c>total_gross</c>,
+///     <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.
+/// </param>
+public sealed record QueryParameterOrder(
+    int? Limit = null,
+    int? Offset = null,
+    string? OrderBy = null
+)
+{
+    /// <summary>
+    ///     The underlying <see cref="Models.QueryParameter" /> passed to <see cref="Interfaces.IBexioConnectionHandler" />.
+    ///     <see langword="null" /> when every input is <see langword="null" /> so the handler appends no query string.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy);
+
+    private static QueryParameter? BuildQueryParameter(int? limit, int? offset, string? orderBy)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l)
+            parameters["limit"] = l;
+
+        if (offset is { } o)
+            parameters["offset"] = o;
+
+        if (!string.IsNullOrWhiteSpace(orderBy))
+            parameters["order_by"] = orderBy;
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+}

--- a/src/BexioApiNet/Models/QueryParameterQuote.cs
+++ b/src/BexioApiNet/Models/QueryParameterQuote.cs
@@ -1,0 +1,64 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Typed query parameter wrapper for the Bexio quote (offer) endpoints
+/// (<c>GET /2.0/kb_offer</c>, <c>GET /2.0/kb_offer/{id}</c> and <c>POST /2.0/kb_offer/search</c>).
+/// Each constructor argument is optional so callers can supply only the parameters they need;
+/// <see langword="null"/> values are skipped and not serialized onto the URL.
+/// </summary>
+/// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+/// <param name="OrderBy">Sort clause — one of <c>id</c>, <c>total</c>, <c>total_net</c>, <c>total_gross</c>, <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.</param>
+public sealed record QueryParameterQuote(
+    int? Limit = null,
+    int? Offset = null,
+    string? OrderBy = null
+)
+{
+    /// <summary>
+    /// The underlying <see cref="Models.QueryParameter"/> passed to <see cref="Interfaces.IBexioConnectionHandler"/>.
+    /// <see langword="null"/> when every input is <see langword="null"/> so the handler appends no query string.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy);
+
+    private static QueryParameter? BuildQueryParameter(int? limit, int? offset, string? orderBy)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l)
+            parameters["limit"] = l;
+
+        if (offset is { } o)
+            parameters["offset"] = o;
+
+        if (!string.IsNullOrWhiteSpace(orderBy))
+            parameters["order_by"] = orderBy;
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+};

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -105,6 +105,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IOrderService Orders { get; set; }
 
+    /// <inheritdoc />
+    public IDeliveryService Deliveries { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -131,7 +134,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IInvoiceService invoices,
         IInvoiceReminderService invoiceReminders,
         IQuoteService quotes,
-        IOrderService orders)
+        IOrderService orders,
+        IDeliveryService deliveries)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -156,6 +160,7 @@ public sealed class BexioApiClient : IBexioApiClient
         InvoiceReminders = invoiceReminders;
         Quotes = quotes;
         Orders = orders;
+        Deliveries = deliveries;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -96,6 +96,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IInvoiceService Invoices { get; set; }
 
+    /// <inheritdoc />
+    public IInvoiceReminderService InvoiceReminders { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -119,7 +122,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IContactRelationService contactRelations,
         IContactSectorService contactSectors,
         IAdditionalAddressService contactAdditionalAddresses,
-        IInvoiceService invoices)
+        IInvoiceService invoices,
+        IInvoiceReminderService invoiceReminders)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -141,6 +145,7 @@ public sealed class BexioApiClient : IBexioApiClient
         ContactSectors = contactSectors;
         ContactAdditionalAddresses = contactAdditionalAddresses;
         Invoices = invoices;
+        InvoiceReminders = invoiceReminders;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -27,6 +27,7 @@ using BexioApiNet.Interfaces;
 using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Interfaces.Connectors.Sales;
 
 namespace BexioApiNet.Services;
 
@@ -92,6 +93,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IAdditionalAddressService ContactAdditionalAddresses { get; set; }
 
+    /// <inheritdoc />
+    public IInvoiceService Invoices { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -114,7 +118,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IContactGroupService contactGroups,
         IContactRelationService contactRelations,
         IContactSectorService contactSectors,
-        IAdditionalAddressService contactAdditionalAddresses)
+        IAdditionalAddressService contactAdditionalAddresses,
+        IInvoiceService invoices)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -135,6 +140,7 @@ public sealed class BexioApiClient : IBexioApiClient
         ContactRelations = contactRelations;
         ContactSectors = contactSectors;
         ContactAdditionalAddresses = contactAdditionalAddresses;
+        Invoices = invoices;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -99,6 +99,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IInvoiceReminderService InvoiceReminders { get; set; }
 
+    /// <inheritdoc />
+    public IQuoteService Quotes { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -123,7 +126,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IContactSectorService contactSectors,
         IAdditionalAddressService contactAdditionalAddresses,
         IInvoiceService invoices,
-        IInvoiceReminderService invoiceReminders)
+        IInvoiceReminderService invoiceReminders,
+        IQuoteService quotes)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -146,6 +150,7 @@ public sealed class BexioApiClient : IBexioApiClient
         ContactAdditionalAddresses = contactAdditionalAddresses;
         Invoices = invoices;
         InvoiceReminders = invoiceReminders;
+        Quotes = quotes;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -102,6 +102,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IQuoteService Quotes { get; set; }
 
+    /// <inheritdoc />
+    public IOrderService Orders { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -127,7 +130,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IAdditionalAddressService contactAdditionalAddresses,
         IInvoiceService invoices,
         IInvoiceReminderService invoiceReminders,
-        IQuoteService quotes)
+        IQuoteService quotes,
+        IOrderService orders)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -151,6 +155,7 @@ public sealed class BexioApiClient : IBexioApiClient
         Invoices = invoices;
         InvoiceReminders = invoiceReminders;
         Quotes = quotes;
+        Orders = orders;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/Connectors/Sales/DeliveryConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/DeliveryConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <summary>
+///     Delivery endpoint configuration
+/// </summary>
+public struct DeliveryConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    ///     The request path
+    /// </summary>
+    public const string EndpointRoot = "kb_delivery";
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/DeliveryService.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/DeliveryService.cs
@@ -1,0 +1,87 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Deliveries;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Sales;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <inheritdoc cref="IDeliveryService" />
+public sealed class DeliveryService : ConnectorService, IDeliveryService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = DeliveryConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = DeliveryConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public DeliveryService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Delivery>?>> Get([Optional] QueryParameterDelivery? queryParameterDelivery,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Delivery>?>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterDelivery?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Delivery>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterDelivery?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Delivery>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Delivery>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Issue(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/issue", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/DeliveryService.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/DeliveryService.cs
@@ -38,12 +38,12 @@ namespace BexioApiNet.Services.Connectors.Sales;
 public sealed class DeliveryService : ConnectorService, IDeliveryService
 {
     /// <summary>
-    ///     The api endpoint version
+    /// The api endpoint version
     /// </summary>
     private const string ApiVersion = DeliveryConfiguration.ApiVersion;
 
     /// <summary>
-    ///     The api request path
+    /// The api request path
     /// </summary>
     private const string EndpointRoot = DeliveryConfiguration.EndpointRoot;
 
@@ -53,14 +53,11 @@ public sealed class DeliveryService : ConnectorService, IDeliveryService
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<List<Delivery>?>> Get([Optional] QueryParameterDelivery? queryParameterDelivery,
-        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<List<Delivery>?>> Get([Optional] QueryParameterDelivery? queryParameterDelivery, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
     {
-        var res = await ConnectionHandler.GetAsync<List<Delivery>?>($"{ApiVersion}/{EndpointRoot}",
-            queryParameterDelivery?.QueryParameter, cancellationToken);
+        var res = await ConnectionHandler.GetAsync<List<Delivery>?>($"{ApiVersion}/{EndpointRoot}", queryParameterDelivery?.QueryParameter, cancellationToken);
 
-        if (!autoPage || !res.IsSuccess || res.Data is null ||
-            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
             return res;
 
         res.Data.AddRange(await ConnectionHandler.FetchAll<Delivery>(

--- a/src/BexioApiNet/Services/Connectors/Sales/InvoiceConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/InvoiceConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <summary>
+/// Invoice endpoint configuration
+/// </summary>
+public struct InvoiceConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "kb_invoice";
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/InvoiceReminderConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/InvoiceReminderConfiguration.cs
@@ -1,0 +1,47 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <summary>
+/// Invoice reminder endpoint configuration
+/// </summary>
+public struct InvoiceReminderConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The root request path (invoice resource)
+    /// </summary>
+    public const string EndpointRoot = "kb_invoice";
+
+    /// <summary>
+    /// The nested reminder path segment
+    /// </summary>
+    public const string ReminderPath = "kb_reminder";
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/InvoiceReminderService.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/InvoiceReminderService.cs
@@ -1,0 +1,113 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.InvoiceReminders;
+using BexioApiNet.Abstractions.Models.Sales.InvoiceReminders.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Sales;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <inheritdoc cref="IInvoiceReminderService" />
+public sealed class InvoiceReminderService : ConnectorService, IInvoiceReminderService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = InvoiceReminderConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path for the owning invoice resource
+    /// </summary>
+    private const string EndpointRoot = InvoiceReminderConfiguration.EndpointRoot;
+
+    /// <summary>
+    /// The nested reminder path segment
+    /// </summary>
+    private const string ReminderPath = InvoiceReminderConfiguration.ReminderPath;
+
+    /// <inheritdoc />
+    public InvoiceReminderService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<InvoiceReminder>?>> Get(int invoiceId, [Optional] QueryParameterInvoiceReminder? queryParameterInvoiceReminder, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<InvoiceReminder>?>($"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}", queryParameterInvoiceReminder?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<InvoiceReminder>> GetById(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<InvoiceReminder>($"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}/{reminderId}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<byte[]>> GetPdf(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetBinaryAsync($"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}/{reminderId}/pdf", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<InvoiceReminder>> Create(int invoiceId, InvoiceReminderCreate reminder, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<InvoiceReminder, InvoiceReminderCreate>(reminder, $"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<InvoiceReminder>>> Search(int invoiceId, List<SearchCriteria> searchCriteria, [Optional] QueryParameterInvoiceReminder? queryParameterInvoiceReminder, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<InvoiceReminder>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}/search", queryParameterInvoiceReminder?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Send(int invoiceId, int reminderId, InvoiceReminderSendRequest request, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<object, InvoiceReminderSendRequest>(request, $"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}/{reminderId}/send", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> MarkAsSent(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}/{reminderId}/mark_as_sent", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> MarkAsUnsent(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}/{reminderId}/mark_as_unsent", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int invoiceId, int reminderId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{invoiceId}/{ReminderPath}/{reminderId}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/InvoiceService.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/InvoiceService.cs
@@ -1,0 +1,169 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Sales;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <inheritdoc cref="IInvoiceService" />
+public sealed class InvoiceService : ConnectorService, IInvoiceService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = InvoiceConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = InvoiceConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public InvoiceService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Invoice>?>> Get([Optional] QueryParameterInvoice? queryParameterInvoice, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Invoice>?>($"{ApiVersion}/{EndpointRoot}", queryParameterInvoice?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Invoice>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterInvoice?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Invoice>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Invoice>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<byte[]>> GetPdf(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetBinaryAsync($"{ApiVersion}/{EndpointRoot}/{id}/pdf", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Invoice>> Create(InvoiceCreate invoice, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Invoice, InvoiceCreate>(invoice, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Invoice>> Update(int id, InvoiceUpdate invoice, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Invoice, InvoiceUpdate>(invoice, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Invoice>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterInvoice? queryParameterInvoice, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Invoice>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterInvoice?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Issue(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/issue", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> RevertIssue(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/revert_issue", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Cancel(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/cancel", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> MarkAsSent(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/mark_as_sent", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Invoice>> Copy(int id, InvoiceCopyRequest request, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Invoice, InvoiceCopyRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/copy", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Send(int id, InvoiceSendRequest request, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<object, InvoiceSendRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/send", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<InvoicePayment>?>> GetPayments(int invoiceId, [Optional] QueryParameterInvoice? queryParameterInvoice, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<InvoicePayment>?>($"{ApiVersion}/{EndpointRoot}/{invoiceId}/payment", queryParameterInvoice?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<InvoicePayment>> GetPaymentById(int invoiceId, int paymentId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<InvoicePayment>($"{ApiVersion}/{EndpointRoot}/{invoiceId}/payment/{paymentId}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<InvoicePayment>> CreatePayment(int invoiceId, InvoicePaymentCreate payment, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<InvoicePayment, InvoicePaymentCreate>(payment, $"{ApiVersion}/{EndpointRoot}/{invoiceId}/payment", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> DeletePayment(int invoiceId, int paymentId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{invoiceId}/payment/{paymentId}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/OrderConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/OrderConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <summary>
+///     Order endpoint configuration
+/// </summary>
+public struct OrderConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    ///     The request path
+    /// </summary>
+    public const string EndpointRoot = "kb_order";
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/OrderService.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/OrderService.cs
@@ -1,0 +1,155 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
+using BexioApiNet.Abstractions.Models.Sales.Orders.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Sales;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <inheritdoc cref="IOrderService" />
+public sealed class OrderService : ConnectorService, IOrderService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = OrderConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = OrderConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public OrderService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Order>?>> Get([Optional] QueryParameterOrder? queryParameterOrder,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Order>?>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterOrder?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Order>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterOrder?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Order>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Order>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<byte[]>> GetPdf(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetBinaryAsync($"{ApiVersion}/{EndpointRoot}/{id}/pdf", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<OrderRepetition>> GetRepetition(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<OrderRepetition>($"{ApiVersion}/{EndpointRoot}/{id}/repetition", null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Order>> Create(OrderCreate order, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Order, OrderCreate>(order, $"{ApiVersion}/{EndpointRoot}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Order>> Update(int id, OrderUpdate order,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Order, OrderUpdate>(order, $"{ApiVersion}/{EndpointRoot}/{id}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Order>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterOrder? queryParameterOrder, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Order>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search",
+            queryParameterOrder?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> CreateDeliveryFromOrder(int id, OrderConvertRequest request,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<object, OrderConvertRequest>(request,
+            $"{ApiVersion}/{EndpointRoot}/{id}/delivery", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Invoice>> CreateInvoiceFromOrder(int id, OrderConvertRequest request,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Invoice, OrderConvertRequest>(request,
+            $"{ApiVersion}/{EndpointRoot}/{id}/invoice", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<OrderRepetition>> CreateRepetition(int id, OrderRepetitionCreate repetition,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<OrderRepetition, OrderRepetitionCreate>(repetition,
+            $"{ApiVersion}/{EndpointRoot}/{id}/repetition", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> DeleteRepetition(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}/repetition", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/OrderService.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/OrderService.cs
@@ -26,6 +26,7 @@ SOFTWARE.
 using System.Runtime.InteropServices;
 using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Deliveries;
 using BexioApiNet.Abstractions.Models.Sales.Invoices;
 using BexioApiNet.Abstractions.Models.Sales.Orders;
 using BexioApiNet.Abstractions.Models.Sales.Orders.Views;
@@ -40,12 +41,12 @@ namespace BexioApiNet.Services.Connectors.Sales;
 public sealed class OrderService : ConnectorService, IOrderService
 {
     /// <summary>
-    ///     The api endpoint version
+    /// The api endpoint version
     /// </summary>
     private const string ApiVersion = OrderConfiguration.ApiVersion;
 
     /// <summary>
-    ///     The api request path
+    /// The api request path
     /// </summary>
     private const string EndpointRoot = OrderConfiguration.EndpointRoot;
 
@@ -55,14 +56,11 @@ public sealed class OrderService : ConnectorService, IOrderService
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<List<Order>?>> Get([Optional] QueryParameterOrder? queryParameterOrder,
-        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<List<Order>?>> Get([Optional] QueryParameterOrder? queryParameterOrder, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
     {
-        var res = await ConnectionHandler.GetAsync<List<Order>?>($"{ApiVersion}/{EndpointRoot}",
-            queryParameterOrder?.QueryParameter, cancellationToken);
+        var res = await ConnectionHandler.GetAsync<List<Order>?>($"{ApiVersion}/{EndpointRoot}", queryParameterOrder?.QueryParameter, cancellationToken);
 
-        if (!autoPage || !res.IsSuccess || res.Data is null ||
-            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
             return res;
 
         res.Data.AddRange(await ConnectionHandler.FetchAll<Order>(
@@ -90,23 +88,19 @@ public sealed class OrderService : ConnectorService, IOrderService
     /// <inheritdoc />
     public async Task<ApiResult<OrderRepetition>> GetRepetition(int id, [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.GetAsync<OrderRepetition>($"{ApiVersion}/{EndpointRoot}/{id}/repetition", null,
-            cancellationToken);
+        return await ConnectionHandler.GetAsync<OrderRepetition>($"{ApiVersion}/{EndpointRoot}/{id}/repetition", null, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<ApiResult<Order>> Create(OrderCreate order, [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.PostAsync<Order, OrderCreate>(order, $"{ApiVersion}/{EndpointRoot}",
-            cancellationToken);
+        return await ConnectionHandler.PostAsync<Order, OrderCreate>(order, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<Order>> Update(int id, OrderUpdate order,
-        [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<Order>> Update(int id, OrderUpdate order, [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.PostAsync<Order, OrderUpdate>(order, $"{ApiVersion}/{EndpointRoot}/{id}",
-            cancellationToken);
+        return await ConnectionHandler.PostAsync<Order, OrderUpdate>(order, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
     }
 
     /// <inheritdoc />
@@ -116,35 +110,27 @@ public sealed class OrderService : ConnectorService, IOrderService
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<List<Order>>> Search(List<SearchCriteria> searchCriteria,
-        [Optional] QueryParameterOrder? queryParameterOrder, [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<List<Order>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterOrder? queryParameterOrder, [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.PostSearchAsync<Order>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search",
-            queryParameterOrder?.QueryParameter, cancellationToken);
+        return await ConnectionHandler.PostSearchAsync<Order>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterOrder?.QueryParameter, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<object>> CreateDeliveryFromOrder(int id, OrderConvertRequest request,
-        [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<Delivery>> CreateDeliveryFromOrder(int id, OrderConvertRequest request, [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.PostAsync<object, OrderConvertRequest>(request,
-            $"{ApiVersion}/{EndpointRoot}/{id}/delivery", cancellationToken);
+        return await ConnectionHandler.PostAsync<Delivery, OrderConvertRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/delivery", cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<Invoice>> CreateInvoiceFromOrder(int id, OrderConvertRequest request,
-        [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<Invoice>> CreateInvoiceFromOrder(int id, OrderConvertRequest request, [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.PostAsync<Invoice, OrderConvertRequest>(request,
-            $"{ApiVersion}/{EndpointRoot}/{id}/invoice", cancellationToken);
+        return await ConnectionHandler.PostAsync<Invoice, OrderConvertRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/invoice", cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<OrderRepetition>> CreateRepetition(int id, OrderRepetitionCreate repetition,
-        [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<OrderRepetition>> CreateRepetition(int id, OrderRepetitionCreate repetition, [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.PostAsync<OrderRepetition, OrderRepetitionCreate>(repetition,
-            $"{ApiVersion}/{EndpointRoot}/{id}/repetition", cancellationToken);
+        return await ConnectionHandler.PostAsync<OrderRepetition, OrderRepetitionCreate>(repetition, $"{ApiVersion}/{EndpointRoot}/{id}/repetition", cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/Connectors/Sales/QuoteConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/QuoteConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <summary>
+/// Quote (offer) endpoint configuration
+/// </summary>
+public struct QuoteConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "kb_offer";
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/QuoteService.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/QuoteService.cs
@@ -1,0 +1,170 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Quotes;
+using BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Sales;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Sales;
+
+/// <inheritdoc cref="IQuoteService" />
+public sealed class QuoteService : ConnectorService, IQuoteService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = QuoteConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = QuoteConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public QuoteService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Quote>?>> Get([Optional] QueryParameterQuote? queryParameterQuote, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Quote>?>($"{ApiVersion}/{EndpointRoot}", queryParameterQuote?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Quote>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterQuote?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Quote>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Quote>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<byte[]>> GetPdf(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetBinaryAsync($"{ApiVersion}/{EndpointRoot}/{id}/pdf", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Quote>> Create(QuoteCreate quote, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Quote, QuoteCreate>(quote, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Quote>> Update(int id, QuoteUpdate quote, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Quote, QuoteUpdate>(quote, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Quote>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterQuote? queryParameterQuote, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Quote>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterQuote?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Issue(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/issue", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> RevertIssue(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/revertIssue", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Accept(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/accept", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Reject(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/reject", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Reissue(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/reissue", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> MarkAsSent(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostActionAsync($"{ApiVersion}/{EndpointRoot}/{id}/mark_as_sent", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Send(int id, QuoteSendRequest request, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<object, QuoteSendRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/send", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Quote>> Copy(int id, QuoteCopyRequest request, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Quote, QuoteCopyRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/copy", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> CreateOrderFromQuote(int id, QuoteConvertRequest request, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<object, QuoteConvertRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/order", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Invoice>> CreateInvoiceFromQuote(int id, QuoteConvertRequest request, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Invoice, QuoteConvertRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/invoice", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Sales/QuoteService.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/QuoteService.cs
@@ -27,6 +27,7 @@ using System.Runtime.InteropServices;
 using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
 using BexioApiNet.Abstractions.Models.Sales.Quotes;
 using BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
 using BexioApiNet.Interfaces;
@@ -157,9 +158,9 @@ public sealed class QuoteService : ConnectorService, IQuoteService
     }
 
     /// <inheritdoc />
-    public async Task<ApiResult<object>> CreateOrderFromQuote(int id, QuoteConvertRequest request, [Optional] CancellationToken cancellationToken)
+    public async Task<ApiResult<Order>> CreateOrderFromQuote(int id, QuoteConvertRequest request, [Optional] CancellationToken cancellationToken)
     {
-        return await ConnectionHandler.PostAsync<object, QuoteConvertRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/order", cancellationToken);
+        return await ConnectionHandler.PostAsync<Order, QuoteConvertRequest>(request, $"{ApiVersion}/{EndpointRoot}/{id}/order", cancellationToken);
     }
 
     /// <inheritdoc />

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -92,7 +92,8 @@ public abstract class BexioE2eTestBase
             new ContactRelationService(connectionHandler),
             new ContactSectorService(connectionHandler),
             new AdditionalAddressService(connectionHandler),
-            new InvoiceService(connectionHandler));
+            new InvoiceService(connectionHandler),
+            new InvoiceReminderService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -93,7 +93,8 @@ public abstract class BexioE2eTestBase
             new ContactSectorService(connectionHandler),
             new AdditionalAddressService(connectionHandler),
             new InvoiceService(connectionHandler),
-            new InvoiceReminderService(connectionHandler));
+            new InvoiceReminderService(connectionHandler),
+            new QuoteService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -94,7 +94,8 @@ public abstract class BexioE2eTestBase
             new AdditionalAddressService(connectionHandler),
             new InvoiceService(connectionHandler),
             new InvoiceReminderService(connectionHandler),
-            new QuoteService(connectionHandler));
+            new QuoteService(connectionHandler),
+            new OrderService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -27,6 +27,7 @@ using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Services.Connectors.Accounting;
 using BexioApiNet.Services.Connectors.Banking;
 using BexioApiNet.Services.Connectors.Contacts;
+using BexioApiNet.Services.Connectors.Sales;
 
 namespace BexioApiNet.E2eTests;
 
@@ -90,7 +91,8 @@ public abstract class BexioE2eTestBase
             new ContactGroupService(connectionHandler),
             new ContactRelationService(connectionHandler),
             new ContactSectorService(connectionHandler),
-            new AdditionalAddressService(connectionHandler));
+            new AdditionalAddressService(connectionHandler),
+            new InvoiceService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -95,7 +95,8 @@ public abstract class BexioE2eTestBase
             new InvoiceService(connectionHandler),
             new InvoiceReminderService(connectionHandler),
             new QuoteService(connectionHandler),
-            new OrderService(connectionHandler));
+            new OrderService(connectionHandler),
+            new DeliveryService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/Tests/Sales/Deliveries/DeliveryServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Sales/Deliveries/DeliveryServiceE2eTests.cs
@@ -1,0 +1,87 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Sales.Deliveries;
+
+/// <summary>
+/// Live end-to-end tests for the delivery connector exposed via
+/// <see cref="IBexioApiClient.Deliveries"/>. Tests are skipped when the required
+/// environment variables (<c>BexioApiNet__BaseUri</c>, <c>BexioApiNet__JwtToken</c>) are
+/// not present. The mutating <c>issue</c> action is intentionally omitted to avoid
+/// transitioning live tenant state — it is covered offline by the integration suite.
+/// </summary>
+[Category("E2E")]
+public sealed class DeliveryServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists the first page of deliveries and asserts the request round-trips successfully.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsDeliveries()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.Deliveries.Get(new QueryParameterDelivery(Limit: 5));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches a single delivery by id using the first one returned from the list endpoint
+    /// and asserts round-trip equality on the id.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsDelivery()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Deliveries.Get(new QueryParameterDelivery(Limit: 1));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existing)
+        {
+            Assert.Ignore("no deliveries available on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.Deliveries.GetById(existing[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data?.Id, Is.EqualTo(existing[0].Id));
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Sales/InvoiceReminders/InvoiceReminderServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Sales/InvoiceReminders/InvoiceReminderServiceE2eTests.cs
@@ -1,0 +1,146 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Sales.InvoiceReminders;
+
+/// <summary>
+/// Live end-to-end tests for the invoice reminder connector exposed via
+/// <see cref="IBexioApiClient.InvoiceReminders"/>. Tests are skipped when the required
+/// environment variables (<c>BexioApiNet__BaseUri</c>, <c>BexioApiNet__JwtToken</c>) are not
+/// present. Mutating operations (create / send / mark / delete) are intentionally omitted to
+/// avoid leaving orphaned reminders on the live tenant — they are covered offline by the
+/// integration and unit suites.
+/// </summary>
+[Category("E2E")]
+public sealed class InvoiceReminderServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists reminders for the first available invoice and asserts the nested route round-trips
+    /// successfully. The test is skipped when the tenant has no invoices.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsReminders()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Invoices.Get(new QueryParameterInvoice(Limit: 1));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existingInvoices)
+        {
+            Assert.Ignore("no invoices available on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.InvoiceReminders.Get(existingInvoices[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches a single reminder by id using the first one returned from the list endpoint
+    /// and asserts round-trip equality on the id. Skipped when no reminder exists on the
+    /// first available invoice.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsReminder()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var invoiceList = await BexioApiClient!.Invoices.Get(new QueryParameterInvoice(Limit: 1));
+        Assert.That(invoiceList.IsSuccess, Is.True);
+
+        if (invoiceList.Data is not { Count: > 0 } existingInvoices)
+        {
+            Assert.Ignore("no invoices available on this tenant");
+            return;
+        }
+
+        var invoiceId = existingInvoices[0].Id;
+
+        var reminderList = await BexioApiClient.InvoiceReminders.Get(invoiceId);
+        Assert.That(reminderList.IsSuccess, Is.True);
+
+        if (reminderList.Data is not { Count: > 0 } existingReminders)
+        {
+            Assert.Ignore("no reminders available for the first invoice on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.InvoiceReminders.GetById(invoiceId, existingReminders[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data?.Id, Is.EqualTo(existingReminders[0].Id));
+            Assert.That(result.Data?.KbInvoiceId, Is.EqualTo(invoiceId));
+        });
+    }
+
+    /// <summary>
+    /// Searches reminders for the first available invoice by title and asserts the request
+    /// round-trips successfully. Skipped when no invoice is available.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsReminders()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var invoiceList = await BexioApiClient!.Invoices.Get(new QueryParameterInvoice(Limit: 1));
+        Assert.That(invoiceList.IsSuccess, Is.True);
+
+        if (invoiceList.Data is not { Count: > 0 } existingInvoices)
+        {
+            Assert.Ignore("no invoices available on this tenant");
+            return;
+        }
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Test", Criteria = "like" }
+        };
+
+        var result = await BexioApiClient.InvoiceReminders.Search(existingInvoices[0].Id, criteria);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Sales/Invoices/InvoiceServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Sales/Invoices/InvoiceServiceE2eTests.cs
@@ -1,0 +1,143 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Sales.Invoices;
+
+/// <summary>
+/// Live end-to-end tests for the invoice connector exposed via
+/// <see cref="IBexioApiClient.Invoices"/>. Tests are skipped when the required environment
+/// variables (<c>BexioApiNet__BaseUri</c>, <c>BexioApiNet__JwtToken</c>) are not present.
+/// Mutating operations (create / update / cancel / delete) are intentionally omitted to avoid
+/// leaving orphaned draft invoices on the live tenant — they are covered offline by the
+/// integration suite.
+/// </summary>
+[Category("E2E")]
+public sealed class InvoiceServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists the first page of invoices and asserts the request round-trips successfully.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsInvoices()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.Invoices.Get(new QueryParameterInvoice(Limit: 5));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches a single invoice by id using the first one returned from the list endpoint
+    /// and asserts round-trip equality on the id.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsInvoice()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Invoices.Get(new QueryParameterInvoice(Limit: 1));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existing)
+        {
+            Assert.Ignore("no invoices available on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.Invoices.GetById(existing[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data?.Id, Is.EqualTo(existing[0].Id));
+        });
+    }
+
+    /// <summary>
+    /// Searches invoices by title and asserts the request round-trips successfully.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsInvoices()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Test", Criteria = "like" }
+        };
+
+        var result = await BexioApiClient!.Invoices.Search(criteria);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Lists payments on the first available invoice and asserts the payment sub-resource
+    /// route works end-to-end.
+    /// </summary>
+    [Test]
+    public async Task GetPayments_ReturnsPayments()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Invoices.Get(new QueryParameterInvoice(Limit: 1));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existing)
+        {
+            Assert.Ignore("no invoices available on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.Invoices.GetPayments(existing[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Sales/Orders/OrderServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Sales/Orders/OrderServiceE2eTests.cs
@@ -1,0 +1,143 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Sales.Orders;
+
+/// <summary>
+/// Live end-to-end tests for the order connector exposed via
+/// <see cref="IBexioApiClient.Orders"/>. Tests are skipped when the required environment
+/// variables (<c>BexioApiNet__BaseUri</c>, <c>BexioApiNet__JwtToken</c>) are not present.
+/// Mutating operations (create / update / delete / convert to delivery or invoice /
+/// create or delete repetition) are intentionally omitted to avoid leaving orphaned
+/// orders or repetitions on the live tenant — they are covered offline by the
+/// integration suite.
+/// </summary>
+[Category("E2E")]
+public sealed class OrderServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists the first page of orders and asserts the request round-trips successfully.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsOrders()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.Orders.Get(new QueryParameterOrder(Limit: 5));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches a single order by id using the first one returned from the list endpoint
+    /// and asserts round-trip equality on the id.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsOrder()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Orders.Get(new QueryParameterOrder(Limit: 1));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existing)
+        {
+            Assert.Ignore("no orders available on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.Orders.GetById(existing[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data?.Id, Is.EqualTo(existing[0].Id));
+        });
+    }
+
+    /// <summary>
+    /// Downloads the PDF for the first available order and asserts the binary payload is
+    /// returned successfully.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_ReturnsBinary()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Orders.Get(new QueryParameterOrder(Limit: 1));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existing)
+        {
+            Assert.Ignore("no orders available on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.Orders.GetPdf(existing[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Searches orders by title and asserts the request round-trips successfully.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsOrders()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Test", Criteria = "like" }
+        };
+
+        var result = await BexioApiClient!.Orders.Search(criteria);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Sales/Quotes/QuoteServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Sales/Quotes/QuoteServiceE2eTests.cs
@@ -1,0 +1,142 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Sales.Quotes;
+
+/// <summary>
+/// Live end-to-end tests for the quote connector exposed via
+/// <see cref="IBexioApiClient.Quotes"/>. Tests are skipped when the required environment
+/// variables (<c>BexioApiNet__BaseUri</c>, <c>BexioApiNet__JwtToken</c>) are not present.
+/// Mutating operations (create / update / delete / issue / accept / reject / reissue /
+/// send / copy / convert) are intentionally omitted to avoid leaving orphaned quotes on
+/// the live tenant — they are covered offline by the integration suite.
+/// </summary>
+[Category("E2E")]
+public sealed class QuoteServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists the first page of quotes and asserts the request round-trips successfully.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsQuotes()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.Quotes.Get(new QueryParameterQuote(Limit: 5));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches a single quote by id using the first one returned from the list endpoint
+    /// and asserts round-trip equality on the id.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsQuote()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Quotes.Get(new QueryParameterQuote(Limit: 1));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existing)
+        {
+            Assert.Ignore("no quotes available on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.Quotes.GetById(existing[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data?.Id, Is.EqualTo(existing[0].Id));
+        });
+    }
+
+    /// <summary>
+    /// Downloads the PDF for the first available quote and asserts the binary payload is
+    /// returned successfully.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_ReturnsBinary()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var list = await BexioApiClient!.Quotes.Get(new QueryParameterQuote(Limit: 1));
+        Assert.That(list.IsSuccess, Is.True);
+
+        if (list.Data is not { Count: > 0 } existing)
+        {
+            Assert.Ignore("no quotes available on this tenant");
+            return;
+        }
+
+        var result = await BexioApiClient.Quotes.GetPdf(existing[0].Id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Searches quotes by title and asserts the request round-trips successfully.
+    /// </summary>
+    [Test]
+    public async Task Search_ReturnsQuotes()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Test", Criteria = "like" }
+        };
+
+        var result = await BexioApiClient!.Quotes.Search(criteria);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Sales/DeliveryServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Sales/DeliveryServiceIntegrationTests.cs
@@ -1,0 +1,160 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.IntegrationTests.Sales;
+
+/// <summary>
+/// Integration tests covering the full surface of <see cref="DeliveryService"/> against
+/// WireMock stubs. Verifies the path composed from <see cref="DeliveryConfiguration"/>
+/// (<c>2.0/kb_delivery</c>) reaches the handler correctly, that the expected HTTP verbs are
+/// used (including <c>POST</c>-without-body for the <c>/issue</c> action endpoint), and that
+/// the <see cref="Abstractions.Models.Sales.Deliveries.Delivery"/> payload is deserialized
+/// with the expected snake_case field names.
+/// </summary>
+public sealed class DeliveryServiceIntegrationTests : IntegrationTestBase
+{
+    private const string DeliveriesPath = "/2.0/kb_delivery";
+
+    private const string DeliveryResponse = """
+        {
+            "id": 1,
+            "document_nr": "LS-1000",
+            "title": "Test delivery",
+            "contact_id": 42,
+            "contact_sub_id": null,
+            "user_id": 1,
+            "logopaper_id": null,
+            "language_id": null,
+            "bank_account_id": null,
+            "currency_id": 1,
+            "header": null,
+            "footer": null,
+            "total_gross": "100.00",
+            "total_net": "92.00",
+            "total_taxes": "8.00",
+            "total": "100.00",
+            "total_rounding_difference": 0.0,
+            "mwst_type": 0,
+            "mwst_is_net": true,
+            "is_valid_from": "2026-04-01",
+            "contact_address": null,
+            "delivery_address_type": 0,
+            "delivery_address": null,
+            "kb_item_status_id": 10,
+            "api_reference": null,
+            "viewed_by_client_at": null,
+            "updated_at": "2026-04-01 12:00:00",
+            "taxs": [],
+            "positions": []
+        }
+        """;
+
+    /// <summary>
+    /// <c>DeliveryService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/kb_delivery</c> and return a successful <c>ApiResult</c> when the server
+    /// returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task DeliveryService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(DeliveriesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new DeliveryService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(DeliveriesPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>DeliveryService.GetById</c> must issue a <c>GET</c> request that includes the target
+    /// id in the URL path and surface the returned delivery on success.
+    /// </summary>
+    [Test]
+    public async Task DeliveryService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{DeliveriesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(DeliveryResponse));
+
+        var service = new DeliveryService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(result.Data.DocumentNr, Is.EqualTo("LS-1000"));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>DeliveryService.Issue</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_delivery/{id}/issue</c>.
+    /// </summary>
+    [Test]
+    public async Task DeliveryService_Issue_SendsPostRequest_ToIssuePath()
+    {
+        const int id = 1;
+        var expectedPath = $"{DeliveriesPath}/{id}/issue";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new DeliveryService(ConnectionHandler);
+
+        var result = await service.Issue(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Sales/InvoiceReminderServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Sales/InvoiceReminderServiceIntegrationTests.cs
@@ -1,0 +1,339 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.InvoiceReminders.Views;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.IntegrationTests.Sales;
+
+/// <summary>
+/// Integration tests covering the full surface of <see cref="InvoiceReminderService"/> against
+/// WireMock stubs. Verifies that the nested path composed from
+/// <see cref="InvoiceReminderConfiguration"/> (<c>2.0/kb_invoice/{invoice_id}/kb_reminder</c>)
+/// reaches the handler correctly, that the expected HTTP verbs are used (including the
+/// Bexio-specific body-less <c>POST</c> for action endpoints such as <c>/mark_as_sent</c>),
+/// and that payloads are serialized with the expected snake_case field names.
+/// </summary>
+public sealed class InvoiceReminderServiceIntegrationTests : IntegrationTestBase
+{
+    private const int InvoiceId = 1;
+    private const int ReminderId = 7;
+    private static readonly string RemindersPath = $"/2.0/kb_invoice/{InvoiceId}/kb_reminder";
+
+    private const string ReminderResponse = """
+        {
+            "id": 7,
+            "kb_invoice_id": 1,
+            "title": "First reminder",
+            "is_valid_from": "2026-04-01",
+            "is_valid_to": "2026-05-01",
+            "reminder_period_in_days": 14,
+            "reminder_level": 1,
+            "show_positions": true,
+            "remaining_price": "100.00",
+            "received_total": "0.00",
+            "is_sent": false,
+            "header": null,
+            "footer": null
+        }
+        """;
+
+    /// <summary>
+    /// <c>InvoiceReminderService.Get</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/kb_invoice/{invoice_id}/kb_reminder</c> and return a successful
+    /// <c>ApiResult</c> when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(RemindersPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var result = await service.Get(InvoiceId, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(RemindersPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceReminderService.GetById</c> must issue a <c>GET</c> request that includes the
+    /// target reminder id in the URL path and surface the returned reminder on success.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_GetById_SendsGetRequest()
+    {
+        var expectedPath = $"{RemindersPath}/{ReminderId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ReminderResponse));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var result = await service.GetById(InvoiceId, ReminderId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(ReminderId));
+            Assert.That(result.Data!.KbInvoiceId, Is.EqualTo(InvoiceId));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceReminderService.GetPdf</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}/pdf</c> and return
+    /// the raw PDF bytes.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_GetPdf_SendsGetRequest_AndReturnsBytes()
+    {
+        var expectedPath = $"{RemindersPath}/{ReminderId}/pdf";
+        var pdfBytes = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // "%PDF"
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/pdf")
+                .WithBody(pdfBytes));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var result = await service.GetPdf(InvoiceId, ReminderId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.EqualTo(pdfBytes));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceReminderService.Create</c> must send a <c>POST</c> request whose body is the
+    /// serialized <see cref="InvoiceReminderCreate"/> payload, and must surface the returned
+    /// reminder on success.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(RemindersPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(ReminderResponse));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var payload = new InvoiceReminderCreate(
+            Title: "First reminder",
+            ReminderPeriodInDays: 14,
+            ShowPositions: true);
+
+        var result = await service.Create(InvoiceId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(ReminderId));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(RemindersPath));
+            Assert.That(request.Body, Does.Contain("\"title\":\"First reminder\""));
+            Assert.That(request.Body, Does.Contain("\"reminder_period_in_days\":14"));
+            Assert.That(request.Body, Does.Contain("\"show_positions\":true"));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceReminderService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/kb_invoice/{invoice_id}/kb_reminder/search</c> with the <see cref="SearchCriteria"/>
+    /// list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{RemindersPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{ReminderResponse}]"));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "First", Criteria = "like" }
+        };
+
+        var result = await service.Search(InvoiceId, criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"title\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceReminderService.Send</c> must send a <c>POST</c> against
+    /// <c>/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}/send</c> with the serialized
+    /// <see cref="InvoiceReminderSendRequest"/> payload.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_Send_SendsPostRequest_WithBody()
+    {
+        var expectedPath = $"{RemindersPath}/{ReminderId}/send";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var payload = new InvoiceReminderSendRequest(
+            RecipientEmail: "reminder@example.com",
+            Subject: "Overdue invoice",
+            Message: "Please find the document at [Network Link].");
+
+        var result = await service.Send(InvoiceId, ReminderId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"recipient_email\":\"reminder@example.com\""));
+            Assert.That(request.Body, Does.Contain("\"subject\":\"Overdue invoice\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceReminderService.MarkAsSent</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}/mark_as_sent</c>.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_MarkAsSent_SendsPostRequest_ToMarkAsSentPath()
+    {
+        var expectedPath = $"{RemindersPath}/{ReminderId}/mark_as_sent";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var result = await service.MarkAsSent(InvoiceId, ReminderId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceReminderService.MarkAsUnsent</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_invoice/{invoice_id}/kb_reminder/{reminder_id}/mark_as_unsent</c>.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_MarkAsUnsent_SendsPostRequest_ToMarkAsUnsentPath()
+    {
+        var expectedPath = $"{RemindersPath}/{ReminderId}/mark_as_unsent";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var result = await service.MarkAsUnsent(InvoiceId, ReminderId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceReminderService.Delete</c> must issue a <c>DELETE</c> request that includes
+    /// the target reminder id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task InvoiceReminderService_Delete_SendsDeleteRequest()
+    {
+        var expectedPath = $"{RemindersPath}/{ReminderId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceReminderService(ConnectionHandler);
+
+        var result = await service.Delete(InvoiceId, ReminderId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Sales/InvoiceServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Sales/InvoiceServiceIntegrationTests.cs
@@ -1,0 +1,632 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.IntegrationTests.Sales;
+
+/// <summary>
+/// Integration tests covering the full surface of <see cref="InvoiceService"/> against WireMock
+/// stubs. Verifies the path composed from <see cref="InvoiceConfiguration"/>
+/// (<c>2.0/kb_invoice</c>) reaches the handler correctly, that the expected HTTP verbs are used
+/// (including the Bexio-specific <c>POST</c> for edits and <c>POST</c>-without-body for action
+/// endpoints such as <c>/issue</c>), that payment sub-resource routes are composed correctly,
+/// and that payloads are serialized with the expected snake_case field names.
+/// </summary>
+public sealed class InvoiceServiceIntegrationTests : IntegrationTestBase
+{
+    private const string InvoicesPath = "/2.0/kb_invoice";
+
+    private const string InvoiceResponse = """
+        {
+            "id": 1,
+            "document_nr": "RE-1000",
+            "title": "Test invoice",
+            "contact_id": 42,
+            "contact_sub_id": null,
+            "user_id": 1,
+            "project_id": null,
+            "pr_project_id": null,
+            "logopaper_id": null,
+            "language_id": null,
+            "bank_account_id": null,
+            "currency_id": 1,
+            "payment_type_id": null,
+            "header": null,
+            "footer": null,
+            "total_gross": "100.00",
+            "total_net": "92.00",
+            "total_taxes": "8.00",
+            "total_received_payments": "0.00",
+            "total_credit_vouchers": "0.00",
+            "total_remaining_payments": "100.00",
+            "total": "100.00",
+            "total_rounding_difference": 0.0,
+            "mwst_type": 0,
+            "mwst_is_net": true,
+            "show_position_taxes": false,
+            "is_valid_from": "2026-04-01",
+            "is_valid_to": "2026-05-01",
+            "contact_address": null,
+            "contact_address_manual": null,
+            "kb_item_status_id": 7,
+            "reference": null,
+            "api_reference": null,
+            "viewed_by_client_at": null,
+            "updated_at": "2026-04-01 12:00:00",
+            "esr_id": null,
+            "qr_invoice_id": null,
+            "template_slug": null,
+            "taxs": [],
+            "network_link": null,
+            "positions": []
+        }
+        """;
+
+    private const string PaymentResponse = """
+        {
+            "id": 10,
+            "date": "2026-04-10",
+            "value": "100.00",
+            "bank_account_id": 1,
+            "title": "Received Payment",
+            "payment_service_id": null,
+            "is_client_account_redemption": false,
+            "is_cash_discount": false,
+            "kb_invoice_id": 1,
+            "kb_credit_voucher_id": null,
+            "kb_bill_id": null,
+            "kb_credit_voucher_text": null
+        }
+        """;
+
+    /// <summary>
+    /// <c>InvoiceService.Get()</c> must issue a <c>GET</c> request against <c>/2.0/kb_invoice</c>
+    /// and return a successful <c>ApiResult</c> when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(InvoicesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(InvoicesPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.GetById</c> must issue a <c>GET</c> request that includes the target id
+    /// in the URL path and surface the returned invoice on success.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(InvoiceResponse));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.GetPdf</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/kb_invoice/{id}/pdf</c> and return the raw PDF bytes.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_GetPdf_SendsGetRequest_AndReturnsBytes()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}/pdf";
+        var pdfBytes = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // "%PDF"
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/pdf")
+                .WithBody(pdfBytes));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.GetPdf(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.EqualTo(pdfBytes));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.Create</c> must send a <c>POST</c> request whose body is the serialized
+    /// <see cref="InvoiceCreate"/> payload, and must surface the returned invoice on success.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(InvoicesPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(InvoiceResponse));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var payload = new InvoiceCreate(
+            UserId: 1,
+            Title: "Test invoice",
+            ContactId: 42);
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(InvoicesPath));
+            Assert.That(request.Body, Does.Contain("\"user_id\":1"));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Test invoice\""));
+            Assert.That(request.Body, Does.Contain("\"contact_id\":42"));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request against
+    /// <c>/2.0/kb_invoice/{id}</c> — Bexio uses POST for full-replacement edits on this resource.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Update_SendsPostRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(InvoiceResponse));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var payload = new InvoiceUpdate(
+            UserId: 1,
+            Title: "Updated title",
+            ContactId: 42);
+
+        var result = await service.Update(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Updated title\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.Delete</c> must issue a <c>DELETE</c> request that includes the target id
+    /// in the URL path.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{InvoicesPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.Delete(idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/kb_invoice/search</c> with the <see cref="SearchCriteria"/> list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{InvoicesPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{InvoiceResponse}]"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Test", Criteria = "like" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"title\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.Issue</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_invoice/{id}/issue</c>.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Issue_SendsPostRequest_ToIssuePath()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}/issue";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.Issue(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.RevertIssue</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_invoice/{id}/revert_issue</c>.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_RevertIssue_SendsPostRequest_ToRevertIssuePath()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}/revert_issue";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.RevertIssue(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.Cancel</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_invoice/{id}/cancel</c>.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Cancel_SendsPostRequest_ToCancelPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}/cancel";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.Cancel(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.MarkAsSent</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_invoice/{id}/mark_as_sent</c>.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_MarkAsSent_SendsPostRequest_ToMarkAsSentPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}/mark_as_sent";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.MarkAsSent(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.Copy</c> must send a <c>POST</c> against <c>/2.0/kb_invoice/{id}/copy</c>
+    /// with the <see cref="InvoiceCopyRequest"/> payload, and return the new invoice.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Copy_SendsPostRequest_WithBody()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}/copy";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(InvoiceResponse));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var payload = new InvoiceCopyRequest(ContactId: 42, Title: "Copy of invoice");
+
+        var result = await service.Copy(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"contact_id\":42"));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Copy of invoice\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.Send</c> must send a <c>POST</c> against <c>/2.0/kb_invoice/{id}/send</c>
+    /// with the <see cref="InvoiceSendRequest"/> payload.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_Send_SendsPostRequest_WithBody()
+    {
+        const int id = 1;
+        var expectedPath = $"{InvoicesPath}/{id}/send";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var payload = new InvoiceSendRequest(
+            RecipientEmail: "test@example.com",
+            Subject: "Your invoice",
+            Message: "Please find your invoice at [Network Link].");
+
+        var result = await service.Send(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"recipient_email\":\"test@example.com\""));
+            Assert.That(request.Body, Does.Contain("\"subject\":\"Your invoice\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.GetPayments</c> must issue a <c>GET</c> against
+    /// <c>/2.0/kb_invoice/{invoice_id}/payment</c>.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_GetPayments_SendsGetRequest_ToPaymentPath()
+    {
+        const int invoiceId = 1;
+        var expectedPath = $"{InvoicesPath}/{invoiceId}/payment";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.GetPayments(invoiceId, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.GetPaymentById</c> must issue a <c>GET</c> against
+    /// <c>/2.0/kb_invoice/{invoice_id}/payment/{payment_id}</c> and surface the payment.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_GetPaymentById_SendsGetRequest()
+    {
+        const int invoiceId = 1;
+        const int paymentId = 10;
+        var expectedPath = $"{InvoicesPath}/{invoiceId}/payment/{paymentId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(PaymentResponse));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.GetPaymentById(invoiceId, paymentId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(paymentId));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.CreatePayment</c> must send a <c>POST</c> against
+    /// <c>/2.0/kb_invoice/{invoice_id}/payment</c> with the serialized
+    /// <see cref="InvoicePaymentCreate"/> body.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_CreatePayment_SendsPostRequest_WithBody()
+    {
+        const int invoiceId = 1;
+        var expectedPath = $"{InvoicesPath}/{invoiceId}/payment";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(PaymentResponse));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var payload = new InvoicePaymentCreate(
+            Value: "100.00",
+            Date: new DateOnly(2026, 4, 10),
+            BankAccountId: 1);
+
+        var result = await service.CreatePayment(invoiceId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"value\":\"100.00\""));
+            Assert.That(request.Body, Does.Contain("\"bank_account_id\":1"));
+        });
+    }
+
+    /// <summary>
+    /// <c>InvoiceService.DeletePayment</c> must issue a <c>DELETE</c> against
+    /// <c>/2.0/kb_invoice/{invoice_id}/payment/{payment_id}</c>.
+    /// </summary>
+    [Test]
+    public async Task InvoiceService_DeletePayment_SendsDeleteRequest()
+    {
+        const int invoiceId = 1;
+        const int paymentId = 10;
+        var expectedPath = $"{InvoicesPath}/{invoiceId}/payment/{paymentId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new InvoiceService(ConnectionHandler);
+
+        var result = await service.DeletePayment(invoiceId, paymentId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Sales/OrderServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Sales/OrderServiceIntegrationTests.cs
@@ -392,8 +392,8 @@ public sealed class OrderServiceIntegrationTests : IntegrationTestBase
 
     /// <summary>
     /// <c>OrderService.CreateDeliveryFromOrder</c> must send a <c>POST</c> against
-    /// <c>/2.0/kb_order/{id}/delivery</c>. The response is returned as a generic
-    /// <see cref="object"/> until a dedicated <c>Delivery</c> model is added in a later sub-issue.
+    /// <c>/2.0/kb_order/{id}/delivery</c> and surface the resulting
+    /// <see cref="Abstractions.Models.Sales.Deliveries.Delivery"/>.
     /// </summary>
     [Test]
     public async Task OrderService_CreateDeliveryFromOrder_SendsPostRequest_ToDeliveryPath()
@@ -414,6 +414,8 @@ public sealed class OrderServiceIntegrationTests : IntegrationTestBase
         Assert.Multiple(() =>
         {
             Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(99));
             Assert.That(request.Method, Is.EqualTo("POST"));
             Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
         });

--- a/tests/BexioApiNet.IntegrationTests/Sales/OrderServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Sales/OrderServiceIntegrationTests.cs
@@ -1,0 +1,517 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Orders.Views;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.IntegrationTests.Sales;
+
+/// <summary>
+/// Integration tests covering the full surface of <see cref="OrderService"/> against WireMock
+/// stubs. Verifies the path composed from <see cref="OrderConfiguration"/>
+/// (<c>2.0/kb_order</c>) reaches the handler correctly, that the expected HTTP verbs are used
+/// (including the Bexio-specific <c>POST</c> for edits and the nested
+/// <c>/repetition</c>, <c>/delivery</c> and <c>/invoice</c> routes), and that payloads are
+/// serialized with the expected snake_case field names.
+/// </summary>
+public sealed class OrderServiceIntegrationTests : IntegrationTestBase
+{
+    private const string OrdersPath = "/2.0/kb_order";
+
+    private const string OrderResponse = """
+        {
+            "id": 1,
+            "document_nr": "AU-1000",
+            "title": "Test order",
+            "contact_id": 42,
+            "contact_sub_id": null,
+            "user_id": 1,
+            "project_id": null,
+            "pr_project_id": null,
+            "logopaper_id": null,
+            "language_id": null,
+            "bank_account_id": null,
+            "currency_id": 1,
+            "payment_type_id": null,
+            "header": null,
+            "footer": null,
+            "total_gross": "100.00",
+            "total_net": "92.00",
+            "total_taxes": "8.00",
+            "total": "100.00",
+            "total_rounding_difference": 0.0,
+            "mwst_type": 0,
+            "mwst_is_net": true,
+            "show_position_taxes": false,
+            "is_valid_from": "2026-04-01",
+            "contact_address": null,
+            "contact_address_manual": null,
+            "delivery_address_type": 0,
+            "delivery_address": null,
+            "delivery_address_manual": null,
+            "kb_item_status_id": 5,
+            "is_recurring": false,
+            "api_reference": null,
+            "viewed_by_client_at": null,
+            "updated_at": "2026-04-01 12:00:00",
+            "template_slug": null,
+            "taxs": [],
+            "network_link": null,
+            "positions": []
+        }
+        """;
+
+    private const string OrderRepetitionResponse = """
+        {
+            "start": "2026-04-01",
+            "end": null,
+            "repetition": { "type": "daily", "interval": 1 }
+        }
+        """;
+
+    private const string InvoiceResponse = """
+        {
+            "id": 77,
+            "document_nr": "RE-1000",
+            "title": "Invoice from order",
+            "contact_id": 42,
+            "contact_sub_id": null,
+            "user_id": 1,
+            "project_id": null,
+            "pr_project_id": null,
+            "logopaper_id": null,
+            "language_id": null,
+            "bank_account_id": null,
+            "currency_id": 1,
+            "payment_type_id": null,
+            "header": null,
+            "footer": null,
+            "total_gross": "100.00",
+            "total_net": "92.00",
+            "total_taxes": "8.00",
+            "total_received_payments": "0.00",
+            "total_credit_vouchers": "0.00",
+            "total_remaining_payments": "100.00",
+            "total": "100.00",
+            "total_rounding_difference": 0.0,
+            "mwst_type": 0,
+            "mwst_is_net": true,
+            "show_position_taxes": false,
+            "is_valid_from": "2026-04-01",
+            "is_valid_to": "2026-05-01",
+            "contact_address": null,
+            "contact_address_manual": null,
+            "kb_item_status_id": 7,
+            "reference": null,
+            "api_reference": null,
+            "viewed_by_client_at": null,
+            "updated_at": "2026-04-01 12:00:00",
+            "esr_id": null,
+            "qr_invoice_id": null,
+            "template_slug": null,
+            "taxs": [],
+            "network_link": null,
+            "positions": []
+        }
+        """;
+
+    /// <summary>
+    /// <c>OrderService.Get()</c> must issue a <c>GET</c> request against <c>/2.0/kb_order</c>
+    /// and return a successful <c>ApiResult</c> when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task OrderService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(OrdersPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(OrdersPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.GetById</c> must issue a <c>GET</c> request that includes the target id
+    /// in the URL path and surface the returned order on success.
+    /// </summary>
+    [Test]
+    public async Task OrderService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{OrdersPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(OrderResponse));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.GetPdf</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/kb_order/{id}/pdf</c> and return the raw PDF bytes.
+    /// </summary>
+    [Test]
+    public async Task OrderService_GetPdf_SendsGetRequest_AndReturnsBytes()
+    {
+        const int id = 1;
+        var expectedPath = $"{OrdersPath}/{id}/pdf";
+        var pdfBytes = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // "%PDF"
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/pdf")
+                .WithBody(pdfBytes));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var result = await service.GetPdf(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.EqualTo(pdfBytes));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.GetRepetition</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/kb_order/{id}/repetition</c> and return the repetition descriptor.
+    /// </summary>
+    [Test]
+    public async Task OrderService_GetRepetition_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{OrdersPath}/{id}/repetition";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(OrderRepetitionResponse));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var result = await service.GetRepetition(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Start, Is.EqualTo("2026-04-01"));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.Create</c> must send a <c>POST</c> request whose body is the serialized
+    /// <see cref="OrderCreate"/> payload, and must surface the returned order on success.
+    /// </summary>
+    [Test]
+    public async Task OrderService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(OrdersPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(OrderResponse));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var payload = new OrderCreate(
+            UserId: 1,
+            Title: "Test order",
+            ContactId: 42);
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(OrdersPath));
+            Assert.That(request.Body, Does.Contain("\"user_id\":1"));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Test order\""));
+            Assert.That(request.Body, Does.Contain("\"contact_id\":42"));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request against
+    /// <c>/2.0/kb_order/{id}</c> — Bexio uses POST for full-replacement edits on this resource.
+    /// </summary>
+    [Test]
+    public async Task OrderService_Update_SendsPostRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{OrdersPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(OrderResponse));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var payload = new OrderUpdate(
+            UserId: 1,
+            Title: "Updated title",
+            ContactId: 42);
+
+        var result = await service.Update(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Updated title\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.Delete</c> must issue a <c>DELETE</c> request that includes the target id
+    /// in the URL path.
+    /// </summary>
+    [Test]
+    public async Task OrderService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{OrdersPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var result = await service.Delete(idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/kb_order/search</c> with the <see cref="SearchCriteria"/> list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task OrderService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{OrdersPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{OrderResponse}]"));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Test", Criteria = "like" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"title\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.CreateDeliveryFromOrder</c> must send a <c>POST</c> against
+    /// <c>/2.0/kb_order/{id}/delivery</c>. The response is returned as a generic
+    /// <see cref="object"/> until a dedicated <c>Delivery</c> model is added in a later sub-issue.
+    /// </summary>
+    [Test]
+    public async Task OrderService_CreateDeliveryFromOrder_SendsPostRequest_ToDeliveryPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{OrdersPath}/{id}/delivery";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody("{\"id\":99}"));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var result = await service.CreateDeliveryFromOrder(id, new OrderConvertRequest(), TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.CreateInvoiceFromOrder</c> must send a <c>POST</c> against
+    /// <c>/2.0/kb_order/{id}/invoice</c> and surface the resulting invoice.
+    /// </summary>
+    [Test]
+    public async Task OrderService_CreateInvoiceFromOrder_SendsPostRequest_ToInvoicePath()
+    {
+        const int id = 1;
+        var expectedPath = $"{OrdersPath}/{id}/invoice";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(InvoiceResponse));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var result = await service.CreateInvoiceFromOrder(id, new OrderConvertRequest(), TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(77));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.CreateRepetition</c> must send a <c>POST</c> against
+    /// <c>/2.0/kb_order/{id}/repetition</c> with the serialized <see cref="OrderRepetitionCreate"/>
+    /// payload and surface the returned repetition descriptor.
+    /// </summary>
+    [Test]
+    public async Task OrderService_CreateRepetition_SendsPostRequest_ToRepetitionPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{OrdersPath}/{id}/repetition";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(OrderRepetitionResponse));
+
+        var service = new OrderService(ConnectionHandler);
+
+        using var repetition = JsonDocument.Parse("""{"type":"daily","interval":1}""");
+        var payload = new OrderRepetitionCreate(
+            Start: "2026-04-01",
+            Repetition: repetition.RootElement.Clone());
+
+        var result = await service.CreateRepetition(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Start, Is.EqualTo("2026-04-01"));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"start\":\"2026-04-01\""));
+            Assert.That(request.Body, Does.Contain("\"type\":\"daily\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>OrderService.DeleteRepetition</c> must issue a <c>DELETE</c> request against
+    /// <c>/2.0/kb_order/{id}/repetition</c>.
+    /// </summary>
+    [Test]
+    public async Task OrderService_DeleteRepetition_SendsDeleteRequest_ToRepetitionPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{OrdersPath}/{id}/repetition";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new OrderService(ConnectionHandler);
+
+        var result = await service.DeleteRepetition(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Sales/QuoteServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Sales/QuoteServiceIntegrationTests.cs
@@ -1,0 +1,653 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.IntegrationTests.Sales;
+
+/// <summary>
+/// Integration tests covering the full surface of <see cref="QuoteService"/> against WireMock
+/// stubs. Verifies the path composed from <see cref="QuoteConfiguration"/>
+/// (<c>2.0/kb_offer</c>) reaches the handler correctly, that the expected HTTP verbs are used
+/// (including the Bexio-specific <c>POST</c> for edits and <c>POST</c>-without-body for action
+/// endpoints such as <c>/issue</c>, <c>/accept</c>, <c>/reject</c>, <c>/reissue</c>,
+/// <c>/mark_as_sent</c>, <c>/revertIssue</c>), and that payloads are serialized with the expected
+/// snake_case field names.
+/// </summary>
+public sealed class QuoteServiceIntegrationTests : IntegrationTestBase
+{
+    private const string QuotesPath = "/2.0/kb_offer";
+
+    private const string QuoteResponse = """
+        {
+            "id": 1,
+            "document_nr": "AN-1000",
+            "title": "Test quote",
+            "contact_id": 42,
+            "contact_sub_id": null,
+            "user_id": 1,
+            "project_id": null,
+            "pr_project_id": null,
+            "logopaper_id": null,
+            "language_id": null,
+            "bank_account_id": null,
+            "currency_id": 1,
+            "payment_type_id": null,
+            "header": null,
+            "footer": null,
+            "total_gross": "100.00",
+            "total_net": "92.00",
+            "total_taxes": "8.00",
+            "total": "100.00",
+            "total_rounding_difference": 0.0,
+            "mwst_type": 0,
+            "mwst_is_net": true,
+            "show_position_taxes": false,
+            "is_valid_from": "2026-04-01",
+            "is_valid_until": "2026-05-01",
+            "contact_address": null,
+            "contact_address_manual": null,
+            "delivery_address_type": 0,
+            "delivery_address": null,
+            "delivery_address_manual": null,
+            "kb_item_status_id": 1,
+            "api_reference": null,
+            "viewed_by_client_at": null,
+            "kb_terms_of_payment_template_id": null,
+            "show_total": true,
+            "updated_at": "2026-04-01 12:00:00",
+            "template_slug": null,
+            "taxs": [],
+            "network_link": null,
+            "positions": []
+        }
+        """;
+
+    private const string InvoiceResponse = """
+        {
+            "id": 77,
+            "document_nr": "RE-1000",
+            "title": "Invoice from quote",
+            "contact_id": 42,
+            "contact_sub_id": null,
+            "user_id": 1,
+            "project_id": null,
+            "pr_project_id": null,
+            "logopaper_id": null,
+            "language_id": null,
+            "bank_account_id": null,
+            "currency_id": 1,
+            "payment_type_id": null,
+            "header": null,
+            "footer": null,
+            "total_gross": "100.00",
+            "total_net": "92.00",
+            "total_taxes": "8.00",
+            "total_received_payments": "0.00",
+            "total_credit_vouchers": "0.00",
+            "total_remaining_payments": "100.00",
+            "total": "100.00",
+            "total_rounding_difference": 0.0,
+            "mwst_type": 0,
+            "mwst_is_net": true,
+            "show_position_taxes": false,
+            "is_valid_from": "2026-04-01",
+            "is_valid_to": "2026-05-01",
+            "contact_address": null,
+            "contact_address_manual": null,
+            "kb_item_status_id": 7,
+            "reference": null,
+            "api_reference": null,
+            "viewed_by_client_at": null,
+            "updated_at": "2026-04-01 12:00:00",
+            "esr_id": null,
+            "qr_invoice_id": null,
+            "template_slug": null,
+            "taxs": [],
+            "network_link": null,
+            "positions": []
+        }
+        """;
+
+    /// <summary>
+    /// <c>QuoteService.Get()</c> must issue a <c>GET</c> request against <c>/2.0/kb_offer</c>
+    /// and return a successful <c>ApiResult</c> when the server returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(QuotesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(QuotesPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.GetById</c> must issue a <c>GET</c> request that includes the target id
+    /// in the URL path and surface the returned quote on success.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(QuoteResponse));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.GetPdf</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/kb_offer/{id}/pdf</c> and return the raw PDF bytes.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_GetPdf_SendsGetRequest_AndReturnsBytes()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/pdf";
+        var pdfBytes = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // "%PDF"
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/pdf")
+                .WithBody(pdfBytes));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.GetPdf(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.EqualTo(pdfBytes));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Create</c> must send a <c>POST</c> request whose body is the serialized
+    /// <see cref="QuoteCreate"/> payload, and must surface the returned quote on success.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(QuotesPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(QuoteResponse));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var payload = new QuoteCreate(
+            UserId: 1,
+            Title: "Test quote",
+            ContactId: 42);
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(QuotesPath));
+            Assert.That(request.Body, Does.Contain("\"user_id\":1"));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Test quote\""));
+            Assert.That(request.Body, Does.Contain("\"contact_id\":42"));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request against
+    /// <c>/2.0/kb_offer/{id}</c> — Bexio uses POST for full-replacement edits on this resource.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Update_SendsPostRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(QuoteResponse));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var payload = new QuoteUpdate(
+            UserId: 1,
+            Title: "Updated title",
+            ContactId: 42);
+
+        var result = await service.Update(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Updated title\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Delete</c> must issue a <c>DELETE</c> request that includes the target id
+    /// in the URL path.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{QuotesPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.Delete(idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/kb_offer/search</c> with the <see cref="SearchCriteria"/> list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{QuotesPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{QuoteResponse}]"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Test", Criteria = "like" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"title\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Issue</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_offer/{id}/issue</c>.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Issue_SendsPostRequest_ToIssuePath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/issue";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.Issue(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.RevertIssue</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_offer/{id}/revertIssue</c>. Note the camelCase <c>revertIssue</c> path
+    /// — it differs from invoices' snake_case <c>revert_issue</c>.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_RevertIssue_SendsPostRequest_ToRevertIssuePath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/revertIssue";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.RevertIssue(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Accept</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_offer/{id}/accept</c>.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Accept_SendsPostRequest_ToAcceptPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/accept";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.Accept(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Reject</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_offer/{id}/reject</c> (Bexio names the action "decline" but routes it under
+    /// <c>/reject</c>).
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Reject_SendsPostRequest_ToRejectPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/reject";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.Reject(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Reissue</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_offer/{id}/reissue</c>.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Reissue_SendsPostRequest_ToReissuePath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/reissue";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.Reissue(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.MarkAsSent</c> must send a body-less <c>POST</c> against
+    /// <c>/2.0/kb_offer/{id}/mark_as_sent</c>.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_MarkAsSent_SendsPostRequest_ToMarkAsSentPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/mark_as_sent";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.MarkAsSent(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Send</c> must send a <c>POST</c> against <c>/2.0/kb_offer/{id}/send</c>
+    /// with the <see cref="QuoteSendRequest"/> payload.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Send_SendsPostRequest_WithBody()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/send";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var payload = new QuoteSendRequest(
+            RecipientEmail: "test@example.com",
+            Subject: "Your quote",
+            Message: "Please find your quote at [Network Link].");
+
+        var result = await service.Send(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"recipient_email\":\"test@example.com\""));
+            Assert.That(request.Body, Does.Contain("\"subject\":\"Your quote\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.Copy</c> must send a <c>POST</c> against <c>/2.0/kb_offer/{id}/copy</c>
+    /// with the <see cref="QuoteCopyRequest"/> payload, and return the new quote.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_Copy_SendsPostRequest_WithBody()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/copy";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(QuoteResponse));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var payload = new QuoteCopyRequest(ContactId: 42, Title: "Copy of quote");
+
+        var result = await service.Copy(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"contact_id\":42"));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Copy of quote\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.CreateOrderFromQuote</c> must send a <c>POST</c> against
+    /// <c>/2.0/kb_offer/{id}/order</c>. The response is returned as a generic <see cref="object"/>
+    /// until a dedicated <c>Order</c> model is added in a later sub-issue.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_CreateOrderFromQuote_SendsPostRequest_ToOrderPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/order";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody("{\"id\":55}"));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.CreateOrderFromQuote(id, new QuoteConvertRequest(), TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>QuoteService.CreateInvoiceFromQuote</c> must send a <c>POST</c> against
+    /// <c>/2.0/kb_offer/{id}/invoice</c> and surface the resulting invoice.
+    /// </summary>
+    [Test]
+    public async Task QuoteService_CreateInvoiceFromQuote_SendsPostRequest_ToInvoicePath()
+    {
+        const int id = 1;
+        var expectedPath = $"{QuotesPath}/{id}/invoice";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(InvoiceResponse));
+
+        var service = new QuoteService(ConnectionHandler);
+
+        var result = await service.CreateInvoiceFromQuote(id, new QuoteConvertRequest(), TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(77));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Sales/QuoteServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Sales/QuoteServiceIntegrationTests.cs
@@ -594,8 +594,7 @@ public sealed class QuoteServiceIntegrationTests : IntegrationTestBase
 
     /// <summary>
     /// <c>QuoteService.CreateOrderFromQuote</c> must send a <c>POST</c> against
-    /// <c>/2.0/kb_offer/{id}/order</c>. The response is returned as a generic <see cref="object"/>
-    /// until a dedicated <c>Order</c> model is added in a later sub-issue.
+    /// <c>/2.0/kb_offer/{id}/order</c> and surface the resulting <see cref="Abstractions.Models.Sales.Orders.Order"/>.
     /// </summary>
     [Test]
     public async Task QuoteService_CreateOrderFromQuote_SendsPostRequest_ToOrderPath()
@@ -616,6 +615,8 @@ public sealed class QuoteServiceIntegrationTests : IntegrationTestBase
         Assert.Multiple(() =>
         {
             Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(55));
             Assert.That(request.Method, Is.EqualTo("POST"));
             Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
         });

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -69,7 +69,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IContactRelationService>(),
             Substitute.For<IContactSectorService>(),
             Substitute.For<IAdditionalAddressService>(),
-            Substitute.For<IInvoiceService>());
+            Substitute.For<IInvoiceService>(),
+            Substitute.For<IInvoiceReminderService>());
 
         Assert.Multiple(() =>
         {
@@ -92,6 +93,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.ContactSectors, Is.Not.Null);
             Assert.That(client.ContactAdditionalAddresses, Is.Not.Null);
             Assert.That(client.Invoices, Is.Not.Null);
+            Assert.That(client.InvoiceReminders, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -71,7 +71,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IAdditionalAddressService>(),
             Substitute.For<IInvoiceService>(),
             Substitute.For<IInvoiceReminderService>(),
-            Substitute.For<IQuoteService>());
+            Substitute.For<IQuoteService>(),
+            Substitute.For<IOrderService>());
 
         Assert.Multiple(() =>
         {
@@ -96,6 +97,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.Invoices, Is.Not.Null);
             Assert.That(client.InvoiceReminders, Is.Not.Null);
             Assert.That(client.Quotes, Is.Not.Null);
+            Assert.That(client.Orders, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -72,7 +72,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IInvoiceService>(),
             Substitute.For<IInvoiceReminderService>(),
             Substitute.For<IQuoteService>(),
-            Substitute.For<IOrderService>());
+            Substitute.For<IOrderService>(),
+            Substitute.For<IDeliveryService>());
 
         Assert.Multiple(() =>
         {
@@ -98,6 +99,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.InvoiceReminders, Is.Not.Null);
             Assert.That(client.Quotes, Is.Not.Null);
             Assert.That(client.Orders, Is.Not.Null);
+            Assert.That(client.Deliveries, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -26,6 +26,7 @@ SOFTWARE.
 using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Interfaces.Connectors.Sales;
 
 namespace BexioApiNet.UnitTests;
 
@@ -67,7 +68,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IContactGroupService>(),
             Substitute.For<IContactRelationService>(),
             Substitute.For<IContactSectorService>(),
-            Substitute.For<IAdditionalAddressService>());
+            Substitute.For<IAdditionalAddressService>(),
+            Substitute.For<IInvoiceService>());
 
         Assert.Multiple(() =>
         {
@@ -89,6 +91,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.ContactRelations, Is.Not.Null);
             Assert.That(client.ContactSectors, Is.Not.Null);
             Assert.That(client.ContactAdditionalAddresses, Is.Not.Null);
+            Assert.That(client.Invoices, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -70,7 +70,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IContactSectorService>(),
             Substitute.For<IAdditionalAddressService>(),
             Substitute.For<IInvoiceService>(),
-            Substitute.For<IInvoiceReminderService>());
+            Substitute.For<IInvoiceReminderService>(),
+            Substitute.For<IQuoteService>());
 
         Assert.Multiple(() =>
         {
@@ -94,6 +95,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.ContactAdditionalAddresses, Is.Not.Null);
             Assert.That(client.Invoices, Is.Not.Null);
             Assert.That(client.InvoiceReminders, Is.Not.Null);
+            Assert.That(client.Quotes, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/Sales/DeliveryServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/DeliveryServiceTests.cs
@@ -1,0 +1,242 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Deliveries;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.UnitTests.Sales;
+
+/// <summary>
+///     Offline unit tests for <see cref="DeliveryService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+///     returns the handler's result unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class DeliveryServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="DeliveryService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new DeliveryService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/kb_delivery";
+
+    private DeliveryService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    ///     the expected endpoint path and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<Delivery>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Delivery>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<Delivery>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get forwards the <see cref="QueryParameterDelivery" />'s underlying <see cref="QueryParameter" />
+    ///     to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterDelivery(100, 50);
+        var response = new ApiResult<List<Delivery>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Delivery>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Delivery>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    ///     the full result set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<Delivery> { BuildDelivery(1), BuildDelivery(2) };
+        var initial = new ApiResult<List<Delivery>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Delivery>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<Delivery>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Delivery>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    ///     auto-paging is not requested.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResult()
+    {
+        var response = new ApiResult<List<Delivery>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Delivery>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    ///     endpoint path including the delivery id.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<Delivery> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Delivery>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task Issue_CallsPostActionAsync_WithIssuePath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Issue(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/issue"));
+    }
+
+    private static Delivery BuildDelivery(int id)
+    {
+        return new Delivery(
+            Id: id,
+            DocumentNr: $"LS-{id:D5}",
+            Title: $"Delivery {id}",
+            ContactId: null,
+            ContactSubId: null,
+            UserId: 1,
+            LogopaperId: null,
+            LanguageId: null,
+            BankAccountId: null,
+            CurrencyId: null,
+            Header: null,
+            Footer: null,
+            TotalGross: null,
+            TotalNet: null,
+            TotalTaxes: null,
+            Total: null,
+            TotalRoundingDifference: null,
+            MwstType: null,
+            MwstIsNet: null,
+            IsValidFrom: null,
+            ContactAddress: null,
+            DeliveryAddressType: null,
+            DeliveryAddress: null,
+            KbItemStatusId: null,
+            ApiReference: null,
+            ViewedByClientAt: null,
+            UpdatedAt: null,
+            Taxs: null,
+            Positions: null);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Sales/InvoiceReminderServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/InvoiceReminderServiceTests.cs
@@ -1,0 +1,263 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.InvoiceReminders;
+using BexioApiNet.Abstractions.Models.Sales.InvoiceReminders.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.UnitTests.Sales;
+
+/// <summary>
+///     Offline unit tests for <see cref="InvoiceReminderService" />. Each test verifies that the
+///     service forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected
+///     arguments (including the owning invoice id in every path) and returns the handler's result
+///     unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class InvoiceReminderServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="InvoiceReminderService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new InvoiceReminderService(ConnectionHandler);
+    }
+
+    private const int InvoiceId = 1;
+    private const string ExpectedEndpoint = "2.0/kb_invoice";
+    private const string ReminderPath = "kb_reminder";
+
+    private InvoiceReminderService _sut = null!;
+
+    /// <summary>
+    ///     Get forwards the call to <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the
+    ///     nested <c>/{invoiceId}/kb_reminder</c> path.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsync_WithInvoiceIdInPath()
+    {
+        var response = new ApiResult<List<InvoiceReminder>?> { IsSuccess = true, Data = [] };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<List<InvoiceReminder>?>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(InvoiceId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}"));
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
+    ///     <c>/{invoiceId}/kb_reminder/{reminderId}</c>.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithReminderIdInPath()
+    {
+        const int reminderId = 7;
+        var response = new ApiResult<InvoiceReminder> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<InvoiceReminder>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(InvoiceId, reminderId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}/{reminderId}"));
+    }
+
+    /// <summary>
+    ///     GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
+    ///     <c>/{reminderId}/pdf</c> sub-resource.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_CallsGetBinaryAsync_WithPdfPath()
+    {
+        const int reminderId = 7;
+        var response = new ApiResult<byte[]> { IsSuccess = true, Data = [1, 2, 3] };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetBinaryAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetPdf(InvoiceId, reminderId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}/{reminderId}/pdf"));
+    }
+
+    /// <summary>
+    ///     Create forwards the payload and the nested endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync_WithReminderPath()
+    {
+        var payload = new InvoiceReminderCreate(Title: "First reminder");
+        var response = new ApiResult<InvoiceReminder> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<InvoiceReminder, InvoiceReminderCreate>(
+                Arg.Any<InvoiceReminderCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(InvoiceId, payload);
+
+        await ConnectionHandler.Received(1).PostAsync<InvoiceReminder, InvoiceReminderCreate>(
+            payload,
+            $"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "First", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterInvoiceReminder(Limit: 50);
+        var response = new ApiResult<List<InvoiceReminder>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<InvoiceReminder>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(InvoiceId, criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<InvoiceReminder>(
+            criteria,
+            $"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Send posts the <see cref="InvoiceReminderSendRequest"/> body to the <c>/{reminderId}/send</c>
+    ///     endpoint.
+    /// </summary>
+    [Test]
+    public async Task Send_CallsPostAsync_WithSendPath()
+    {
+        const int reminderId = 7;
+        var payload = new InvoiceReminderSendRequest(
+            RecipientEmail: "reminder@example.com",
+            Subject: "Overdue invoice",
+            Message: "Please find the document at [Network Link]");
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<object, InvoiceReminderSendRequest>(
+                Arg.Any<InvoiceReminderSendRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Send(InvoiceId, reminderId, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}/{reminderId}/send"));
+    }
+
+    /// <summary>
+    ///     MarkAsSent posts to the <c>/{reminderId}/mark_as_sent</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task MarkAsSent_CallsPostActionAsync_WithMarkAsSentPath()
+    {
+        const int reminderId = 7;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.MarkAsSent(InvoiceId, reminderId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}/{reminderId}/mark_as_sent"));
+    }
+
+    /// <summary>
+    ///     MarkAsUnsent posts to the <c>/{reminderId}/mark_as_unsent</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task MarkAsUnsent_CallsPostActionAsync_WithMarkAsUnsentPath()
+    {
+        const int reminderId = 7;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.MarkAsUnsent(InvoiceId, reminderId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}/{reminderId}/mark_as_unsent"));
+    }
+
+    /// <summary>
+    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the nested
+    ///     <c>/{invoiceId}/kb_reminder/{reminderId}</c> path.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithReminderIdInPath()
+    {
+        const int reminderId = 7;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Delete(InvoiceId, reminderId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{InvoiceId}/{ReminderPath}/{reminderId}"));
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Sales/InvoiceServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/InvoiceServiceTests.cs
@@ -1,0 +1,589 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.UnitTests.Sales;
+
+/// <summary>
+///     Offline unit tests for <see cref="InvoiceService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+///     returns the handler's result unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class InvoiceServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="InvoiceService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new InvoiceService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/kb_invoice";
+
+    private InvoiceService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    ///     the expected endpoint path and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<Invoice>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Invoice>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<Invoice>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get forwards the <see cref="QueryParameterInvoice" />'s underlying <see cref="QueryParameter" />
+    ///     to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterInvoice(Limit: 100, Offset: 50);
+        var response = new ApiResult<List<Invoice>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Invoice>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Invoice>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    ///     the full result set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<Invoice> { BuildInvoice(1), BuildInvoice(2) };
+        var initial = new ApiResult<List<Invoice>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Invoice>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<Invoice>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Invoice>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    ///     auto-paging is not requested.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResult()
+    {
+        var response = new ApiResult<List<Invoice>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Invoice>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    ///     endpoint path including the invoice id.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<Invoice> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Invoice>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
+    ///     <c>/{id}/pdf</c> sub-resource.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_CallsGetBinaryAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<byte[]> { IsSuccess = true, Data = [1, 2, 3] };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetBinaryAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetPdf(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/pdf"));
+    }
+
+    /// <summary>
+    ///     Create forwards the payload and the expected endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<Invoice> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Invoice, InvoiceCreate>(
+                Arg.Any<InvoiceCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<Invoice, InvoiceCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
+    ///     <c>/2.0/kb_invoice/{id}</c> — Bexio edits invoices via POST on this resource.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPostAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<Invoice> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Invoice, InvoiceUpdate>(
+                Arg.Any<InvoiceUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Update(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the invoice id
+    ///     appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Acme", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterInvoice(Limit: 50);
+        var response = new ApiResult<List<Invoice>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<Invoice>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Invoice>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task Issue_CallsPostActionAsync_WithIssuePath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Issue(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/issue"));
+    }
+
+    /// <summary>
+    ///     RevertIssue posts to the <c>/{id}/revert_issue</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task RevertIssue_CallsPostActionAsync_WithRevertIssuePath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.RevertIssue(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/revert_issue"));
+    }
+
+    /// <summary>
+    ///     Cancel posts to the <c>/{id}/cancel</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task Cancel_CallsPostActionAsync_WithCancelPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Cancel(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/cancel"));
+    }
+
+    /// <summary>
+    ///     MarkAsSent posts to the <c>/{id}/mark_as_sent</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task MarkAsSent_CallsPostActionAsync_WithMarkAsSentPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.MarkAsSent(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/mark_as_sent"));
+    }
+
+    /// <summary>
+    ///     Copy posts the <see cref="InvoiceCopyRequest"/> body to the <c>/{id}/copy</c> endpoint.
+    /// </summary>
+    [Test]
+    public async Task Copy_CallsPostAsync_WithCopyPath()
+    {
+        const int id = 42;
+        var payload = new InvoiceCopyRequest(ContactId: 14);
+        var response = new ApiResult<Invoice> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Invoice, InvoiceCopyRequest>(
+                Arg.Any<InvoiceCopyRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Copy(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/copy"));
+        await ConnectionHandler.Received(1).PostAsync<Invoice, InvoiceCopyRequest>(
+            payload,
+            $"{ExpectedEndpoint}/{id}/copy",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Send posts the <see cref="InvoiceSendRequest"/> body to the <c>/{id}/send</c> endpoint.
+    /// </summary>
+    [Test]
+    public async Task Send_CallsPostAsync_WithSendPath()
+    {
+        const int id = 42;
+        var payload = new InvoiceSendRequest(
+            RecipientEmail: "invoice@example.com",
+            Subject: "Your invoice",
+            Message: "Please find the document at [Network Link]");
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<object, InvoiceSendRequest>(
+                Arg.Any<InvoiceSendRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Send(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/send"));
+    }
+
+    /// <summary>
+    ///     GetPayments calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
+    ///     <c>/{invoiceId}/payment</c>.
+    /// </summary>
+    [Test]
+    public async Task GetPayments_CallsGetAsync_WithPaymentPath()
+    {
+        const int invoiceId = 42;
+        var response = new ApiResult<List<InvoicePayment>?> { IsSuccess = true, Data = [] };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<List<InvoicePayment>?>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetPayments(invoiceId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{invoiceId}/payment"));
+    }
+
+    /// <summary>
+    ///     GetPaymentById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
+    ///     <c>/{invoiceId}/payment/{paymentId}</c>.
+    /// </summary>
+    [Test]
+    public async Task GetPaymentById_CallsGetAsync_WithPaymentIdInPath()
+    {
+        const int invoiceId = 42;
+        const int paymentId = 7;
+        var response = new ApiResult<InvoicePayment> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<InvoicePayment>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetPaymentById(invoiceId, paymentId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{invoiceId}/payment/{paymentId}"));
+    }
+
+    /// <summary>
+    ///     CreatePayment posts the <see cref="InvoicePaymentCreate"/> body to the <c>/{invoiceId}/payment</c>
+    ///     endpoint.
+    /// </summary>
+    [Test]
+    public async Task CreatePayment_CallsPostAsync_WithPaymentPath()
+    {
+        const int invoiceId = 42;
+        var payload = new InvoicePaymentCreate(Value: "100.0000");
+        var response = new ApiResult<InvoicePayment> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<InvoicePayment, InvoicePaymentCreate>(
+                Arg.Any<InvoicePaymentCreate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.CreatePayment(invoiceId, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{invoiceId}/payment"));
+        await ConnectionHandler.Received(1).PostAsync<InvoicePayment, InvoicePaymentCreate>(
+            payload,
+            $"{ExpectedEndpoint}/{invoiceId}/payment",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     DeletePayment forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the
+    ///     nested <c>/payment/{paymentId}</c> path.
+    /// </summary>
+    [Test]
+    public async Task DeletePayment_CallsConnectionHandlerDelete_WithPaymentPath()
+    {
+        const int invoiceId = 42;
+        const int paymentId = 7;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.DeletePayment(invoiceId, paymentId);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{invoiceId}/payment/{paymentId}"));
+    }
+
+    private static InvoiceCreate BuildCreatePayload()
+    {
+        return new InvoiceCreate(UserId: 1, Title: "Invoice");
+    }
+
+    private static InvoiceUpdate BuildUpdatePayload()
+    {
+        return new InvoiceUpdate(UserId: 1, Title: "Invoice");
+    }
+
+    private static Invoice BuildInvoice(int id)
+    {
+        return new Invoice(
+            Id: id,
+            DocumentNr: $"RE-{id:D5}",
+            Title: $"Invoice {id}",
+            ContactId: null,
+            ContactSubId: null,
+            UserId: 1,
+            ProjectId: null,
+            PrProjectId: null,
+            LogopaperId: null,
+            LanguageId: null,
+            BankAccountId: null,
+            CurrencyId: null,
+            PaymentTypeId: null,
+            Header: null,
+            Footer: null,
+            TotalGross: null,
+            TotalNet: null,
+            TotalTaxes: null,
+            TotalReceivedPayments: null,
+            TotalCreditVouchers: null,
+            TotalRemainingPayments: null,
+            Total: null,
+            TotalRoundingDifference: null,
+            MwstType: null,
+            MwstIsNet: null,
+            ShowPositionTaxes: null,
+            IsValidFrom: null,
+            IsValidTo: null,
+            ContactAddress: null,
+            ContactAddressManual: null,
+            KbItemStatusId: null,
+            Reference: null,
+            ApiReference: null,
+            ViewedByClientAt: null,
+            UpdatedAt: null,
+            EsrId: null,
+            QrInvoiceId: null,
+            TemplateSlug: null,
+            Taxs: null,
+            NetworkLink: null,
+            Positions: null);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Sales/OrderServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/OrderServiceTests.cs
@@ -1,0 +1,489 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
+using BexioApiNet.Abstractions.Models.Sales.Orders.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.UnitTests.Sales;
+
+/// <summary>
+///     Offline unit tests for <see cref="OrderService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+///     returns the handler's result unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class OrderServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="OrderService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new OrderService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/kb_order";
+
+    private OrderService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    ///     the expected endpoint path and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<Order>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Order>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<Order>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get forwards the <see cref="QueryParameterOrder" />'s underlying <see cref="QueryParameter" />
+    ///     to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterOrder(100, 50);
+        var response = new ApiResult<List<Order>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Order>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Order>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    ///     the full result set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<Order> { BuildOrder(1), BuildOrder(2) };
+        var initial = new ApiResult<List<Order>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Order>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<Order>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Order>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    ///     auto-paging is not requested.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResult()
+    {
+        var response = new ApiResult<List<Order>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Order>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    ///     endpoint path including the order id.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<Order> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Order>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
+    ///     <c>/{id}/pdf</c> sub-resource.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_CallsGetBinaryAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<byte[]> { IsSuccess = true, Data = [1, 2, 3] };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetBinaryAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetPdf(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/pdf"));
+    }
+
+    /// <summary>
+    ///     GetRepetition calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the
+    ///     expected endpoint path including the order id and the <c>/repetition</c> sub-resource.
+    /// </summary>
+    [Test]
+    public async Task GetRepetition_CallsGetAsync_WithRepetitionPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<OrderRepetition> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<OrderRepetition>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetRepetition(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/repetition"));
+    }
+
+    /// <summary>
+    ///     Create forwards the payload and the expected endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<Order> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Order, OrderCreate>(
+                Arg.Any<OrderCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<Order, OrderCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
+    ///     <c>/2.0/kb_order/{id}</c> — Bexio edits orders via POST on this resource.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPostAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<Order> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Order, OrderUpdate>(
+                Arg.Any<OrderUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Update(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the order id
+    ///     appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Acme", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterOrder(50);
+        var response = new ApiResult<List<Order>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<Order>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Order>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     CreateDeliveryFromOrder posts the optional <see cref="OrderConvertRequest" /> body to the
+    ///     <c>/{id}/delivery</c> endpoint. The response type is <see cref="object" /> until a dedicated
+    ///     <c>Delivery</c> model is added in a later sub-issue.
+    /// </summary>
+    [Test]
+    public async Task CreateDeliveryFromOrder_CallsPostAsync_WithDeliveryPath()
+    {
+        const int id = 42;
+        var payload = new OrderConvertRequest();
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<object, OrderConvertRequest>(
+                Arg.Any<OrderConvertRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.CreateDeliveryFromOrder(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/delivery"));
+    }
+
+    /// <summary>
+    ///     CreateInvoiceFromOrder posts the optional <see cref="OrderConvertRequest" /> body to the
+    ///     <c>/{id}/invoice</c> endpoint and returns the newly created <see cref="Invoice" />.
+    /// </summary>
+    [Test]
+    public async Task CreateInvoiceFromOrder_CallsPostAsync_WithInvoicePath()
+    {
+        const int id = 42;
+        var payload = new OrderConvertRequest();
+        var response = new ApiResult<Invoice> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Invoice, OrderConvertRequest>(
+                Arg.Any<OrderConvertRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.CreateInvoiceFromOrder(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/invoice"));
+    }
+
+    /// <summary>
+    ///     CreateRepetition posts the <see cref="OrderRepetitionCreate" /> body to the
+    ///     <c>/{id}/repetition</c> endpoint and returns the resulting <see cref="OrderRepetition" />.
+    /// </summary>
+    [Test]
+    public async Task CreateRepetition_CallsPostAsync_WithRepetitionPath()
+    {
+        const int id = 42;
+        var payload = BuildRepetitionCreatePayload();
+        var response = new ApiResult<OrderRepetition> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<OrderRepetition, OrderRepetitionCreate>(
+                Arg.Any<OrderRepetitionCreate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.CreateRepetition(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/repetition"));
+        await ConnectionHandler.Received(1).PostAsync<OrderRepetition, OrderRepetitionCreate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}/repetition",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     DeleteRepetition calls <see cref="IBexioConnectionHandler.Delete" /> against the
+    ///     <c>/{id}/repetition</c> sub-resource.
+    /// </summary>
+    [Test]
+    public async Task DeleteRepetition_CallsConnectionHandlerDelete_WithRepetitionPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.DeleteRepetition(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/repetition"));
+    }
+
+    private static OrderCreate BuildCreatePayload()
+    {
+        return new OrderCreate(1, Title: "Order");
+    }
+
+    private static OrderUpdate BuildUpdatePayload()
+    {
+        return new OrderUpdate(1, Title: "Order");
+    }
+
+    private static OrderRepetitionCreate BuildRepetitionCreatePayload()
+    {
+        using var doc = JsonDocument.Parse("""{"type":"daily","interval":1}""");
+        return new OrderRepetitionCreate(
+            "2026-01-01",
+            doc.RootElement.Clone(),
+            "2026-12-31");
+    }
+
+    private static Order BuildOrder(int id)
+    {
+        return new Order(
+            id,
+            $"AU-{id:D5}",
+            $"Order {id}",
+            null,
+            null,
+            1,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Sales/OrderServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/OrderServiceTests.cs
@@ -26,6 +26,7 @@ SOFTWARE.
 using System.Text.Json;
 using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Deliveries;
 using BexioApiNet.Abstractions.Models.Sales.Invoices;
 using BexioApiNet.Abstractions.Models.Sales.Orders;
 using BexioApiNet.Abstractions.Models.Sales.Orders.Views;
@@ -332,18 +333,17 @@ public sealed class OrderServiceTests : ServiceTestBase
 
     /// <summary>
     ///     CreateDeliveryFromOrder posts the optional <see cref="OrderConvertRequest" /> body to the
-    ///     <c>/{id}/delivery</c> endpoint. The response type is <see cref="object" /> until a dedicated
-    ///     <c>Delivery</c> model is added in a later sub-issue.
+    ///     <c>/{id}/delivery</c> endpoint and returns the newly created <see cref="Delivery" />.
     /// </summary>
     [Test]
     public async Task CreateDeliveryFromOrder_CallsPostAsync_WithDeliveryPath()
     {
         const int id = 42;
         var payload = new OrderConvertRequest();
-        var response = new ApiResult<object> { IsSuccess = true };
+        var response = new ApiResult<Delivery> { IsSuccess = true };
         string? capturedPath = null;
         ConnectionHandler
-            .PostAsync<object, OrderConvertRequest>(
+            .PostAsync<Delivery, OrderConvertRequest>(
                 Arg.Any<OrderConvertRequest>(),
                 Arg.Do<string>(path => capturedPath = path),
                 Arg.Any<CancellationToken>())

--- a/tests/BexioApiNet.UnitTests/Sales/QuoteServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/QuoteServiceTests.cs
@@ -1,0 +1,585 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Quotes;
+using BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Sales;
+
+namespace BexioApiNet.UnitTests.Sales;
+
+/// <summary>
+///     Offline unit tests for <see cref="QuoteService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+///     returns the handler's result unchanged. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class QuoteServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="QuoteService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new QuoteService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/kb_offer";
+
+    private QuoteService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    ///     the expected endpoint path and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<Quote>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Quote>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<Quote>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get forwards the <see cref="QueryParameterQuote" />'s underlying <see cref="QueryParameter" />
+    ///     to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterQuote(Limit: 100, Offset: 50);
+        var response = new ApiResult<List<Quote>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Quote>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Quote>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    ///     the full result set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<Quote> { BuildQuote(1), BuildQuote(2) };
+        var initial = new ApiResult<List<Quote>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Quote>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<Quote>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Quote>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    ///     auto-paging is not requested.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResult()
+    {
+        var response = new ApiResult<List<Quote>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Quote>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    ///     endpoint path including the quote id.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<Quote> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Quote>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
+    ///     <c>/{id}/pdf</c> sub-resource.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_CallsGetBinaryAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<byte[]> { IsSuccess = true, Data = [1, 2, 3] };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetBinaryAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetPdf(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/pdf"));
+    }
+
+    /// <summary>
+    ///     Create forwards the payload and the expected endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<Quote> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Quote, QuoteCreate>(
+                Arg.Any<QuoteCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<Quote, QuoteCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
+    ///     <c>/2.0/kb_offer/{id}</c> — Bexio edits quotes via POST on this resource.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPostAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var payload = BuildUpdatePayload();
+        var response = new ApiResult<Quote> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Quote, QuoteUpdate>(
+                Arg.Any<QuoteUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Update(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the quote id
+    ///     appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "title", Value = "Acme", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterQuote(Limit: 50);
+        var response = new ApiResult<List<Quote>> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .PostSearchAsync<Quote>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Quote>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task Issue_CallsPostActionAsync_WithIssuePath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Issue(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/issue"));
+    }
+
+    /// <summary>
+    ///     RevertIssue posts to the <c>/{id}/revertIssue</c> action endpoint with no request body. Note
+    ///     that Bexio uses camelCase <c>revertIssue</c> on quotes (different from the snake_case used on
+    ///     invoices).
+    /// </summary>
+    [Test]
+    public async Task RevertIssue_CallsPostActionAsync_WithRevertIssuePath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.RevertIssue(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/revertIssue"));
+    }
+
+    /// <summary>
+    ///     Accept posts to the <c>/{id}/accept</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task Accept_CallsPostActionAsync_WithAcceptPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Accept(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/accept"));
+    }
+
+    /// <summary>
+    ///     Reject posts to the <c>/{id}/reject</c> action endpoint with no request body. Bexio names
+    ///     the method "decline" but exposes it at <c>/reject</c>.
+    /// </summary>
+    [Test]
+    public async Task Reject_CallsPostActionAsync_WithRejectPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Reject(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/reject"));
+    }
+
+    /// <summary>
+    ///     Reissue posts to the <c>/{id}/reissue</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task Reissue_CallsPostActionAsync_WithReissuePath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Reissue(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/reissue"));
+    }
+
+    /// <summary>
+    ///     MarkAsSent posts to the <c>/{id}/mark_as_sent</c> action endpoint with no request body.
+    /// </summary>
+    [Test]
+    public async Task MarkAsSent_CallsPostActionAsync_WithMarkAsSentPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostActionAsync(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.MarkAsSent(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/mark_as_sent"));
+    }
+
+    /// <summary>
+    ///     Send posts the <see cref="QuoteSendRequest"/> body to the <c>/{id}/send</c> endpoint.
+    /// </summary>
+    [Test]
+    public async Task Send_CallsPostAsync_WithSendPath()
+    {
+        const int id = 42;
+        var payload = new QuoteSendRequest(
+            RecipientEmail: "quote@example.com",
+            Subject: "Your quote",
+            Message: "Please find the document at [Network Link]");
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<object, QuoteSendRequest>(
+                Arg.Any<QuoteSendRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Send(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/send"));
+    }
+
+    /// <summary>
+    ///     Copy posts the <see cref="QuoteCopyRequest"/> body to the <c>/{id}/copy</c> endpoint.
+    /// </summary>
+    [Test]
+    public async Task Copy_CallsPostAsync_WithCopyPath()
+    {
+        const int id = 42;
+        var payload = new QuoteCopyRequest(ContactId: 14);
+        var response = new ApiResult<Quote> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Quote, QuoteCopyRequest>(
+                Arg.Any<QuoteCopyRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Copy(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/copy"));
+        await ConnectionHandler.Received(1).PostAsync<Quote, QuoteCopyRequest>(
+            payload,
+            $"{ExpectedEndpoint}/{id}/copy",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     CreateOrderFromQuote posts the optional <see cref="QuoteConvertRequest"/> body to the
+    ///     <c>/{id}/order</c> endpoint. The response type is <see cref="object"/> until a dedicated
+    ///     <c>Order</c> model is added in a later sub-issue.
+    /// </summary>
+    [Test]
+    public async Task CreateOrderFromQuote_CallsPostAsync_WithOrderPath()
+    {
+        const int id = 42;
+        var payload = new QuoteConvertRequest();
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<object, QuoteConvertRequest>(
+                Arg.Any<QuoteConvertRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.CreateOrderFromQuote(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/order"));
+    }
+
+    /// <summary>
+    ///     CreateInvoiceFromQuote posts the optional <see cref="QuoteConvertRequest"/> body to the
+    ///     <c>/{id}/invoice</c> endpoint and returns the newly created <see cref="Invoice"/>.
+    /// </summary>
+    [Test]
+    public async Task CreateInvoiceFromQuote_CallsPostAsync_WithInvoicePath()
+    {
+        const int id = 42;
+        var payload = new QuoteConvertRequest();
+        var response = new ApiResult<Invoice> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Invoice, QuoteConvertRequest>(
+                Arg.Any<QuoteConvertRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.CreateInvoiceFromQuote(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/invoice"));
+    }
+
+    private static QuoteCreate BuildCreatePayload()
+    {
+        return new QuoteCreate(UserId: 1, Title: "Quote");
+    }
+
+    private static QuoteUpdate BuildUpdatePayload()
+    {
+        return new QuoteUpdate(UserId: 1, Title: "Quote");
+    }
+
+    private static Quote BuildQuote(int id)
+    {
+        return new Quote(
+            Id: id,
+            DocumentNr: $"AN-{id:D5}",
+            Title: $"Quote {id}",
+            ContactId: null,
+            ContactSubId: null,
+            UserId: 1,
+            ProjectId: null,
+            PrProjectId: null,
+            LogopaperId: null,
+            LanguageId: null,
+            BankAccountId: null,
+            CurrencyId: null,
+            PaymentTypeId: null,
+            Header: null,
+            Footer: null,
+            TotalGross: null,
+            TotalNet: null,
+            TotalTaxes: null,
+            Total: null,
+            TotalRoundingDifference: null,
+            MwstType: null,
+            MwstIsNet: null,
+            ShowPositionTaxes: null,
+            IsValidFrom: null,
+            IsValidUntil: null,
+            ContactAddress: null,
+            ContactAddressManual: null,
+            DeliveryAddressType: null,
+            DeliveryAddress: null,
+            DeliveryAddressManual: null,
+            KbItemStatusId: null,
+            ApiReference: null,
+            ViewedByClientAt: null,
+            KbTermsOfPaymentTemplateId: null,
+            ShowTotal: null,
+            UpdatedAt: null,
+            TemplateSlug: null,
+            Taxs: null,
+            NetworkLink: null,
+            Positions: null);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Sales/QuoteServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/QuoteServiceTests.cs
@@ -26,6 +26,7 @@ SOFTWARE.
 using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Abstractions.Models.Sales.Invoices;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
 using BexioApiNet.Abstractions.Models.Sales.Quotes;
 using BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
 using BexioApiNet.Models;
@@ -483,18 +484,17 @@ public sealed class QuoteServiceTests : ServiceTestBase
 
     /// <summary>
     ///     CreateOrderFromQuote posts the optional <see cref="QuoteConvertRequest"/> body to the
-    ///     <c>/{id}/order</c> endpoint. The response type is <see cref="object"/> until a dedicated
-    ///     <c>Order</c> model is added in a later sub-issue.
+    ///     <c>/{id}/order</c> endpoint and returns the newly created <see cref="Order"/>.
     /// </summary>
     [Test]
     public async Task CreateOrderFromQuote_CallsPostAsync_WithOrderPath()
     {
         const int id = 42;
         var payload = new QuoteConvertRequest();
-        var response = new ApiResult<object> { IsSuccess = true };
+        var response = new ApiResult<Order> { IsSuccess = true };
         string? capturedPath = null;
         ConnectionHandler
-            .PostAsync<object, QuoteConvertRequest>(
+            .PostAsync<Order, QuoteConvertRequest>(
                 Arg.Any<QuoteConvertRequest>(),
                 Arg.Do<string>(path => capturedPath = path),
                 Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Summary

Implements Wave 2 of the Bexio API coverage roadmap (#22): all **58 new endpoints** across 5 sales document services. All sub-issues were implemented sequentially (shared central registry), verified, and approved.

Closes #25

## Sub-Issues Completed

| # | Service | Endpoints | Verdict |
|---|---------|-----------|---------|
| #53 | `InvoiceService` | 17 endpoints under `/2.0/kb_invoice` | ✅ APPROVED |
| #54 | `InvoiceReminderService` | 9 endpoints under `/2.0/kb_invoice/{id}/kb_reminder` | ✅ APPROVED |
| #55 | `QuoteService` | 17 endpoints under `/2.0/kb_offer` | ✅ APPROVED |
| #56 | `OrderService` | 12 endpoints under `/2.0/kb_order` | ✅ APPROVED |
| #57 | `DeliveryService` | 3 endpoints under `/2.0/kb_delivery` | ✅ APPROVED |

## Commits

- `4acdf17` feat(issue-25): add InvoiceService covering 17 /2.0/kb_invoice endpoints
- `4910870` feat(issue-25): add InvoiceReminderService covering 9 /2.0/kb_invoice/{id}/kb_reminder endpoints
- `fdd5838` feat(issue-25): add QuoteService covering 17 /2.0/kb_offer endpoints
- `05d4c72` feat(issue-25): add OrderService covering 12 /2.0/kb_order endpoints
- `595fc01` feat(issue-25): add DeliveryService covering 3 /2.0/kb_delivery endpoints
- `b7e9702` docs(wave2): sync documentation with Wave 2 Sales Documents implementation

## Key Implementation Details

- **PDF downloads** — `GetBinaryAsync` used for all PDF endpoints (`/pdf`)
- **Action endpoints** — `PostActionAsync` (body-less POST) for: `issue`, `cancel`, `revert_issue`, `mark_as_sent`, `accept`, `reject`, `mark_as_unsent`
- **Search** — `PostSearchAsync` for all `/search` endpoints
- **Polymorphic positions** — `IReadOnlyList<JsonElement>?` for invoice/quote/order positions (Bexio `anyOf` over 5+ types)
- **Nested resources** — `InvoiceReminderService` takes `invoiceId` as first parameter on every method
- **Central registry** — All 5 services registered in `IBexioApiClient`, `BexioApiClient`, `BexioServiceCollection`

## Test Coverage

All verification agents ran `dotnet build /warnaserror` + `dotnet test --filter TestCategory!=E2E` after each service was added. Final pass: **all offline tests green, zero warnings**.

- Unit tests: NSubstitute mocks, one test per endpoint method
- Integration tests: WireMock.Net stubs validating HTTP verb, URL path, and request body
- E2E stubs: read-only live tests, mutating operations intentionally excluded (no credential side-effects)

## Documentation

`api-completeness-audit.md`, `ai-readiness.md`, and `doc/architecture/components/library.md` updated to reflect Wave 2 completion (141 endpoints implemented, 45.6% coverage).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)