### PR TITLE
feat(issue-59): strongly-typed polymorphic unions for positions and order repetition

### DIFF
--- a/ai_instructions.md
+++ b/ai_instructions.md
@@ -81,6 +81,7 @@ If a change would require bumping any of these, stop and escalate.
 5. Place domain models in `src/BexioApiNet.Abstractions/Models/<Domain>/<Subdomain>/`. Keep "Create" / "Edit" view models in a sibling `Views/` folder.
 6. For static / lookup collections prefer `IReadOnlyList<T>` or `ImmutableArray<T>` in public APIs.
 7. Every `public` / `protected` type and member needs an XML `<summary>`. Missing docs produce build warnings, which break the build.
+8. **Polymorphic / Discriminated Unions:** For `anyOf` or `oneOf` types in the Bexio JSON (e.g., `Position` or `OrderRepetitionSchedule`), model them as an abstract base record and sealed concrete subrecords. Use the `DiscriminatedJsonConverter<TBase>` (from `BexioApiNet.Abstractions.Json`) registered via `[JsonConverter(typeof(...))]` on the base type to dispatch based on a discriminator field (e.g., `type`). Never use raw `JsonElement`.
 
 ## 5. Testing Rules (hard limits)
 

--- a/doc/ai-readiness.md
+++ b/doc/ai-readiness.md
@@ -5,7 +5,7 @@ tags: [readiness, ai, assessment]
 
 # AI Readiness Assessment
 
-_Last updated: 2026-04-18 (Issue #8 — vendor Bexio OpenAPI spec)_
+_Last updated: 2026-04-19 (Issue #59 — typed polymorphic positions and order-repetition schedules)_
 
 ## Section 1: Documentation Quality
 The documentation landscape for this project is formal and AI-aware.
@@ -70,6 +70,13 @@ Three-tier testing strategy now in place: offline unit tests, offline integratio
 - **Why it's noted**: Many Bexio domains (Items, Projects, etc.) are not implemented.
 - **Precautions**: When implementing a new domain, follow [`doc/development/feature-addition-guide.md`](./development/feature-addition-guide.md) verbatim. Ship unit tests with every new method.
 
+### 4. Typed Positions and Order Repetitions (Resolved in Issue #59)
+- **Status**: **Resolved**
+- **Location**: `src/BexioApiNet.Abstractions/Models/Sales/Positions/`, `src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetition*.cs`, `src/BexioApiNet.Abstractions/Json/`
+- **What changed**: The sales document DTOs (`Quote`, `QuoteCreate`, `QuoteConvertRequest`, `Order`, `OrderCreate`, `OrderConvertRequest`, `Invoice`, `InvoiceCreate`, `Delivery`) previously exposed `IReadOnlyList<JsonElement>? Positions`. They now expose `IReadOnlyList<Position>? Positions`, where `Position` is an abstract record with seven sealed subtypes (`PositionArticle`, `PositionCustom`, `PositionText`, `PositionSubposition`, `PositionSubtotal`, `PositionPagebreak`, `PositionDiscount`) discriminated on the `type` field (`KbPositionArticle`, `KbPositionCustom`, …). Similarly, `OrderRepetition.Repetition` and `OrderRepetitionCreate.Repetition` previously carried a raw `JsonElement` and now carry the `OrderRepetitionSchedule` abstract record — one of `OrderRepetitionDaily`, `OrderRepetitionWeekly`, `OrderRepetitionMonthly`, `OrderRepetitionYearly` — discriminated on the lowercase `type` field.
+- **How it works**: `BexioApiNet.Abstractions.Json.DiscriminatedJsonConverter<TBase>` is the shared converter base; `PositionJsonConverter` and `OrderRepetitionScheduleJsonConverter` subclass it and provide the type map. The converter attribute is applied to the abstract base only, so derived records serialize through the default metadata path — no recursion.
+- **Migration note (breaking change)**: Callers that previously passed `JsonElement` values must now construct the concrete subtypes, e.g. `new OrderRepetitionDaily { Interval = 1 }` instead of `JsonDocument.Parse(…).RootElement.Clone()`. Response consumers that enumerated `JsonElement` properties must pattern-match on the concrete subtype instead (`switch (position) { case PositionArticle a: …; case PositionText t: …; }`). The Update DTOs intentionally keep no `Positions` field — positions are only writable via Create and the convert endpoints.
+
 ## Section 4: Backlog Ideas
 
 | Title | Description | Complexity | Priority |
@@ -90,4 +97,4 @@ Three-tier testing strategy now in place: offline unit tests, offline integratio
 | Scaffold three-tier test architecture | Issue #7 — UnitTests, IntegrationTests, and E2eTests projects. |
 | Add comprehensive offline Unit and Integration coverage | Issue #7 — comprehensive Unit tests and WireMock.Net integration tests added. |
 | Vendor Bexio OpenAPI Spec | Issue #8 — `doc/openapi/bexio-v3.json` committed (OpenAPI 3.0.2, API v3.0.0, 355 paths, retrieved 2026-04-18). Refresh procedure in `doc/openapi/README.md`. |
-cedure in `doc/openapi/README.md`. |
+| Typed polymorphic positions and repetition schedules | Issue #59 — `IReadOnlyList<JsonElement>? Positions` replaced by `IReadOnlyList<Position>?` on 9 DTOs; `JsonElement? Repetition` replaced by `OrderRepetitionSchedule?` on 2 DTOs. Round-trip tests cover every variant. |

--- a/doc/architecture/README.md
+++ b/doc/architecture/README.md
@@ -10,6 +10,7 @@ Welcome to the architecture documentation for BexioApiNet. This project uses the
 ## Architecture Decision Records
 - [ADR-001: ApiResult Wrapper Pattern](decisions/001-apiresult-wrapper.md)
 - [ADR-002: Service Connector Partitioning](decisions/002-service-connector-pattern.md)
+- [ADR-003: Polymorphic Unions for API Types](decisions/003-polymorphic-unions.md)
 
 ## Reference
 - [Domain Glossary](glossary.md)

--- a/doc/architecture/decisions/003-polymorphic-unions.md
+++ b/doc/architecture/decisions/003-polymorphic-unions.md
@@ -1,0 +1,16 @@
+# ADR 003: Polymorphic Unions for API Types
+
+**Status:** Accepted  
+**Date:** 2026-04-19
+
+## Context
+The Bexio API uses polymorphic types in several places, such as positions (`anyOf` over `kb_position_*`) and order repetitions (`oneOf` over schedule types). System.Text.Json does not natively support deserializing these discriminators into a unified base type out-of-the-box in a zero-configuration way without custom converters. Initially, we mapped these to `JsonElement` leaving the parsing up to the consumer, which defeats the purpose of a strongly-typed client.
+
+## Decision
+We model polymorphic unions as an abstract base `record` with sealed concrete derived `record`s. We implement a custom `DiscriminatedJsonConverter<TBase>` that inspects a discriminator field (usually `type`) and delegates to the appropriate concrete type. The `[JsonConverter]` attribute is applied only to the base abstract record.
+
+## Consequences
+- Consumers get a fully strongly-typed object model without having to parse raw JSON or work with `JsonElement`.
+- We avoid dependencies on third-party JSON libraries (e.g., Newtonsoft.Json), remaining strictly on `System.Text.Json` as required by our architectural principles.
+- Adding new subtypes requires adding a new record and updating the switch statement in the relevant converter subclass.
+- Response consumers that formerly enumerated over `JsonElement` properties will need to adapt to pattern matching on the concrete subtype (e.g. `switch (position) { case PositionArticle a: ... }`).

--- a/doc/development/feature-addition-guide.md
+++ b/doc/development/feature-addition-guide.md
@@ -43,6 +43,7 @@ Adjust names for your actual endpoint — do not copy these literally.
 - Match Bexio's types exactly: `int` for numeric IDs, `decimal` for money, `DateOnly`/`DateTime` for dates, `string?` for nullable strings.
 - XML `<summary>` on the record and every property (required — doc generation fails otherwise).
 - If the response contains nested objects, model them as separate records in the same folder.
+- If a field represents a polymorphic union (`anyOf` / `oneOf`), use an abstract base record + sealed subtypes, backed by `DiscriminatedJsonConverter<TBase>` (see `Position` or `OrderRepetitionSchedule`). Never use `JsonElement`.
 
 **Worked example:**
 

--- a/src/BexioApiNet.Abstractions/Json/DiscriminatedJsonConverter.cs
+++ b/src/BexioApiNet.Abstractions/Json/DiscriminatedJsonConverter.cs
@@ -1,0 +1,90 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+
+namespace BexioApiNet.Abstractions.Json;
+
+/// <summary>
+///     Reusable <see cref="JsonConverter{T}" /> base for discriminated-union style polymorphic
+///     hierarchies. Derived converters only need to name the discriminator JSON property and map
+///     the discriminator value to a concrete CLR type. On write, each value is serialized under
+///     its runtime type so the concrete record's own property metadata drives the output.
+/// </summary>
+/// <remarks>
+///     Registering the converter with <c>[JsonConverter(typeof(...))]</c> on the abstract base only
+///     applies to that base (the attribute lookup uses <c>inherit: false</c>); concrete subtypes
+///     therefore do not re-enter the converter on write and the <c>Read</c>/<c>Write</c> paths
+///     stay recursion-free.
+/// </remarks>
+/// <typeparam name="TBase">The polymorphic base type handled by this converter.</typeparam>
+public abstract class DiscriminatedJsonConverter<TBase> : JsonConverter<TBase>
+    where TBase : class
+{
+    /// <summary>
+    ///     Name of the JSON property that carries the discriminator value (e.g. <c>"type"</c>).
+    /// </summary>
+    protected abstract string DiscriminatorPropertyName { get; }
+
+    /// <summary>
+    ///     Map a discriminator value read from the JSON payload to the concrete CLR type that
+    ///     should be instantiated. Return <see langword="null" /> to signal an unknown value and
+    ///     have <see cref="Read" /> throw a <see cref="JsonException" />.
+    /// </summary>
+    /// <param name="discriminator">The discriminator string extracted from the payload.</param>
+    /// <returns>The concrete subtype to deserialize into, or <see langword="null" /> if unknown.</returns>
+    protected abstract Type? ResolveType(string discriminator);
+
+    /// <inheritdoc />
+    public override TBase? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType is JsonTokenType.Null)
+            return null;
+
+        using var document = JsonDocument.ParseValue(ref reader);
+        var root = document.RootElement;
+
+        if (root.ValueKind is not JsonValueKind.Object)
+            throw new JsonException($"Expected JSON object for {typeof(TBase).Name}, found {root.ValueKind}.");
+
+        if (!root.TryGetProperty(DiscriminatorPropertyName, out var discriminatorElement)
+            || discriminatorElement.ValueKind is not JsonValueKind.String)
+        {
+            throw new JsonException(
+                $"Missing or non-string discriminator '{DiscriminatorPropertyName}' on {typeof(TBase).Name}.");
+        }
+
+        var discriminator = discriminatorElement.GetString()!;
+        var concreteType = ResolveType(discriminator)
+            ?? throw new JsonException(
+                $"Unknown discriminator '{discriminator}' for {typeof(TBase).Name}.");
+
+        return (TBase?)root.Deserialize(concreteType, options);
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, TBase value, JsonSerializerOptions options)
+        => JsonSerializer.Serialize(writer, value, value.GetType(), options);
+}

--- a/src/BexioApiNet.Abstractions/Json/DiscriminatedJsonConverter.cs
+++ b/src/BexioApiNet.Abstractions/Json/DiscriminatedJsonConverter.cs
@@ -28,30 +28,30 @@ using System.Text.Json;
 namespace BexioApiNet.Abstractions.Json;
 
 /// <summary>
-///     Reusable <see cref="JsonConverter{T}" /> base for discriminated-union style polymorphic
-///     hierarchies. Derived converters only need to name the discriminator JSON property and map
-///     the discriminator value to a concrete CLR type. On write, each value is serialized under
-///     its runtime type so the concrete record's own property metadata drives the output.
+/// Reusable <see cref="JsonConverter{T}" /> base for discriminated-union style polymorphic
+/// hierarchies. Derived converters only need to name the discriminator JSON property and map
+/// the discriminator value to a concrete CLR type. On write, each value is serialized under
+/// its runtime type so the concrete record's own property metadata drives the output.
 /// </summary>
 /// <remarks>
-///     Registering the converter with <c>[JsonConverter(typeof(...))]</c> on the abstract base only
-///     applies to that base (the attribute lookup uses <c>inherit: false</c>); concrete subtypes
-///     therefore do not re-enter the converter on write and the <c>Read</c>/<c>Write</c> paths
-///     stay recursion-free.
+/// Registering the converter with <c>[JsonConverter(typeof(...))]</c> on the abstract base only
+/// applies to that base (the attribute lookup uses <c>inherit: false</c>); concrete subtypes
+/// therefore do not re-enter the converter on write and the <c>Read</c>/<c>Write</c> paths
+/// stay recursion-free.
 /// </remarks>
 /// <typeparam name="TBase">The polymorphic base type handled by this converter.</typeparam>
 public abstract class DiscriminatedJsonConverter<TBase> : JsonConverter<TBase>
     where TBase : class
 {
     /// <summary>
-    ///     Name of the JSON property that carries the discriminator value (e.g. <c>"type"</c>).
+    /// Name of the JSON property that carries the discriminator value (e.g. <c>"type"</c>).
     /// </summary>
     protected abstract string DiscriminatorPropertyName { get; }
 
     /// <summary>
-    ///     Map a discriminator value read from the JSON payload to the concrete CLR type that
-    ///     should be instantiated. Return <see langword="null" /> to signal an unknown value and
-    ///     have <see cref="Read" /> throw a <see cref="JsonException" />.
+    /// Map a discriminator value read from the JSON payload to the concrete CLR type that
+    /// should be instantiated. Return <see langword="null" /> to signal an unknown value and
+    /// have <see cref="Read" /> throw a <see cref="JsonException" />.
     /// </summary>
     /// <param name="discriminator">The discriminator string extracted from the payload.</param>
     /// <returns>The concrete subtype to deserialize into, or <see langword="null" /> if unknown.</returns>

--- a/src/BexioApiNet.Abstractions/Json/OrderRepetitionScheduleJsonConverter.cs
+++ b/src/BexioApiNet.Abstractions/Json/OrderRepetitionScheduleJsonConverter.cs
@@ -28,10 +28,10 @@ using BexioApiNet.Abstractions.Models.Sales.Orders;
 namespace BexioApiNet.Abstractions.Json;
 
 /// <summary>
-///     <see cref="System.Text.Json.Serialization.JsonConverter{T}" /> that maps Bexio's
-///     <c>oneOf</c> order-repetition payload onto the strongly-typed
-///     <see cref="OrderRepetitionSchedule" /> hierarchy. Uses the <c>type</c> discriminator
-///     (<c>daily</c>, <c>weekly</c>, <c>monthly</c>, <c>yearly</c>).
+/// <see cref="System.Text.Json.Serialization.JsonConverter{T}" /> that maps Bexio's
+/// <c>oneOf</c> order-repetition payload onto the strongly-typed
+/// <see cref="OrderRepetitionSchedule" /> hierarchy. Uses the <c>type</c> discriminator
+/// (<c>daily</c>, <c>weekly</c>, <c>monthly</c>, <c>yearly</c>).
 /// </summary>
 public sealed class OrderRepetitionScheduleJsonConverter : DiscriminatedJsonConverter<OrderRepetitionSchedule>
 {

--- a/src/BexioApiNet.Abstractions/Json/OrderRepetitionScheduleJsonConverter.cs
+++ b/src/BexioApiNet.Abstractions/Json/OrderRepetitionScheduleJsonConverter.cs
@@ -23,19 +23,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BexioApiNet.Abstractions.Models.Sales.Positions;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
 
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Json;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     <see cref="System.Text.Json.Serialization.JsonConverter{T}" /> that maps Bexio's
+///     <c>oneOf</c> order-repetition payload onto the strongly-typed
+///     <see cref="OrderRepetitionSchedule" /> hierarchy. Uses the <c>type</c> discriminator
+///     (<c>daily</c>, <c>weekly</c>, <c>monthly</c>, <c>yearly</c>).
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+public sealed class OrderRepetitionScheduleJsonConverter : DiscriminatedJsonConverter<OrderRepetitionSchedule>
+{
+    /// <inheritdoc />
+    protected override string DiscriminatorPropertyName => "type";
+
+    /// <inheritdoc />
+    protected override Type? ResolveType(string discriminator) => discriminator switch
+    {
+        OrderRepetitionTypes.Daily => typeof(OrderRepetitionDaily),
+        OrderRepetitionTypes.Weekly => typeof(OrderRepetitionWeekly),
+        OrderRepetitionTypes.Monthly => typeof(OrderRepetitionMonthly),
+        OrderRepetitionTypes.Yearly => typeof(OrderRepetitionYearly),
+        _ => null
+    };
+}

--- a/src/BexioApiNet.Abstractions/Json/PositionJsonConverter.cs
+++ b/src/BexioApiNet.Abstractions/Json/PositionJsonConverter.cs
@@ -25,17 +25,30 @@ SOFTWARE.
 
 using BexioApiNet.Abstractions.Models.Sales.Positions;
 
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Json;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     <see cref="System.Text.Json.Serialization.JsonConverter{T}" /> that maps Bexio's
+///     <c>anyOf</c> position payload onto the strongly-typed <see cref="Position" /> hierarchy.
+///     Uses the <c>type</c> discriminator (<c>KbPositionArticle</c>, <c>KbPositionCustom</c>,
+///     <c>KbPositionText</c>, <c>KbPositionSubposition</c>, <c>KbPositionSubtotal</c>,
+///     <c>KbPositionPagebreak</c>, <c>KbPositionDiscount</c>) emitted on every position element.
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+public sealed class PositionJsonConverter : DiscriminatedJsonConverter<Position>
+{
+    /// <inheritdoc />
+    protected override string DiscriminatorPropertyName => "type";
+
+    /// <inheritdoc />
+    protected override Type? ResolveType(string discriminator) => discriminator switch
+    {
+        PositionTypes.Article => typeof(PositionArticle),
+        PositionTypes.Custom => typeof(PositionCustom),
+        PositionTypes.Text => typeof(PositionText),
+        PositionTypes.Subposition => typeof(PositionSubposition),
+        PositionTypes.Subtotal => typeof(PositionSubtotal),
+        PositionTypes.Pagebreak => typeof(PositionPagebreak),
+        PositionTypes.Discount => typeof(PositionDiscount),
+        _ => null
+    };
+}

--- a/src/BexioApiNet.Abstractions/Json/PositionJsonConverter.cs
+++ b/src/BexioApiNet.Abstractions/Json/PositionJsonConverter.cs
@@ -28,11 +28,11 @@ using BexioApiNet.Abstractions.Models.Sales.Positions;
 namespace BexioApiNet.Abstractions.Json;
 
 /// <summary>
-///     <see cref="System.Text.Json.Serialization.JsonConverter{T}" /> that maps Bexio's
-///     <c>anyOf</c> position payload onto the strongly-typed <see cref="Position" /> hierarchy.
-///     Uses the <c>type</c> discriminator (<c>KbPositionArticle</c>, <c>KbPositionCustom</c>,
-///     <c>KbPositionText</c>, <c>KbPositionSubposition</c>, <c>KbPositionSubtotal</c>,
-///     <c>KbPositionPagebreak</c>, <c>KbPositionDiscount</c>) emitted on every position element.
+/// <see cref="System.Text.Json.Serialization.JsonConverter{T}" /> that maps Bexio's
+/// <c>anyOf</c> position payload onto the strongly-typed <see cref="Position" /> hierarchy.
+/// Uses the <c>type</c> discriminator (<c>KbPositionArticle</c>, <c>KbPositionCustom</c>,
+/// <c>KbPositionText</c>, <c>KbPositionSubposition</c>, <c>KbPositionSubtotal</c>,
+/// <c>KbPositionPagebreak</c>, <c>KbPositionDiscount</c>) emitted on every position element.
 /// </summary>
 public sealed class PositionJsonConverter : DiscriminatedJsonConverter<Position>
 {

--- a/src/BexioApiNet.Abstractions/Models/Accounting/BusinessYears/BusinessYear.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/BusinessYears/BusinessYear.cs
@@ -28,7 +28,7 @@ using BexioApiNet.Abstractions.Models.Accounting.BusinessYears.Enums;
 namespace BexioApiNet.Abstractions.Models.Accounting.BusinessYears;
 
 /// <summary>
-///     Business year object. <see href="https://docs.bexio.com/#tag/Business-Years" />
+/// Business year object. <see href="https://docs.bexio.com/#tag/Business-Years" />
 /// </summary>
 /// <param name="Id"></param>
 /// <param name="Start"></param>

--- a/src/BexioApiNet.Abstractions/Models/Accounting/BusinessYears/Enums/BusinessYearStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/BusinessYears/Enums/BusinessYearStatus.cs
@@ -28,23 +28,23 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Accounting.BusinessYears.Enums;
 
 /// <summary>
-///     Status of a business year. <see href="https://docs.bexio.com/#tag/Business-Years" />
+/// Status of a business year. <see href="https://docs.bexio.com/#tag/Business-Years" />
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BusinessYearStatus
 {
     /// <summary>
-    ///     The business year period is open for new bookings.
+    /// The business year period is open for new bookings.
     /// </summary>
     open,
 
     /// <summary>
-    ///     The business year period is closed for new bookings, but without an ordinary year end closing.
+    /// The business year period is closed for new bookings, but without an ordinary year end closing.
     /// </summary>
     locked,
 
     /// <summary>
-    ///     The business year period is closed for new bookings, but with an ordinary year end closing.
+    /// The business year period is closed for new bookings, but with an ordinary year end closing.
     /// </summary>
     closed
 }

--- a/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/ExchangeRate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/ExchangeRate.cs
@@ -26,23 +26,23 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Accounting.Currencies;
 
 /// <summary>
-///     Exchange rate for a currency.
-///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ListExchangeRatesForCurrency">
-///         List Exchange Rates For
-///         Currency
-///     </see>
+/// Exchange rate for a currency.
+/// <see href="https://docs.bexio.com/#tag/Currencies/operation/ListExchangeRatesForCurrency">
+/// List Exchange Rates For
+/// Currency
+/// </see>
 /// </summary>
 /// <param name="FactorNr">
-///     The exchange rate of the currency in comparison with the currency listed in
-///     <paramref name="ExchangeCurrency" />.
+/// The exchange rate of the currency in comparison with the currency listed in
+/// <paramref name="ExchangeCurrency" />.
 /// </param>
 /// <param name="ExchangeCurrency">The currency that the exchange rate is compared against.</param>
 /// <param name="Ratio">The ratio representing how much of the base currency equals one unit of the quote currency.</param>
 /// <param name="ExchangeRateToRatio">The exchange rate of the currency multiplied by the ratio.</param>
 /// <param name="Source">The source where the exchange rate is fetched from (<c>custom</c>, <c>monthly_average</c>).</param>
 /// <param name="SourceReason">
-///     The reason why the source of the exchange rate was chosen (<c>monthly_average_provided</c>,
-///     <c>monthly_average_unavailable</c>, <c>monthly_average_unreachable</c>, <c>source_custom</c>).
+/// The reason why the source of the exchange rate was chosen (<c>monthly_average_provided</c>,
+/// <c>monthly_average_unavailable</c>, <c>monthly_average_unreachable</c>, <c>source_custom</c>).
 /// </param>
 /// <param name="ExchangeRateDate">The validity date of the exchange rate.</param>
 public sealed record ExchangeRate(

--- a/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/Views/CurrencyCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/Views/CurrencyCreate.cs
@@ -26,13 +26,13 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
 
 /// <summary>
-///     Create view for a currency.
-///     <see href="https://docs.bexio.com/#tag/Currencies/operation/CreateCurrency">Create Currency</see>
+/// Create view for a currency.
+/// <see href="https://docs.bexio.com/#tag/Currencies/operation/CreateCurrency">Create Currency</see>
 /// </summary>
 /// <param name="Name">A name of the currency. Must be in the format "ISO 4217" and must be unique. Maximum 80 characters.</param>
 /// <param name="RoundFactor">
-///     The round factor of the currency. E.g.: In order to round CHF to 5 Rp. the round_factor must
-///     be set to 0.05.
+/// The round factor of the currency. E.g.: In order to round CHF to 5 Rp. the round_factor must
+/// be set to 0.05.
 /// </param>
 public sealed record CurrencyCreate(
     [property: JsonPropertyName("name")] string Name,

--- a/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/Views/CurrencyPatch.cs
+++ b/src/BexioApiNet.Abstractions/Models/Accounting/Currencies/Views/CurrencyPatch.cs
@@ -26,12 +26,12 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
 
 /// <summary>
-///     Patch view for a currency.
-///     <see href="https://docs.bexio.com/#tag/Currencies/operation/UpdateCurrency">Update Currency</see>
+/// Patch view for a currency.
+/// <see href="https://docs.bexio.com/#tag/Currencies/operation/UpdateCurrency">Update Currency</see>
 /// </summary>
 /// <param name="RoundFactor">
-///     The round factor of the currency. E.g.: In order to round CHF to 5 Rp. the round_factor must
-///     be set to 0.05.
+/// The round factor of the currency. E.g.: In order to round CHF to 5 Rp. the round_factor must
+/// be set to 0.05.
 /// </param>
 public sealed record CurrencyPatch(
     [property: JsonPropertyName("round_factor")]

--- a/src/BexioApiNet.Abstractions/Models/Banking/PaymentTypes/PaymentType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Banking/PaymentTypes/PaymentType.cs
@@ -26,7 +26,7 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Banking.PaymentTypes;
 
 /// <summary>
-///     Bexio payment type. <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2ListPaymentTypes" />
+/// Bexio payment type. <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2ListPaymentTypes" />
 /// </summary>
 /// <param name="Id">Unique payment type identifier (read-only).</param>
 /// <param name="Name">Human-readable payment type name (e.g. <c>Cash</c>, <c>Bank</c>).</param>

--- a/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/Delivery.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/Delivery.cs
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
 
 namespace BexioApiNet.Abstractions.Models.Sales.Deliveries;
 
@@ -68,8 +68,8 @@ namespace BexioApiNet.Abstractions.Models.Sales.Deliveries;
 /// <param name="UpdatedAt">Timestamp of the last update in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format (read-only).</param>
 /// <param name="Taxs">Read-only aggregated tax summary lines.</param>
 /// <param name="Positions">
-///     Optional polymorphic positions array populated on show responses. Kept as raw
-///     <see cref="JsonElement" /> values since Bexio returns a union of several position types.
+///     Optional polymorphic positions array populated on show responses. Each element is
+///     deserialized into the concrete <see cref="Position" /> subtype identified by its <c>type</c> discriminator.
 /// </param>
 public sealed record Delivery(
     [property: JsonPropertyName("id")] int Id,
@@ -123,5 +123,5 @@ public sealed record Delivery(
     string? UpdatedAt,
     [property: JsonPropertyName("taxs")] IReadOnlyList<DeliveryTax>? Taxs,
     [property: JsonPropertyName("positions")]
-    IReadOnlyList<JsonElement>? Positions
+    IReadOnlyList<Position>? Positions
 );

--- a/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/Delivery.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/Delivery.cs
@@ -28,10 +28,10 @@ using BexioApiNet.Abstractions.Models.Sales.Positions;
 namespace BexioApiNet.Abstractions.Models.Sales.Deliveries;
 
 /// <summary>
-///     Delivery as returned by the Bexio <c>/2.0/kb_delivery</c> endpoint. Covers both the plain
-///     <c>Delivery</c> schema returned by list and the <c>DeliveryWithDetails</c> variant returned by
-///     show (which additionally populates <see cref="Positions" />).
-///     <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ListDeliveries" />
+/// Delivery as returned by the Bexio <c>/2.0/kb_delivery</c> endpoint. Covers both the plain
+/// <c>Delivery</c> schema returned by list and the <c>DeliveryWithDetails</c> variant returned by
+/// show (which additionally populates <see cref="Positions" />).
+/// <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ListDeliveries" />
 /// </summary>
 /// <param name="Id">Unique delivery identifier (read-only).</param>
 /// <param name="DocumentNr">Delivery number (read-only, e.g. <c>LS-00001</c>).</param>
@@ -52,14 +52,14 @@ namespace BexioApiNet.Abstractions.Models.Sales.Deliveries;
 /// <param name="TotalRoundingDifference">Rounding difference applied to the total (read-only).</param>
 /// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
 /// <param name="MwstIsNet">
-///     When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
-///     net.
+/// When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
+/// net.
 /// </param>
 /// <param name="IsValidFrom">Delivery validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
 /// <param name="ContactAddress">Composed contact address string (read-only).</param>
 /// <param name="DeliveryAddressType">
-///     Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
-///     address.
+/// Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
+/// address.
 /// </param>
 /// <param name="DeliveryAddress">Composed delivery address string (read-only).</param>
 /// <param name="KbItemStatusId">Read-only delivery status id (10 Draft, 18 Done, 20 Canceled).</param>
@@ -68,8 +68,8 @@ namespace BexioApiNet.Abstractions.Models.Sales.Deliveries;
 /// <param name="UpdatedAt">Timestamp of the last update in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format (read-only).</param>
 /// <param name="Taxs">Read-only aggregated tax summary lines.</param>
 /// <param name="Positions">
-///     Optional polymorphic positions array populated on show responses. Each element is
-///     deserialized into the concrete <see cref="Position" /> subtype identified by its <c>type</c> discriminator.
+/// Optional polymorphic positions array populated on show responses. Each element is
+/// deserialized into the concrete <see cref="Position" /> subtype identified by its <c>type</c> discriminator.
 /// </param>
 public sealed record Delivery(
     [property: JsonPropertyName("id")] int Id,

--- a/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/DeliveryTax.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Deliveries/DeliveryTax.cs
@@ -26,8 +26,8 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Deliveries;
 
 /// <summary>
-///     Read-only tax summary line aggregated onto a <see cref="Delivery" /> by the Bexio API.
-///     Exposed as the items of <see cref="Delivery.Taxs" />.
+/// Read-only tax summary line aggregated onto a <see cref="Delivery" /> by the Bexio API.
+/// Exposed as the items of <see cref="Delivery.Taxs" />.
 /// </summary>
 /// <param name="Percentage">Tax percentage as a formatted decimal string (e.g. <c>"7.70"</c>).</param>
 /// <param name="Value">Amount of tax applied at the given percentage as a formatted decimal string.</param>

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Invoice.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Invoice.cs
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
 
 namespace BexioApiNet.Abstractions.Models.Sales.Invoices;
 
@@ -73,7 +73,7 @@ namespace BexioApiNet.Abstractions.Models.Sales.Invoices;
 /// <param name="TemplateSlug">References a document template slug.</param>
 /// <param name="Taxs">Read-only aggregated tax summary lines.</param>
 /// <param name="NetworkLink">Read-only network link used by the Bexio document viewer.</param>
-/// <param name="Positions">Optional polymorphic positions array populated on show/create/update responses. Kept as raw <see cref="JsonElement"/> values since Bexio returns a union of several position types.</param>
+/// <param name="Positions">Optional polymorphic positions array populated on show/create/update responses. Each element is deserialized into the concrete <see cref="Position"/> subtype identified by its <c>type</c> discriminator.</param>
 public sealed record Invoice(
     [property: JsonPropertyName("id")] int Id,
     [property: JsonPropertyName("document_nr")] string? DocumentNr,
@@ -115,5 +115,5 @@ public sealed record Invoice(
     [property: JsonPropertyName("template_slug")] string? TemplateSlug,
     [property: JsonPropertyName("taxs")] IReadOnlyList<InvoiceTax>? Taxs,
     [property: JsonPropertyName("network_link")] string? NetworkLink,
-    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions
+    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions
 );

--- a/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Invoices/Views/InvoiceCreate.cs
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
 
 namespace BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
 
@@ -55,7 +55,7 @@ namespace BexioApiNet.Abstractions.Models.Sales.Invoices.Views;
 /// <param name="Reference">Free-text reference displayed on the invoice.</param>
 /// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
 /// <param name="TemplateSlug">References a document template slug.</param>
-/// <param name="Positions">Polymorphic list of positions to create. Bexio accepts a union of several position types, so they are accepted as raw <see cref="JsonElement"/> values.</param>
+/// <param name="Positions">Polymorphic list of positions to create. Pass any mix of <see cref="Position"/> subtypes — the converter emits the <c>type</c> discriminator expected by Bexio.</param>
 public sealed record InvoiceCreate(
     [property: JsonPropertyName("user_id")] int UserId,
     [property: JsonPropertyName("document_nr")] string? DocumentNr = null,
@@ -79,5 +79,5 @@ public sealed record InvoiceCreate(
     [property: JsonPropertyName("reference")] string? Reference = null,
     [property: JsonPropertyName("api_reference")] string? ApiReference = null,
     [property: JsonPropertyName("template_slug")] string? TemplateSlug = null,
-    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions = null
+    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
 );

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Order.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Order.cs
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
 
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
@@ -80,8 +80,8 @@ namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 /// <param name="Taxs">Read-only aggregated tax summary lines.</param>
 /// <param name="NetworkLink">Read-only network link used by the Bexio document viewer.</param>
 /// <param name="Positions">
-///     Optional polymorphic positions array populated on show/create/update responses. Kept as raw
-///     <see cref="JsonElement" /> values since Bexio returns a union of several position types.
+///     Optional polymorphic positions array populated on show/create/update responses. Each element is
+///     deserialized into the concrete <see cref="Position" /> subtype identified by its <c>type</c> discriminator.
 /// </param>
 public sealed record Order(
     [property: JsonPropertyName("id")] int Id,
@@ -153,5 +153,5 @@ public sealed record Order(
     [property: JsonPropertyName("network_link")]
     string? NetworkLink,
     [property: JsonPropertyName("positions")]
-    IReadOnlyList<JsonElement>? Positions
+    IReadOnlyList<Position>? Positions
 );

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Order.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Order.cs
@@ -28,10 +28,10 @@ using BexioApiNet.Abstractions.Models.Sales.Positions;
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Order as returned by the Bexio <c>/2.0/kb_order</c> endpoint. Covers both the plain
-///     <c>Order</c> schema returned by list and the <c>OrderWithDetails</c> variant returned by
-///     show/create/update (which additionally populates <see cref="Positions" />).
-///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ListOrders" />
+/// Order as returned by the Bexio <c>/2.0/kb_order</c> endpoint. Covers both the plain
+/// <c>Order</c> schema returned by list and the <c>OrderWithDetails</c> variant returned by
+/// show/create/update (which additionally populates <see cref="Positions" />).
+/// <see href="https://docs.bexio.com/#tag/Orders/operation/v2ListOrders" />
 /// </summary>
 /// <param name="Id">Unique order identifier (read-only).</param>
 /// <param name="DocumentNr">Order number. Must be omitted when automatic numbering is enabled, required otherwise.</param>
@@ -55,21 +55,21 @@ namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 /// <param name="TotalRoundingDifference">Rounding difference applied to the total (read-only).</param>
 /// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
 /// <param name="MwstIsNet">
-///     When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
-///     net.
+/// When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
+/// net.
 /// </param>
 /// <param name="ShowPositionTaxes">When <see langword="true" />, per-position taxes are shown on the printed document.</param>
 /// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
 /// <param name="ContactAddress">Composed contact address string (read-only).</param>
 /// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
 /// <param name="DeliveryAddressType">
-///     Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
-///     address.
+/// Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
+/// address.
 /// </param>
 /// <param name="DeliveryAddress">Composed delivery address string (read-only).</param>
 /// <param name="DeliveryAddressManual">
-///     Manually overridden delivery address (write-only, used when
-///     <see cref="DeliveryAddressType" /> is <c>1</c>).
+/// Manually overridden delivery address (write-only, used when
+/// <see cref="DeliveryAddressType" /> is <c>1</c>).
 /// </param>
 /// <param name="KbItemStatusId">Read-only order status id (5 Pending, 6 Done, 15 Partial, 21 Canceled).</param>
 /// <param name="IsRecurring">When <see langword="true" />, the order has a repetition schedule attached (read-only).</param>
@@ -80,8 +80,8 @@ namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 /// <param name="Taxs">Read-only aggregated tax summary lines.</param>
 /// <param name="NetworkLink">Read-only network link used by the Bexio document viewer.</param>
 /// <param name="Positions">
-///     Optional polymorphic positions array populated on show/create/update responses. Each element is
-///     deserialized into the concrete <see cref="Position" /> subtype identified by its <c>type</c> discriminator.
+/// Optional polymorphic positions array populated on show/create/update responses. Each element is
+/// deserialized into the concrete <see cref="Position" /> subtype identified by its <c>type</c> discriminator.
 /// </param>
 public sealed record Order(
     [property: JsonPropertyName("id")] int Id,

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetition.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetition.cs
@@ -26,20 +26,20 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Order repetition payload returned by (and accepted by) the Bexio
-///     <c>/2.0/kb_order/{order_id}/repetition</c> endpoints. <see cref="Repetition" /> is the
-///     polymorphic <see cref="OrderRepetitionSchedule" /> union deserialized into the concrete subtype
-///     identified by its <c>type</c> discriminator.
-///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition" />
+/// Order repetition payload returned by (and accepted by) the Bexio
+/// <c>/2.0/kb_order/{order_id}/repetition</c> endpoints. <see cref="Repetition" /> is the
+/// polymorphic <see cref="OrderRepetitionSchedule" /> union deserialized into the concrete subtype
+/// identified by its <c>type</c> discriminator.
+/// <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition" />
 /// </summary>
 /// <param name="Start">Repetition start date in Bexio's <c>yyyy-MM-dd</c> format.</param>
 /// <param name="End">
-///     Repetition end date in Bexio's <c>yyyy-MM-dd</c> format; <see langword="null" /> for indefinite
-///     repetitions.
+/// Repetition end date in Bexio's <c>yyyy-MM-dd</c> format; <see langword="null" /> for indefinite
+/// repetitions.
 /// </param>
 /// <param name="Repetition">
-///     Polymorphic repetition descriptor. The <c>type</c> discriminator (<c>daily</c>, <c>weekly</c>,
-///     <c>monthly</c>, <c>yearly</c>) selects the concrete <see cref="OrderRepetitionSchedule" /> subtype.
+/// Polymorphic repetition descriptor. The <c>type</c> discriminator (<c>daily</c>, <c>weekly</c>,
+/// <c>monthly</c>, <c>yearly</c>) selects the concrete <see cref="OrderRepetitionSchedule" /> subtype.
 /// </param>
 public sealed record OrderRepetition(
     [property: JsonPropertyName("start")] string? Start,

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionDaily.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionDaily.cs
@@ -26,8 +26,8 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Daily repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" /> days.
-///     Corresponds to the Bexio <c>OrderRepetitionDaily</c> schema (<c>type = "daily"</c>).
+/// Daily repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" /> days.
+/// Corresponds to the Bexio <c>OrderRepetitionDaily</c> schema (<c>type = "daily"</c>).
 /// </summary>
 public sealed record OrderRepetitionDaily : OrderRepetitionSchedule
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionDaily.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionDaily.cs
@@ -23,19 +23,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BexioApiNet.Abstractions.Models.Sales.Positions;
-
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     Daily repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" /> days.
+///     Corresponds to the Bexio <c>OrderRepetitionDaily</c> schema (<c>type = "daily"</c>).
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+public sealed record OrderRepetitionDaily : OrderRepetitionSchedule
+{
+    /// <inheritdoc />
+    public override string Type => OrderRepetitionTypes.Daily;
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionMonthly.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionMonthly.cs
@@ -26,9 +26,9 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Monthly repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" />
-///     months on the day described by <see cref="Schedule" />. Corresponds to the Bexio
-///     <c>OrderRepetitionMonthly</c> schema (<c>type = "monthly"</c>).
+/// Monthly repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" />
+/// months on the day described by <see cref="Schedule" />. Corresponds to the Bexio
+/// <c>OrderRepetitionMonthly</c> schema (<c>type = "monthly"</c>).
 /// </summary>
 public sealed record OrderRepetitionMonthly : OrderRepetitionSchedule
 {
@@ -36,8 +36,8 @@ public sealed record OrderRepetitionMonthly : OrderRepetitionSchedule
     public override string Type => OrderRepetitionTypes.Monthly;
 
     /// <summary>
-    ///     Day-of-month selector. One of the Bexio literals <c>fixed_day</c>, <c>week_day</c>,
-    ///     <c>first_day</c> or <c>last_day</c>.
+    /// Day-of-month selector. One of the Bexio literals <c>fixed_day</c>, <c>week_day</c>,
+    /// <c>first_day</c> or <c>last_day</c>.
     /// </summary>
     [JsonPropertyName("schedule")]
     public string Schedule { get; init; } = string.Empty;

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionMonthly.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionMonthly.cs
@@ -23,19 +23,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BexioApiNet.Abstractions.Models.Sales.Positions;
-
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     Monthly repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" />
+///     months on the day described by <see cref="Schedule" />. Corresponds to the Bexio
+///     <c>OrderRepetitionMonthly</c> schema (<c>type = "monthly"</c>).
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+public sealed record OrderRepetitionMonthly : OrderRepetitionSchedule
+{
+    /// <inheritdoc />
+    public override string Type => OrderRepetitionTypes.Monthly;
+
+    /// <summary>
+    ///     Day-of-month selector. One of the Bexio literals <c>fixed_day</c>, <c>week_day</c>,
+    ///     <c>first_day</c> or <c>last_day</c>.
+    /// </summary>
+    [JsonPropertyName("schedule")]
+    public string Schedule { get; init; } = string.Empty;
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionSchedule.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionSchedule.cs
@@ -23,27 +23,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using BexioApiNet.Abstractions.Json;
+
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Order repetition payload returned by (and accepted by) the Bexio
-///     <c>/2.0/kb_order/{order_id}/repetition</c> endpoints. <see cref="Repetition" /> is the
-///     polymorphic <see cref="OrderRepetitionSchedule" /> union deserialized into the concrete subtype
-///     identified by its <c>type</c> discriminator.
+///     Discriminated union over the four repetition schedules Bexio accepts on an
+///     <see cref="OrderRepetition" /> payload — <see cref="OrderRepetitionDaily" />,
+///     <see cref="OrderRepetitionWeekly" />, <see cref="OrderRepetitionMonthly" /> and
+///     <see cref="OrderRepetitionYearly" />. The concrete subtype is selected from the
+///     <c>type</c> discriminator (<c>daily</c>, <c>weekly</c>, <c>monthly</c>, <c>yearly</c>).
 ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition" />
 /// </summary>
-/// <param name="Start">Repetition start date in Bexio's <c>yyyy-MM-dd</c> format.</param>
-/// <param name="End">
-///     Repetition end date in Bexio's <c>yyyy-MM-dd</c> format; <see langword="null" /> for indefinite
-///     repetitions.
-/// </param>
-/// <param name="Repetition">
-///     Polymorphic repetition descriptor. The <c>type</c> discriminator (<c>daily</c>, <c>weekly</c>,
-///     <c>monthly</c>, <c>yearly</c>) selects the concrete <see cref="OrderRepetitionSchedule" /> subtype.
-/// </param>
-public sealed record OrderRepetition(
-    [property: JsonPropertyName("start")] string? Start,
-    [property: JsonPropertyName("end")] string? End,
-    [property: JsonPropertyName("repetition")]
-    OrderRepetitionSchedule? Repetition
-);
+[JsonConverter(typeof(OrderRepetitionScheduleJsonConverter))]
+public abstract record OrderRepetitionSchedule
+{
+    /// <summary>
+    ///     Discriminator string identifying the concrete schedule (<c>daily</c>, <c>weekly</c>,
+    ///     <c>monthly</c> or <c>yearly</c>).
+    /// </summary>
+    [JsonPropertyName("type")]
+    public abstract string Type { get; }
+
+    /// <summary>
+    ///     Multiplier applied to the schedule's natural period (e.g. <c>interval = 2</c> on a
+    ///     weekly schedule means "every other week").
+    /// </summary>
+    [JsonPropertyName("interval")]
+    public int Interval { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionSchedule.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionSchedule.cs
@@ -28,26 +28,26 @@ using BexioApiNet.Abstractions.Json;
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Discriminated union over the four repetition schedules Bexio accepts on an
-///     <see cref="OrderRepetition" /> payload — <see cref="OrderRepetitionDaily" />,
-///     <see cref="OrderRepetitionWeekly" />, <see cref="OrderRepetitionMonthly" /> and
-///     <see cref="OrderRepetitionYearly" />. The concrete subtype is selected from the
-///     <c>type</c> discriminator (<c>daily</c>, <c>weekly</c>, <c>monthly</c>, <c>yearly</c>).
-///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition" />
+/// Discriminated union over the four repetition schedules Bexio accepts on an
+/// <see cref="OrderRepetition" /> payload — <see cref="OrderRepetitionDaily" />,
+/// <see cref="OrderRepetitionWeekly" />, <see cref="OrderRepetitionMonthly" /> and
+/// <see cref="OrderRepetitionYearly" />. The concrete subtype is selected from the
+/// <c>type</c> discriminator (<c>daily</c>, <c>weekly</c>, <c>monthly</c>, <c>yearly</c>).
+/// <see href="https://docs.bexio.com/#tag/Orders/operation/v2ShowOrderRepetition" />
 /// </summary>
 [JsonConverter(typeof(OrderRepetitionScheduleJsonConverter))]
 public abstract record OrderRepetitionSchedule
 {
     /// <summary>
-    ///     Discriminator string identifying the concrete schedule (<c>daily</c>, <c>weekly</c>,
-    ///     <c>monthly</c> or <c>yearly</c>).
+    /// Discriminator string identifying the concrete schedule (<c>daily</c>, <c>weekly</c>,
+    /// <c>monthly</c> or <c>yearly</c>).
     /// </summary>
     [JsonPropertyName("type")]
     public abstract string Type { get; }
 
     /// <summary>
-    ///     Multiplier applied to the schedule's natural period (e.g. <c>interval = 2</c> on a
-    ///     weekly schedule means "every other week").
+    /// Multiplier applied to the schedule's natural period (e.g. <c>interval = 2</c> on a
+    /// weekly schedule means "every other week").
     /// </summary>
     [JsonPropertyName("interval")]
     public int Interval { get; init; }

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionTypes.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionTypes.cs
@@ -23,19 +23,23 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BexioApiNet.Abstractions.Models.Sales.Positions;
-
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     String literals for the Bexio <c>type</c> discriminator that identifies each concrete
+///     <see cref="OrderRepetitionSchedule" /> variant on the wire.
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+internal static class OrderRepetitionTypes
+{
+    /// <summary>Discriminator for <see cref="OrderRepetitionDaily" />.</summary>
+    public const string Daily = "daily";
+
+    /// <summary>Discriminator for <see cref="OrderRepetitionWeekly" />.</summary>
+    public const string Weekly = "weekly";
+
+    /// <summary>Discriminator for <see cref="OrderRepetitionMonthly" />.</summary>
+    public const string Monthly = "monthly";
+
+    /// <summary>Discriminator for <see cref="OrderRepetitionYearly" />.</summary>
+    public const string Yearly = "yearly";
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionTypes.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionTypes.cs
@@ -26,8 +26,8 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     String literals for the Bexio <c>type</c> discriminator that identifies each concrete
-///     <see cref="OrderRepetitionSchedule" /> variant on the wire.
+/// String literals for the Bexio <c>type</c> discriminator that identifies each concrete
+/// <see cref="OrderRepetitionSchedule" /> variant on the wire.
 /// </summary>
 internal static class OrderRepetitionTypes
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionWeekly.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionWeekly.cs
@@ -26,9 +26,9 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Weekly repetition schedule — fires on the listed <see cref="Weekdays" /> every
-///     <see cref="OrderRepetitionSchedule.Interval" /> weeks. Corresponds to the Bexio
-///     <c>OrderRepetitionWeekly</c> schema (<c>type = "weekly"</c>).
+/// Weekly repetition schedule — fires on the listed <see cref="Weekdays" /> every
+/// <see cref="OrderRepetitionSchedule.Interval" /> weeks. Corresponds to the Bexio
+/// <c>OrderRepetitionWeekly</c> schema (<c>type = "weekly"</c>).
 /// </summary>
 public sealed record OrderRepetitionWeekly : OrderRepetitionSchedule
 {
@@ -36,8 +36,8 @@ public sealed record OrderRepetitionWeekly : OrderRepetitionSchedule
     public override string Type => OrderRepetitionTypes.Weekly;
 
     /// <summary>
-    ///     Weekdays on which the schedule fires. Each entry is a lowercase English day name
-    ///     (<c>monday</c>, <c>tuesday</c>, …, <c>sunday</c>) as accepted by the Bexio API.
+    /// Weekdays on which the schedule fires. Each entry is a lowercase English day name
+    /// (<c>monday</c>, <c>tuesday</c>, …, <c>sunday</c>) as accepted by the Bexio API.
     /// </summary>
     [JsonPropertyName("weekdays")]
     public IReadOnlyList<string> Weekdays { get; init; } = [];

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionWeekly.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionWeekly.cs
@@ -23,19 +23,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BexioApiNet.Abstractions.Models.Sales.Positions;
-
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     Weekly repetition schedule — fires on the listed <see cref="Weekdays" /> every
+///     <see cref="OrderRepetitionSchedule.Interval" /> weeks. Corresponds to the Bexio
+///     <c>OrderRepetitionWeekly</c> schema (<c>type = "weekly"</c>).
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+public sealed record OrderRepetitionWeekly : OrderRepetitionSchedule
+{
+    /// <inheritdoc />
+    public override string Type => OrderRepetitionTypes.Weekly;
+
+    /// <summary>
+    ///     Weekdays on which the schedule fires. Each entry is a lowercase English day name
+    ///     (<c>monday</c>, <c>tuesday</c>, …, <c>sunday</c>) as accepted by the Bexio API.
+    /// </summary>
+    [JsonPropertyName("weekdays")]
+    public IReadOnlyList<string> Weekdays { get; init; } = [];
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionYearly.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionYearly.cs
@@ -23,19 +23,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BexioApiNet.Abstractions.Models.Sales.Positions;
-
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     Yearly repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" />
+///     years. Corresponds to the Bexio <c>OrderRepetitionYearly</c> schema (<c>type = "yearly"</c>).
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+public sealed record OrderRepetitionYearly : OrderRepetitionSchedule
+{
+    /// <inheritdoc />
+    public override string Type => OrderRepetitionTypes.Yearly;
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionYearly.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderRepetitionYearly.cs
@@ -26,8 +26,8 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Yearly repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" />
-///     years. Corresponds to the Bexio <c>OrderRepetitionYearly</c> schema (<c>type = "yearly"</c>).
+/// Yearly repetition schedule — fires every <see cref="OrderRepetitionSchedule.Interval" />
+/// years. Corresponds to the Bexio <c>OrderRepetitionYearly</c> schema (<c>type = "yearly"</c>).
 /// </summary>
 public sealed record OrderRepetitionYearly : OrderRepetitionSchedule
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderTax.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/OrderTax.cs
@@ -26,8 +26,8 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders;
 
 /// <summary>
-///     Read-only tax summary line aggregated onto an <see cref="Order" /> by the Bexio API.
-///     Exposed as the items of <see cref="Order.Taxs" />.
+/// Read-only tax summary line aggregated onto an <see cref="Order" /> by the Bexio API.
+/// Exposed as the items of <see cref="Order.Taxs" />.
 /// </summary>
 /// <param name="Percentage">Tax percentage as a formatted decimal string (e.g. <c>"7.70"</c>).</param>
 /// <param name="Value">Amount of tax applied at the given percentage as a formatted decimal string.</param>

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderConvertRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderConvertRequest.cs
@@ -23,20 +23,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
 
 namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 
 /// <summary>
 ///     Body for <c>POST /2.0/kb_order/{order_id}/delivery</c> and <c>POST /2.0/kb_order/{order_id}/invoice</c>.
 ///     When <see cref="Positions" /> is <see langword="null" />, Bexio copies every position from the source
-///     order; otherwise the supplied subset is used. Positions are a polymorphic union of Bexio's
-///     <c>KbPosition*</c> types, so they are accepted as raw <see cref="JsonElement" /> values.
+///     order; otherwise the supplied subset is used. Positions are typed as the polymorphic
+///     <see cref="Position" /> union so callers can build the desired subtype strongly.
 ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateDeliveryFromOrder" />
 ///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateInvoiceFromOrder" />
 /// </summary>
 /// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
 public sealed record OrderConvertRequest(
     [property: JsonPropertyName("positions")]
-    IReadOnlyList<JsonElement>? Positions = null
+    IReadOnlyList<Position>? Positions = null
 );

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderConvertRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderConvertRequest.cs
@@ -28,12 +28,12 @@ using BexioApiNet.Abstractions.Models.Sales.Positions;
 namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 
 /// <summary>
-///     Body for <c>POST /2.0/kb_order/{order_id}/delivery</c> and <c>POST /2.0/kb_order/{order_id}/invoice</c>.
-///     When <see cref="Positions" /> is <see langword="null" />, Bexio copies every position from the source
-///     order; otherwise the supplied subset is used. Positions are typed as the polymorphic
-///     <see cref="Position" /> union so callers can build the desired subtype strongly.
-///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateDeliveryFromOrder" />
-///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateInvoiceFromOrder" />
+/// Body for <c>POST /2.0/kb_order/{order_id}/delivery</c> and <c>POST /2.0/kb_order/{order_id}/invoice</c>.
+/// When <see cref="Positions" /> is <see langword="null" />, Bexio copies every position from the source
+/// order; otherwise the supplied subset is used. Positions are typed as the polymorphic
+/// <see cref="Position" /> union so callers can build the desired subtype strongly.
+/// <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateDeliveryFromOrder" />
+/// <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateInvoiceFromOrder" />
 /// </summary>
 /// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
 public sealed record OrderConvertRequest(

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderCreate.cs
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
 
 namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 
@@ -65,8 +65,8 @@ namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 /// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
 /// <param name="TemplateSlug">References a document template slug.</param>
 /// <param name="Positions">
-///     Polymorphic list of positions to create. Bexio accepts a union of several position types, so
-///     they are accepted as raw <see cref="JsonElement" /> values.
+///     Polymorphic list of positions to create. Pass any mix of <see cref="Position" /> subtypes — the
+///     converter emits the <c>type</c> discriminator expected by Bexio.
 /// </param>
 public sealed record OrderCreate(
     [property: JsonPropertyName("user_id")]
@@ -111,5 +111,5 @@ public sealed record OrderCreate(
     [property: JsonPropertyName("template_slug")]
     string? TemplateSlug = null,
     [property: JsonPropertyName("positions")]
-    IReadOnlyList<JsonElement>? Positions = null
+    IReadOnlyList<Position>? Positions = null
 );

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderCreate.cs
@@ -28,10 +28,10 @@ using BexioApiNet.Abstractions.Models.Sales.Positions;
 namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 
 /// <summary>
-///     Create view for an order — body of <c>POST /2.0/kb_order</c>. Read-only fields (id, totals,
-///     contact_address, delivery_address, kb_item_status_id, is_recurring, updated_at, taxs,
-///     network_link, project_id, viewed_by_client_at) are intentionally omitted.
-///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateOrder" />
+/// Create view for an order — body of <c>POST /2.0/kb_order</c>. Read-only fields (id, totals,
+/// contact_address, delivery_address, kb_item_status_id, is_recurring, updated_at, taxs,
+/// network_link, project_id, viewed_by_client_at) are intentionally omitted.
+/// <see href="https://docs.bexio.com/#tag/Orders/operation/v2CreateOrder" />
 /// </summary>
 /// <param name="UserId">References the user that owns the order.</param>
 /// <param name="DocumentNr">Order number. Must be omitted when automatic numbering is enabled.</param>
@@ -48,25 +48,25 @@ namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 /// <param name="Footer">Free-text footer printed below the positions.</param>
 /// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
 /// <param name="MwstIsNet">
-///     When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
-///     net.
+/// When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
+/// net.
 /// </param>
 /// <param name="ShowPositionTaxes">When <see langword="true" />, per-position taxes are shown on the printed document.</param>
 /// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
 /// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
 /// <param name="DeliveryAddressType">
-///     Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
-///     address.
+/// Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
+/// address.
 /// </param>
 /// <param name="DeliveryAddressManual">
-///     Manually overridden delivery address (write-only, used when
-///     <see cref="DeliveryAddressType" /> is <c>1</c>).
+/// Manually overridden delivery address (write-only, used when
+/// <see cref="DeliveryAddressType" /> is <c>1</c>).
 /// </param>
 /// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
 /// <param name="TemplateSlug">References a document template slug.</param>
 /// <param name="Positions">
-///     Polymorphic list of positions to create. Pass any mix of <see cref="Position" /> subtypes — the
-///     converter emits the <c>type</c> discriminator expected by Bexio.
+/// Polymorphic list of positions to create. Pass any mix of <see cref="Position" /> subtypes — the
+/// converter emits the <c>type</c> discriminator expected by Bexio.
 /// </param>
 public sealed record OrderCreate(
     [property: JsonPropertyName("user_id")]

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderRepetitionCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderRepetitionCreate.cs
@@ -26,22 +26,22 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 
 /// <summary>
-///     Create/edit view for an order repetition — body of <c>POST /2.0/kb_order/{order_id}/repetition</c>.
-///     Bexio exposes the same <c>OrderRepetition</c> schema on the way in and out, and uses the same
-///     endpoint for both creating a fresh repetition and replacing an existing one (there is no
-///     dedicated PUT).
-///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrderRepetition" />
+/// Create/edit view for an order repetition — body of <c>POST /2.0/kb_order/{order_id}/repetition</c>.
+/// Bexio exposes the same <c>OrderRepetition</c> schema on the way in and out, and uses the same
+/// endpoint for both creating a fresh repetition and replacing an existing one (there is no
+/// dedicated PUT).
+/// <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrderRepetition" />
 /// </summary>
 /// <param name="Start">Repetition start date in Bexio's <c>yyyy-MM-dd</c> format.</param>
 /// <param name="Repetition">
-///     Polymorphic repetition descriptor. Pass the concrete <see cref="OrderRepetitionSchedule" /> subtype
-///     (<see cref="OrderRepetitionDaily" />, <see cref="OrderRepetitionWeekly" />,
-///     <see cref="OrderRepetitionMonthly" />, <see cref="OrderRepetitionYearly" />) — the converter emits
-///     the <c>type</c> discriminator expected by Bexio.
+/// Polymorphic repetition descriptor. Pass the concrete <see cref="OrderRepetitionSchedule" /> subtype
+/// (<see cref="OrderRepetitionDaily" />, <see cref="OrderRepetitionWeekly" />,
+/// <see cref="OrderRepetitionMonthly" />, <see cref="OrderRepetitionYearly" />) — the converter emits
+/// the <c>type</c> discriminator expected by Bexio.
 /// </param>
 /// <param name="End">
-///     Optional repetition end date in Bexio's <c>yyyy-MM-dd</c> format. When <see langword="null" /> the
-///     repetition runs indefinitely.
+/// Optional repetition end date in Bexio's <c>yyyy-MM-dd</c> format. When <see langword="null" /> the
+/// repetition runs indefinitely.
 /// </param>
 public sealed record OrderRepetitionCreate(
     [property: JsonPropertyName("start")] string Start,

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderRepetitionCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderRepetitionCreate.cs
@@ -23,8 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
-
 namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 
 /// <summary>
@@ -36,9 +34,10 @@ namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 /// </summary>
 /// <param name="Start">Repetition start date in Bexio's <c>yyyy-MM-dd</c> format.</param>
 /// <param name="Repetition">
-///     Polymorphic repetition descriptor (<c>daily</c>, <c>weekly</c>, <c>monthly</c> or
-///     <c>yearly</c>). Accepted as a raw <see cref="JsonElement" /> so callers can build the appropriate subtype without
-///     the library prescribing a schema.
+///     Polymorphic repetition descriptor. Pass the concrete <see cref="OrderRepetitionSchedule" /> subtype
+///     (<see cref="OrderRepetitionDaily" />, <see cref="OrderRepetitionWeekly" />,
+///     <see cref="OrderRepetitionMonthly" />, <see cref="OrderRepetitionYearly" />) — the converter emits
+///     the <c>type</c> discriminator expected by Bexio.
 /// </param>
 /// <param name="End">
 ///     Optional repetition end date in Bexio's <c>yyyy-MM-dd</c> format. When <see langword="null" /> the
@@ -47,6 +46,6 @@ namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 public sealed record OrderRepetitionCreate(
     [property: JsonPropertyName("start")] string Start,
     [property: JsonPropertyName("repetition")]
-    JsonElement Repetition,
+    OrderRepetitionSchedule Repetition,
     [property: JsonPropertyName("end")] string? End = null
 );

--- a/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Orders/Views/OrderUpdate.cs
@@ -26,13 +26,13 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 
 /// <summary>
-///     Update view for an order — body of <c>POST /2.0/kb_order/{order_id}</c>. Bexio uses
-///     <c>POST</c> (not <c>PUT</c>) for full-replacement edits on this resource. Read-only fields
-///     (id, totals, contact_address, delivery_address, kb_item_status_id, is_recurring, updated_at,
-///     taxs, network_link, project_id, viewed_by_client_at) are intentionally omitted — positions
-///     are managed via the dedicated position sub-resources, so they live only on
-///     <see cref="OrderCreate" />.
-///     <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrder" />
+/// Update view for an order — body of <c>POST /2.0/kb_order/{order_id}</c>. Bexio uses
+/// <c>POST</c> (not <c>PUT</c>) for full-replacement edits on this resource. Read-only fields
+/// (id, totals, contact_address, delivery_address, kb_item_status_id, is_recurring, updated_at,
+/// taxs, network_link, project_id, viewed_by_client_at) are intentionally omitted — positions
+/// are managed via the dedicated position sub-resources, so they live only on
+/// <see cref="OrderCreate" />.
+/// <see href="https://docs.bexio.com/#tag/Orders/operation/v2EditOrder" />
 /// </summary>
 /// <param name="UserId">References the user that owns the order.</param>
 /// <param name="DocumentNr">Order number. Must be omitted when automatic numbering is enabled.</param>
@@ -49,19 +49,19 @@ namespace BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 /// <param name="Footer">Free-text footer printed below the positions.</param>
 /// <param name="MwstType">VAT/MwSt. handling flag: <c>0</c> including taxes, <c>1</c> excluding taxes, <c>2</c> exempt.</param>
 /// <param name="MwstIsNet">
-///     When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
-///     net.
+/// When <see langword="true" /> and <see cref="MwstType" /> is <c>0</c>, totals are interpreted as
+/// net.
 /// </param>
 /// <param name="ShowPositionTaxes">When <see langword="true" />, per-position taxes are shown on the printed document.</param>
 /// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
 /// <param name="ContactAddressManual">Manually overridden contact address (write-only).</param>
 /// <param name="DeliveryAddressType">
-///     Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
-///     address.
+/// Delivery address selector: <c>0</c> use invoice address, <c>1</c> use custom delivery
+/// address.
 /// </param>
 /// <param name="DeliveryAddressManual">
-///     Manually overridden delivery address (write-only, used when
-///     <see cref="DeliveryAddressType" /> is <c>1</c>).
+/// Manually overridden delivery address (write-only, used when
+/// <see cref="DeliveryAddressType" /> is <c>1</c>).
 /// </param>
 /// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
 /// <param name="TemplateSlug">References a document template slug.</param>

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/Position.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/Position.cs
@@ -28,41 +28,41 @@ using BexioApiNet.Abstractions.Json;
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     Discriminated union over Bexio's seven <c>kb_position_*</c> position types exposed on
-///     quotes, orders, invoices and deliveries. The concrete subtype is selected from the
-///     <c>type</c> discriminator emitted by Bexio (<c>KbPositionArticle</c>,
-///     <c>KbPositionCustom</c>, <c>KbPositionText</c>, <c>KbPositionSubposition</c>,
-///     <c>KbPositionSubtotal</c>, <c>KbPositionPagebreak</c>, <c>KbPositionDiscount</c>).
-///     <see href="https://docs.bexio.com/#tag/Item-positions" />
+/// Discriminated union over Bexio's seven <c>kb_position_*</c> position types exposed on
+/// quotes, orders, invoices and deliveries. The concrete subtype is selected from the
+/// <c>type</c> discriminator emitted by Bexio (<c>KbPositionArticle</c>,
+/// <c>KbPositionCustom</c>, <c>KbPositionText</c>, <c>KbPositionSubposition</c>,
+/// <c>KbPositionSubtotal</c>, <c>KbPositionPagebreak</c>, <c>KbPositionDiscount</c>).
+/// <see href="https://docs.bexio.com/#tag/Item-positions" />
 /// </summary>
 /// <remarks>
-///     Consumers should construct one of the sealed subtypes (<see cref="PositionArticle" />,
-///     <see cref="PositionCustom" />, <see cref="PositionText" />, <see cref="PositionSubposition" />,
-///     <see cref="PositionSubtotal" />, <see cref="PositionPagebreak" />,
-///     <see cref="PositionDiscount" />) directly. Serialization is handled by
-///     <see cref="PositionJsonConverter" /> which reads/writes the <c>type</c> discriminator.
+/// Consumers should construct one of the sealed subtypes (<see cref="PositionArticle" />,
+/// <see cref="PositionCustom" />, <see cref="PositionText" />, <see cref="PositionSubposition" />,
+/// <see cref="PositionSubtotal" />, <see cref="PositionPagebreak" />,
+/// <see cref="PositionDiscount" />) directly. Serialization is handled by
+/// <see cref="PositionJsonConverter" /> which reads/writes the <c>type</c> discriminator.
 /// </remarks>
 [JsonConverter(typeof(PositionJsonConverter))]
 public abstract record Position
 {
     /// <summary>
-    ///     Unique position identifier assigned by Bexio (read-only on show responses, ignored when
-    ///     creating a new position).
+    /// Unique position identifier assigned by Bexio (read-only on show responses, ignored when
+    /// creating a new position).
     /// </summary>
     [JsonPropertyName("id")]
     public int? Id { get; init; }
 
     /// <summary>
-    ///     Optional id of a parent <see cref="PositionSubposition" /> used to group positions on
-    ///     the document. <see langword="null" /> for top-level positions.
+    /// Optional id of a parent <see cref="PositionSubposition" /> used to group positions on
+    /// the document. <see langword="null" /> for top-level positions.
     /// </summary>
     [JsonPropertyName("parent_id")]
     public int? ParentId { get; init; }
 
     /// <summary>
-    ///     The literal Bexio discriminator string identifying this concrete position type (for
-    ///     example <c>KbPositionArticle</c>). Each sealed subtype overrides this with the matching
-    ///     constant.
+    /// The literal Bexio discriminator string identifying this concrete position type (for
+    /// example <c>KbPositionArticle</c>). Each sealed subtype overrides this with the matching
+    /// constant.
     /// </summary>
     [JsonPropertyName("type")]
     public abstract string Type { get; }

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/Position.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/Position.cs
@@ -1,0 +1,69 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Json;
+
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
+
+/// <summary>
+///     Discriminated union over Bexio's seven <c>kb_position_*</c> position types exposed on
+///     quotes, orders, invoices and deliveries. The concrete subtype is selected from the
+///     <c>type</c> discriminator emitted by Bexio (<c>KbPositionArticle</c>,
+///     <c>KbPositionCustom</c>, <c>KbPositionText</c>, <c>KbPositionSubposition</c>,
+///     <c>KbPositionSubtotal</c>, <c>KbPositionPagebreak</c>, <c>KbPositionDiscount</c>).
+///     <see href="https://docs.bexio.com/#tag/Item-positions" />
+/// </summary>
+/// <remarks>
+///     Consumers should construct one of the sealed subtypes (<see cref="PositionArticle" />,
+///     <see cref="PositionCustom" />, <see cref="PositionText" />, <see cref="PositionSubposition" />,
+///     <see cref="PositionSubtotal" />, <see cref="PositionPagebreak" />,
+///     <see cref="PositionDiscount" />) directly. Serialization is handled by
+///     <see cref="PositionJsonConverter" /> which reads/writes the <c>type</c> discriminator.
+/// </remarks>
+[JsonConverter(typeof(PositionJsonConverter))]
+public abstract record Position
+{
+    /// <summary>
+    ///     Unique position identifier assigned by Bexio (read-only on show responses, ignored when
+    ///     creating a new position).
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int? Id { get; init; }
+
+    /// <summary>
+    ///     Optional id of a parent <see cref="PositionSubposition" /> used to group positions on
+    ///     the document. <see langword="null" /> for top-level positions.
+    /// </summary>
+    [JsonPropertyName("parent_id")]
+    public int? ParentId { get; init; }
+
+    /// <summary>
+    ///     The literal Bexio discriminator string identifying this concrete position type (for
+    ///     example <c>KbPositionArticle</c>). Each sealed subtype overrides this with the matching
+    ///     constant.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public abstract string Type { get; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionArticle.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionArticle.cs
@@ -26,9 +26,9 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     Article-backed position — a line item referencing an item from the Bexio item catalogue.
-///     Corresponds to the Bexio <c>KbPositionArticle</c> / <c>PositionArticleExtended</c> schema.
-///     <see href="https://docs.bexio.com/#tag/Article-positions" />
+/// Article-backed position — a line item referencing an item from the Bexio item catalogue.
+/// Corresponds to the Bexio <c>KbPositionArticle</c> / <c>PositionArticleExtended</c> schema.
+/// <see href="https://docs.bexio.com/#tag/Article-positions" />
 /// </summary>
 public sealed record PositionArticle : Position
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionArticle.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionArticle.cs
@@ -1,0 +1,105 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
+
+/// <summary>
+///     Article-backed position — a line item referencing an item from the Bexio item catalogue.
+///     Corresponds to the Bexio <c>KbPositionArticle</c> / <c>PositionArticleExtended</c> schema.
+///     <see href="https://docs.bexio.com/#tag/Article-positions" />
+/// </summary>
+public sealed record PositionArticle : Position
+{
+    /// <inheritdoc />
+    public override string Type => PositionTypes.Article;
+
+    /// <summary>Quantity as a formatted decimal string (max. 6 decimals).</summary>
+    [JsonPropertyName("amount")]
+    public string? Amount { get; init; }
+
+    /// <summary>Reserved quantity as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("amount_reserved")]
+    public string? AmountReserved { get; init; }
+
+    /// <summary>Open quantity remaining to deliver/invoice as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("amount_open")]
+    public string? AmountOpen { get; init; }
+
+    /// <summary>Completed quantity as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("amount_completed")]
+    public string? AmountCompleted { get; init; }
+
+    /// <summary>References a unit object.</summary>
+    [JsonPropertyName("unit_id")]
+    public int? UnitId { get; init; }
+
+    /// <summary>References an account object.</summary>
+    [JsonPropertyName("account_id")]
+    public int? AccountId { get; init; }
+
+    /// <summary>Display name of the unit (read-only).</summary>
+    [JsonPropertyName("unit_name")]
+    public string? UnitName { get; init; }
+
+    /// <summary>References a tax object. Only active sales taxes are valid on quotes/orders/invoices.</summary>
+    [JsonPropertyName("tax_id")]
+    public int? TaxId { get; init; }
+
+    /// <summary>Tax percentage value as a formatted string (read-only).</summary>
+    [JsonPropertyName("tax_value")]
+    public string? TaxValue { get; init; }
+
+    /// <summary>Position text / description shown on the printed document.</summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>Price of one unit as a formatted decimal string (max. 6 decimals).</summary>
+    [JsonPropertyName("unit_price")]
+    public string? UnitPrice { get; init; }
+
+    /// <summary>Per-position discount as a formatted decimal string (max. 6 decimals).</summary>
+    [JsonPropertyName("discount_in_percent")]
+    public string? DiscountInPercent { get; init; }
+
+    /// <summary>Line total as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("position_total")]
+    public string? PositionTotal { get; init; }
+
+    /// <summary>Rendered position number on the document (read-only).</summary>
+    [JsonPropertyName("pos")]
+    public string? Pos { get; init; }
+
+    /// <summary>Internal 1-based position ordering (read-only).</summary>
+    [JsonPropertyName("internal_pos")]
+    public int? InternalPos { get; init; }
+
+    /// <summary>When <see langword="true" />, the position is marked as optional on quotes/orders.</summary>
+    [JsonPropertyName("is_optional")]
+    public bool? IsOptional { get; init; }
+
+    /// <summary>References an item object in the Bexio article catalogue.</summary>
+    [JsonPropertyName("article_id")]
+    public int? ArticleId { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionCustom.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionCustom.cs
@@ -1,0 +1,101 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
+
+/// <summary>
+///     Free-form / custom line item not backed by an article.
+///     Corresponds to the Bexio <c>KbPositionCustom</c> / <c>PositionCustomExtended</c> schema.
+///     <see href="https://docs.bexio.com/#tag/Custom-positions" />
+/// </summary>
+public sealed record PositionCustom : Position
+{
+    /// <inheritdoc />
+    public override string Type => PositionTypes.Custom;
+
+    /// <summary>Quantity as a formatted decimal string (max. 6 decimals).</summary>
+    [JsonPropertyName("amount")]
+    public string? Amount { get; init; }
+
+    /// <summary>Reserved quantity as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("amount_reserved")]
+    public string? AmountReserved { get; init; }
+
+    /// <summary>Open quantity remaining to deliver/invoice as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("amount_open")]
+    public string? AmountOpen { get; init; }
+
+    /// <summary>Completed quantity as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("amount_completed")]
+    public string? AmountCompleted { get; init; }
+
+    /// <summary>References a unit object.</summary>
+    [JsonPropertyName("unit_id")]
+    public int? UnitId { get; init; }
+
+    /// <summary>References an account object.</summary>
+    [JsonPropertyName("account_id")]
+    public int? AccountId { get; init; }
+
+    /// <summary>Display name of the unit (read-only).</summary>
+    [JsonPropertyName("unit_name")]
+    public string? UnitName { get; init; }
+
+    /// <summary>References a tax object. Only active sales taxes are valid on quotes/orders/invoices.</summary>
+    [JsonPropertyName("tax_id")]
+    public int? TaxId { get; init; }
+
+    /// <summary>Tax percentage value as a formatted string (read-only).</summary>
+    [JsonPropertyName("tax_value")]
+    public string? TaxValue { get; init; }
+
+    /// <summary>Position text / description shown on the printed document.</summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>Price of one unit as a formatted decimal string (max. 6 decimals).</summary>
+    [JsonPropertyName("unit_price")]
+    public string? UnitPrice { get; init; }
+
+    /// <summary>Per-position discount as a formatted decimal string (max. 6 decimals).</summary>
+    [JsonPropertyName("discount_in_percent")]
+    public string? DiscountInPercent { get; init; }
+
+    /// <summary>Line total as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("position_total")]
+    public string? PositionTotal { get; init; }
+
+    /// <summary>Rendered position number on the document (read-only).</summary>
+    [JsonPropertyName("pos")]
+    public string? Pos { get; init; }
+
+    /// <summary>Internal 1-based position ordering (read-only).</summary>
+    [JsonPropertyName("internal_pos")]
+    public int? InternalPos { get; init; }
+
+    /// <summary>When <see langword="true" />, the position is marked as optional on quotes/orders (read-only).</summary>
+    [JsonPropertyName("is_optional")]
+    public bool? IsOptional { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionCustom.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionCustom.cs
@@ -26,9 +26,9 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     Free-form / custom line item not backed by an article.
-///     Corresponds to the Bexio <c>KbPositionCustom</c> / <c>PositionCustomExtended</c> schema.
-///     <see href="https://docs.bexio.com/#tag/Custom-positions" />
+/// Free-form / custom line item not backed by an article.
+/// Corresponds to the Bexio <c>KbPositionCustom</c> / <c>PositionCustomExtended</c> schema.
+/// <see href="https://docs.bexio.com/#tag/Custom-positions" />
 /// </summary>
 public sealed record PositionCustom : Position
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionDiscount.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionDiscount.cs
@@ -26,11 +26,11 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     Document-level discount position applied after the subtotal, either as a fixed amount or
-///     a percentage of the running total.
-///     Corresponds to the Bexio <c>KbPositionDiscount</c> / <c>PositionDiscountExtended</c> schema.
-///     Unlike other variants, discount positions do not carry a <see cref="Position.ParentId" />.
-///     <see href="https://docs.bexio.com/#tag/Discount-positions" />
+/// Document-level discount position applied after the subtotal, either as a fixed amount or
+/// a percentage of the running total.
+/// Corresponds to the Bexio <c>KbPositionDiscount</c> / <c>PositionDiscountExtended</c> schema.
+/// Unlike other variants, discount positions do not carry a <see cref="Position.ParentId" />.
+/// <see href="https://docs.bexio.com/#tag/Discount-positions" />
 /// </summary>
 public sealed record PositionDiscount : Position
 {
@@ -42,8 +42,8 @@ public sealed record PositionDiscount : Position
     public string? Text { get; init; }
 
     /// <summary>
-    ///     When <see langword="true" />, <see cref="Value" /> is interpreted as a percentage;
-    ///     otherwise as a fixed amount in the document currency.
+    /// When <see langword="true" />, <see cref="Value" /> is interpreted as a percentage;
+    /// otherwise as a fixed amount in the document currency.
     /// </summary>
     [JsonPropertyName("is_percentual")]
     public bool? IsPercentual { get; init; }

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionDiscount.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionDiscount.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
+
+/// <summary>
+///     Document-level discount position applied after the subtotal, either as a fixed amount or
+///     a percentage of the running total.
+///     Corresponds to the Bexio <c>KbPositionDiscount</c> / <c>PositionDiscountExtended</c> schema.
+///     Unlike other variants, discount positions do not carry a <see cref="Position.ParentId" />.
+///     <see href="https://docs.bexio.com/#tag/Discount-positions" />
+/// </summary>
+public sealed record PositionDiscount : Position
+{
+    /// <inheritdoc />
+    public override string Type => PositionTypes.Discount;
+
+    /// <summary>Discount label rendered on the document.</summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>
+    ///     When <see langword="true" />, <see cref="Value" /> is interpreted as a percentage;
+    ///     otherwise as a fixed amount in the document currency.
+    /// </summary>
+    [JsonPropertyName("is_percentual")]
+    public bool? IsPercentual { get; init; }
+
+    /// <summary>Discount amount as a formatted decimal string (max. 6 decimals).</summary>
+    [JsonPropertyName("value")]
+    public string? Value { get; init; }
+
+    /// <summary>Effective discount total as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("discount_total")]
+    public string? DiscountTotal { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionPagebreak.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionPagebreak.cs
@@ -26,10 +26,10 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     Page-break position that forces a hard page break at its location on the printed document.
-///     Corresponds to the Bexio <c>KbPositionPagebreak</c> / <c>PositionPagebreakExtended</c>
-///     schema.
-///     <see href="https://docs.bexio.com/#tag/Pagebreak-positions" />
+/// Page-break position that forces a hard page break at its location on the printed document.
+/// Corresponds to the Bexio <c>KbPositionPagebreak</c> / <c>PositionPagebreakExtended</c>
+/// schema.
+/// <see href="https://docs.bexio.com/#tag/Pagebreak-positions" />
 /// </summary>
 public sealed record PositionPagebreak : Position
 {
@@ -45,8 +45,8 @@ public sealed record PositionPagebreak : Position
     public bool? IsOptional { get; init; }
 
     /// <summary>
-    ///     Must be <see langword="true" /> on create to actually insert a pagebreak (write-only flag
-    ///     echoed back by the spec).
+    /// Must be <see langword="true" /> on create to actually insert a pagebreak (write-only flag
+    /// echoed back by the spec).
     /// </summary>
     [JsonPropertyName("pagebreak")]
     public bool? Pagebreak { get; init; }

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionPagebreak.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionPagebreak.cs
@@ -23,19 +23,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BexioApiNet.Abstractions.Models.Sales.Positions;
-
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     Page-break position that forces a hard page break at its location on the printed document.
+///     Corresponds to the Bexio <c>KbPositionPagebreak</c> / <c>PositionPagebreakExtended</c>
+///     schema.
+///     <see href="https://docs.bexio.com/#tag/Pagebreak-positions" />
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+public sealed record PositionPagebreak : Position
+{
+    /// <inheritdoc />
+    public override string Type => PositionTypes.Pagebreak;
+
+    /// <summary>Internal 1-based position ordering (read-only).</summary>
+    [JsonPropertyName("internal_pos")]
+    public int? InternalPos { get; init; }
+
+    /// <summary>When <see langword="true" />, the position is marked as optional on quotes/orders (read-only).</summary>
+    [JsonPropertyName("is_optional")]
+    public bool? IsOptional { get; init; }
+
+    /// <summary>
+    ///     Must be <see langword="true" /> on create to actually insert a pagebreak (write-only flag
+    ///     echoed back by the spec).
+    /// </summary>
+    [JsonPropertyName("pagebreak")]
+    public bool? Pagebreak { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionSubposition.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionSubposition.cs
@@ -26,11 +26,11 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     Container / heading position used to group other positions underneath a shared label and
-///     a running subtotal. Other positions point to it via their <see cref="Position.ParentId" />.
-///     Corresponds to the Bexio <c>KbPositionSubposition</c> / <c>PositionSubpositionExtended</c>
-///     schema. Sub-positions are only valid on quotes, orders and invoices — not deliveries.
-///     <see href="https://docs.bexio.com/#tag/Sub-positions" />
+/// Container / heading position used to group other positions underneath a shared label and
+/// a running subtotal. Other positions point to it via their <see cref="Position.ParentId" />.
+/// Corresponds to the Bexio <c>KbPositionSubposition</c> / <c>PositionSubpositionExtended</c>
+/// schema. Sub-positions are only valid on quotes, orders and invoices — not deliveries.
+/// <see href="https://docs.bexio.com/#tag/Sub-positions" />
 /// </summary>
 public sealed record PositionSubposition : Position
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionSubposition.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionSubposition.cs
@@ -1,0 +1,67 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
+
+/// <summary>
+///     Container / heading position used to group other positions underneath a shared label and
+///     a running subtotal. Other positions point to it via their <see cref="Position.ParentId" />.
+///     Corresponds to the Bexio <c>KbPositionSubposition</c> / <c>PositionSubpositionExtended</c>
+///     schema. Sub-positions are only valid on quotes, orders and invoices — not deliveries.
+///     <see href="https://docs.bexio.com/#tag/Sub-positions" />
+/// </summary>
+public sealed record PositionSubposition : Position
+{
+    /// <inheritdoc />
+    public override string Type => PositionTypes.Subposition;
+
+    /// <summary>Heading text rendered above the grouped positions.</summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>Rendered position number on the document (read-only).</summary>
+    [JsonPropertyName("pos")]
+    public string? Pos { get; init; }
+
+    /// <summary>Internal 1-based position ordering (read-only).</summary>
+    [JsonPropertyName("internal_pos")]
+    public int? InternalPos { get; init; }
+
+    /// <summary>When <see langword="true" />, the group's running position number is rendered.</summary>
+    [JsonPropertyName("show_pos_nr")]
+    public bool? ShowPosNr { get; init; }
+
+    /// <summary>When <see langword="true" />, the group is marked as optional on quotes/orders (read-only).</summary>
+    [JsonPropertyName("is_optional")]
+    public bool? IsOptional { get; init; }
+
+    /// <summary>Aggregated total of all child positions as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("total_sum")]
+    public string? TotalSum { get; init; }
+
+    /// <summary>When <see langword="true" />, individual child prices are rendered (read-only).</summary>
+    [JsonPropertyName("show_pos_prices")]
+    public bool? ShowPosPrices { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionSubtotal.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionSubtotal.cs
@@ -23,19 +23,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using BexioApiNet.Abstractions.Models.Sales.Positions;
-
-namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-/// Body for <c>POST /2.0/kb_offer/{quote_id}/invoice</c> and <c>POST /2.0/kb_offer/{quote_id}/order</c>.
-/// When <see cref="Positions"/> is <see langword="null"/>, Bexio copies every position from the source
-/// quote; otherwise the supplied subset is used. Positions are typed as the polymorphic
-/// <see cref="Position"/> union so callers can build the desired subtype strongly.
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateInvoiceFromQuote"/>
-/// <see href="https://docs.bexio.com/#tag/Quotes/operation/v2CreateOrderFromQuote"/>
+///     Subtotal position that prints a running total of preceding positions and a free-text label.
+///     Corresponds to the Bexio <c>KbPositionSubtotal</c> / <c>PositionSubtotalExtended</c> schema.
+///     <see href="https://docs.bexio.com/#tag/Subtotal-positions" />
 /// </summary>
-/// <param name="Positions">Optional subset of positions to carry over to the new document. Omit to copy all.</param>
-public sealed record QuoteConvertRequest(
-    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
-);
+public sealed record PositionSubtotal : Position
+{
+    /// <inheritdoc />
+    public override string Type => PositionTypes.Subtotal;
+
+    /// <summary>Subtotal label rendered on the document.</summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>Running total up to this subtotal line as a formatted decimal string (read-only).</summary>
+    [JsonPropertyName("value")]
+    public string? Value { get; init; }
+
+    /// <summary>Internal 1-based position ordering (read-only).</summary>
+    [JsonPropertyName("internal_pos")]
+    public int? InternalPos { get; init; }
+
+    /// <summary>When <see langword="true" />, the position is marked as optional on quotes/orders (read-only).</summary>
+    [JsonPropertyName("is_optional")]
+    public bool? IsOptional { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionSubtotal.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionSubtotal.cs
@@ -26,9 +26,9 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     Subtotal position that prints a running total of preceding positions and a free-text label.
-///     Corresponds to the Bexio <c>KbPositionSubtotal</c> / <c>PositionSubtotalExtended</c> schema.
-///     <see href="https://docs.bexio.com/#tag/Subtotal-positions" />
+/// Subtotal position that prints a running total of preceding positions and a free-text label.
+/// Corresponds to the Bexio <c>KbPositionSubtotal</c> / <c>PositionSubtotalExtended</c> schema.
+/// <see href="https://docs.bexio.com/#tag/Subtotal-positions" />
 /// </summary>
 public sealed record PositionSubtotal : Position
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionText.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionText.cs
@@ -26,10 +26,10 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     Free-text position used to inject a paragraph of text into a document without any
-///     pricing or quantity. Corresponds to the Bexio <c>KbPositionText</c> /
-///     <c>PositionTextExtended</c> schema.
-///     <see href="https://docs.bexio.com/#tag/Text-positions" />
+/// Free-text position used to inject a paragraph of text into a document without any
+/// pricing or quantity. Corresponds to the Bexio <c>KbPositionText</c> /
+/// <c>PositionTextExtended</c> schema.
+/// <see href="https://docs.bexio.com/#tag/Text-positions" />
 /// </summary>
 public sealed record PositionText : Position
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionText.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionText.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
+
+/// <summary>
+///     Free-text position used to inject a paragraph of text into a document without any
+///     pricing or quantity. Corresponds to the Bexio <c>KbPositionText</c> /
+///     <c>PositionTextExtended</c> schema.
+///     <see href="https://docs.bexio.com/#tag/Text-positions" />
+/// </summary>
+public sealed record PositionText : Position
+{
+    /// <inheritdoc />
+    public override string Type => PositionTypes.Text;
+
+    /// <summary>Free text rendered on the printed document.</summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>When <see langword="true" />, the automatic position number is rendered next to the text.</summary>
+    [JsonPropertyName("show_pos_nr")]
+    public bool? ShowPosNr { get; init; }
+
+    /// <summary>Rendered position number on the document (read-only).</summary>
+    [JsonPropertyName("pos")]
+    public string? Pos { get; init; }
+
+    /// <summary>Internal 1-based position ordering (read-only).</summary>
+    [JsonPropertyName("internal_pos")]
+    public int? InternalPos { get; init; }
+
+    /// <summary>When <see langword="true" />, the position is marked as optional on quotes/orders (read-only).</summary>
+    [JsonPropertyName("is_optional")]
+    public bool? IsOptional { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionTypes.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionTypes.cs
@@ -26,9 +26,9 @@ SOFTWARE.
 namespace BexioApiNet.Abstractions.Models.Sales.Positions;
 
 /// <summary>
-///     String literals for the Bexio <c>type</c> discriminator that identifies each concrete
-///     <see cref="Position" /> variant on the wire. Kept in one place so the converter and each
-///     concrete record share a single source of truth.
+/// String literals for the Bexio <c>type</c> discriminator that identifies each concrete
+/// <see cref="Position" /> variant on the wire. Kept in one place so the converter and each
+/// concrete record share a single source of truth.
 /// </summary>
 internal static class PositionTypes
 {

--- a/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionTypes.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Positions/PositionTypes.cs
@@ -1,0 +1,55 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Sales.Positions;
+
+/// <summary>
+///     String literals for the Bexio <c>type</c> discriminator that identifies each concrete
+///     <see cref="Position" /> variant on the wire. Kept in one place so the converter and each
+///     concrete record share a single source of truth.
+/// </summary>
+internal static class PositionTypes
+{
+    /// <summary>Discriminator for <see cref="PositionArticle" />.</summary>
+    public const string Article = "KbPositionArticle";
+
+    /// <summary>Discriminator for <see cref="PositionCustom" />.</summary>
+    public const string Custom = "KbPositionCustom";
+
+    /// <summary>Discriminator for <see cref="PositionText" />.</summary>
+    public const string Text = "KbPositionText";
+
+    /// <summary>Discriminator for <see cref="PositionSubposition" />.</summary>
+    public const string Subposition = "KbPositionSubposition";
+
+    /// <summary>Discriminator for <see cref="PositionSubtotal" />.</summary>
+    public const string Subtotal = "KbPositionSubtotal";
+
+    /// <summary>Discriminator for <see cref="PositionPagebreak" />.</summary>
+    public const string Pagebreak = "KbPositionPagebreak";
+
+    /// <summary>Discriminator for <see cref="PositionDiscount" />.</summary>
+    public const string Discount = "KbPositionDiscount";
+}

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Quote.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Quote.cs
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
 
 namespace BexioApiNet.Abstractions.Models.Sales.Quotes;
 
@@ -72,7 +72,7 @@ namespace BexioApiNet.Abstractions.Models.Sales.Quotes;
 /// <param name="TemplateSlug">References a document template slug.</param>
 /// <param name="Taxs">Read-only aggregated tax summary lines.</param>
 /// <param name="NetworkLink">Read-only network link used by the Bexio document viewer.</param>
-/// <param name="Positions">Optional polymorphic positions array populated on show/create/update responses. Kept as raw <see cref="JsonElement"/> values since Bexio returns a union of several position types.</param>
+/// <param name="Positions">Optional polymorphic positions array populated on show/create/update responses. Each element is deserialized into the concrete <see cref="Position"/> subtype identified by its <c>type</c> discriminator.</param>
 public sealed record Quote(
     [property: JsonPropertyName("id")] int Id,
     [property: JsonPropertyName("document_nr")] string? DocumentNr,
@@ -113,5 +113,5 @@ public sealed record Quote(
     [property: JsonPropertyName("template_slug")] string? TemplateSlug,
     [property: JsonPropertyName("taxs")] IReadOnlyList<QuoteTax>? Taxs,
     [property: JsonPropertyName("network_link")] string? NetworkLink,
-    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions
+    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions
 );

--- a/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Sales/Quotes/Views/QuoteCreate.cs
@@ -23,7 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
 
 namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
 
@@ -57,7 +57,7 @@ namespace BexioApiNet.Abstractions.Models.Sales.Quotes.Views;
 /// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
 /// <param name="KbTermsOfPaymentTemplateId">Optional reference to a terms-of-payment template.</param>
 /// <param name="TemplateSlug">References a document template slug.</param>
-/// <param name="Positions">Polymorphic list of positions to create. Bexio accepts a union of several position types, so they are accepted as raw <see cref="JsonElement"/> values.</param>
+/// <param name="Positions">Polymorphic list of positions to create. Pass any mix of <see cref="Position"/> subtypes — the converter emits the <c>type</c> discriminator expected by Bexio.</param>
 public sealed record QuoteCreate(
     [property: JsonPropertyName("user_id")] int UserId,
     [property: JsonPropertyName("document_nr")] string? DocumentNr = null,
@@ -83,5 +83,5 @@ public sealed record QuoteCreate(
     [property: JsonPropertyName("api_reference")] string? ApiReference = null,
     [property: JsonPropertyName("kb_terms_of_payment_template_id")] int? KbTermsOfPaymentTemplateId = null,
     [property: JsonPropertyName("template_slug")] string? TemplateSlug = null,
-    [property: JsonPropertyName("positions")] IReadOnlyList<JsonElement>? Positions = null
+    [property: JsonPropertyName("positions")] IReadOnlyList<Position>? Positions = null
 );

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/IBusinessYearService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/IBusinessYearService.cs
@@ -31,14 +31,14 @@ using BexioApiNet.Models;
 namespace BexioApiNet.Interfaces.Connectors.Accounting;
 
 /// <summary>
-///     Service for getting business year entries in accounting namespace.
-///     <see href="https://docs.bexio.com/#tag/Business-Years">Business Years</see>
+/// Service for getting business year entries in accounting namespace.
+/// <see href="https://docs.bexio.com/#tag/Business-Years">Business Years</see>
 /// </summary>
 public interface IBusinessYearService
 {
     /// <summary>
-    ///     Get a list of business years.
-    ///     <see href="https://docs.bexio.com/#tag/Business-Years/operation/ListBusinessYears">List Business Years</see>
+    /// Get a list of business years.
+    /// <see href="https://docs.bexio.com/#tag/Business-Years/operation/ListBusinessYears">List Business Years</see>
     /// </summary>
     /// <param name="queryParameterBusinessYear">Query parameter specific for business years</param>
     /// <param name="autoPage">Fetch all possible results</param>
@@ -48,8 +48,8 @@ public interface IBusinessYearService
         [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Get a single business year by id.
-    ///     <see href="https://docs.bexio.com/#tag/Business-Years/operation/ShowBusinessYear">Show Business Year</see>
+    /// Get a single business year by id.
+    /// <see href="https://docs.bexio.com/#tag/Business-Years/operation/ShowBusinessYear">Show Business Year</see>
     /// </summary>
     /// <param name="id">The id of the business year</param>
     /// <param name="cancellationToken">Cancellation token</param>

--- a/src/BexioApiNet/Interfaces/Connectors/Accounting/ICurrencyService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Accounting/ICurrencyService.cs
@@ -32,14 +32,14 @@ using BexioApiNet.Models;
 namespace BexioApiNet.Interfaces.Connectors.Accounting;
 
 /// <summary>
-///     Service for managing currency entries in the accounting namespace.
-///     <see href="https://docs.bexio.com/#tag/Currencies">Currencies</see>
+/// Service for managing currency entries in the accounting namespace.
+/// <see href="https://docs.bexio.com/#tag/Currencies">Currencies</see>
 /// </summary>
 public interface ICurrencyService
 {
     /// <summary>
-    ///     Get a list of currencies.
-    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ListCurrencies">List Currencies</see>
+    /// Get a list of currencies.
+    /// <see href="https://docs.bexio.com/#tag/Currencies/operation/ListCurrencies">List Currencies</see>
     /// </summary>
     /// <param name="queryParameterCurrency">Query parameter specific for currencies</param>
     /// <param name="autoPage">Fetch all possible results</param>
@@ -49,16 +49,16 @@ public interface ICurrencyService
         [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Fetch all possible currency codes (in the format CHF, EUR, etc.).
-    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ListCurrenciesCodes">List Currencies Codes</see>
+    /// Fetch all possible currency codes (in the format CHF, EUR, etc.).
+    /// <see href="https://docs.bexio.com/#tag/Currencies/operation/ListCurrenciesCodes">List Currencies Codes</see>
     /// </summary>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
     public Task<ApiResult<List<string>>> GetCodes([Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Fetch a single currency by id.
-    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ShowCurrency">Show Currency</see>
+    /// Fetch a single currency by id.
+    /// <see href="https://docs.bexio.com/#tag/Currencies/operation/ShowCurrency">Show Currency</see>
     /// </summary>
     /// <param name="id">The id of the currency</param>
     /// <param name="cancellationToken">Cancellation token</param>
@@ -66,11 +66,11 @@ public interface ICurrencyService
     public Task<ApiResult<Currency>> GetById(int id, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Fetch all configured exchange rates for a given currency.
-    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/ListExchangeRatesForCurrency">
-    ///         List Exchange Rates For
-    ///         Currency
-    ///     </see>
+    /// Fetch all configured exchange rates for a given currency.
+    /// <see href="https://docs.bexio.com/#tag/Currencies/operation/ListExchangeRatesForCurrency">
+    /// List Exchange Rates For
+    /// Currency
+    /// </see>
     /// </summary>
     /// <param name="id">The id of the currency</param>
     /// <param name="queryParameterExchangeRate">Optional query parameter (date filter)</param>
@@ -81,8 +81,8 @@ public interface ICurrencyService
         [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Create a new currency.
-    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/CreateCurrency">Create Currency</see>
+    /// Create a new currency.
+    /// <see href="https://docs.bexio.com/#tag/Currencies/operation/CreateCurrency">Create Currency</see>
     /// </summary>
     /// <param name="currency">Create view describing the new currency</param>
     /// <param name="cancellationToken">Cancellation token</param>
@@ -90,8 +90,8 @@ public interface ICurrencyService
     public Task<ApiResult<Currency>> Create(CurrencyCreate currency, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Partially update an existing currency.
-    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/UpdateCurrency">Update Currency</see>
+    /// Partially update an existing currency.
+    /// <see href="https://docs.bexio.com/#tag/Currencies/operation/UpdateCurrency">Update Currency</see>
     /// </summary>
     /// <param name="id">The id of the currency to update</param>
     /// <param name="currency">Patch view describing the fields to update</param>
@@ -101,8 +101,8 @@ public interface ICurrencyService
         [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Permanently delete a currency by id. This cannot be undone.
-    ///     <see href="https://docs.bexio.com/#tag/Currencies/operation/DeleteCurrency">Delete Currency</see>
+    /// Permanently delete a currency by id. This cannot be undone.
+    /// <see href="https://docs.bexio.com/#tag/Currencies/operation/DeleteCurrency">Delete Currency</see>
     /// </summary>
     /// <param name="id">The id of the currency to delete</param>
     /// <param name="cancellationToken">Cancellation token</param>

--- a/src/BexioApiNet/Interfaces/Connectors/Banking/IPaymentTypeService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Banking/IPaymentTypeService.cs
@@ -31,13 +31,13 @@ using BexioApiNet.Models;
 namespace BexioApiNet.Interfaces.Connectors.Banking;
 
 /// <summary>
-///     Service for accessing payment types. <see href="https://docs.bexio.com/#tag/Payment-Types">Payment Types</see>
+/// Service for accessing payment types. <see href="https://docs.bexio.com/#tag/Payment-Types">Payment Types</see>
 /// </summary>
 public interface IPaymentTypeService
 {
     /// <summary>
-    ///     Get a list of payment types.
-    ///     <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2ListPaymentTypes">List Payment Types</see>
+    /// Get a list of payment types.
+    /// <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2ListPaymentTypes">List Payment Types</see>
     /// </summary>
     /// <param name="queryParameterPaymentType">Query parameter specific for payment types</param>
     /// <param name="autoPage">Fetch all possible results</param>
@@ -47,8 +47,8 @@ public interface IPaymentTypeService
         [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Search payment types.
-    ///     <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2SearchPaymentTypes">Search Payment Types</see>
+    /// Search payment types.
+    /// <see href="https://docs.bexio.com/#tag/Payment-Types/operation/v2SearchPaymentTypes">Search Payment Types</see>
     /// </summary>
     /// <param name="searchCriteria">The search criteria sent as JSON array body. Supported field: <c>name</c>.</param>
     /// <param name="queryParameterPaymentType">Optional query parameter specific for payment types</param>

--- a/src/BexioApiNet/Interfaces/Connectors/Sales/IDeliveryService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Sales/IDeliveryService.cs
@@ -31,18 +31,18 @@ using BexioApiNet.Models;
 namespace BexioApiNet.Interfaces.Connectors.Sales;
 
 /// <summary>
-///     Service for the Bexio delivery endpoints. <see href="https://docs.bexio.com/#tag/Deliveries">Deliveries</see>
+/// Service for the Bexio delivery endpoints. <see href="https://docs.bexio.com/#tag/Deliveries">Deliveries</see>
 /// </summary>
 public interface IDeliveryService
 {
     /// <summary>
-    ///     List all deliveries.
-    ///     <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ListDeliveries">List Deliveries</see>
+    /// List all deliveries.
+    /// <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ListDeliveries">List Deliveries</see>
     /// </summary>
     /// <param name="queryParameterDelivery">Optional query parameters (limit/offset/order_by).</param>
     /// <param name="autoPage">
-    ///     When <see langword="true" />, transparently pages through all remaining results via
-    ///     <c>X-Total-Count</c>.
+    /// When <see langword="true" />, transparently pages through all remaining results via
+    /// <c>X-Total-Count</c>.
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An <see cref="ApiResult{T}" /> with the full page (or all pages) of deliveries.</returns>
@@ -50,8 +50,8 @@ public interface IDeliveryService
         [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Fetch a single delivery by id.
-    ///     <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ShowDelivery">Show Delivery</see>
+    /// Fetch a single delivery by id.
+    /// <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2ShowDelivery">Show Delivery</see>
     /// </summary>
     /// <param name="id">The delivery id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -59,8 +59,8 @@ public interface IDeliveryService
     public Task<ApiResult<Delivery>> GetById(int id, [Optional] CancellationToken cancellationToken);
 
     /// <summary>
-    ///     Issue a delivery. The delivery must be in the draft status.
-    ///     <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2IssueDelivery">Issue Delivery</see>
+    /// Issue a delivery. The delivery must be in the draft status.
+    /// <see href="https://docs.bexio.com/#tag/Deliveries/operation/v2IssueDelivery">Issue Delivery</see>
     /// </summary>
     /// <param name="id">The delivery id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/BexioApiNet/Models/QueryParameterBusinessYear.cs
+++ b/src/BexioApiNet/Models/QueryParameterBusinessYear.cs
@@ -26,7 +26,7 @@ SOFTWARE.
 namespace BexioApiNet.Models;
 
 /// <summary>
-///     Dictionary for optional query parameters
+/// Dictionary for optional query parameters
 /// </summary>
 public sealed record QueryParameterBusinessYear(
     int Limit,

--- a/src/BexioApiNet/Models/QueryParameterDelivery.cs
+++ b/src/BexioApiNet/Models/QueryParameterDelivery.cs
@@ -26,16 +26,16 @@ SOFTWARE.
 namespace BexioApiNet.Models;
 
 /// <summary>
-///     Typed query parameter wrapper for the Bexio delivery list endpoint
-///     (<c>GET /2.0/kb_delivery</c>). Each constructor argument is optional so callers can supply
-///     only the parameters they need; <see langword="null" /> values are skipped and not
-///     serialized onto the URL.
+/// Typed query parameter wrapper for the Bexio delivery list endpoint
+/// (<c>GET /2.0/kb_delivery</c>). Each constructor argument is optional so callers can supply
+/// only the parameters they need; <see langword="null" /> values are skipped and not
+/// serialized onto the URL.
 /// </summary>
 /// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
 /// <param name="Offset">Number of results to skip for pagination.</param>
 /// <param name="OrderBy">
-///     Sort clause — one of <c>id</c>, <c>total</c>, <c>total_net</c>, <c>total_gross</c>,
-///     <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.
+/// Sort clause — one of <c>id</c>, <c>total</c>, <c>total_net</c>, <c>total_gross</c>,
+/// <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.
 /// </param>
 public sealed record QueryParameterDelivery(
     int? Limit = null,
@@ -44,8 +44,8 @@ public sealed record QueryParameterDelivery(
 )
 {
     /// <summary>
-    ///     The underlying <see cref="Models.QueryParameter" /> passed to <see cref="Interfaces.IBexioConnectionHandler" />.
-    ///     <see langword="null" /> when every input is <see langword="null" /> so the handler appends no query string.
+    /// The underlying <see cref="Models.QueryParameter" /> passed to <see cref="Interfaces.IBexioConnectionHandler" />.
+    /// <see langword="null" /> when every input is <see langword="null" /> so the handler appends no query string.
     /// </summary>
     public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy);
 

--- a/src/BexioApiNet/Models/QueryParameterExchangeRate.cs
+++ b/src/BexioApiNet/Models/QueryParameterExchangeRate.cs
@@ -26,7 +26,7 @@ SOFTWARE.
 namespace BexioApiNet.Models;
 
 /// <summary>
-///     Optional query parameters for the <c>3.0/currencies/{id}/exchange_rates</c> endpoint.
+/// Optional query parameters for the <c>3.0/currencies/{id}/exchange_rates</c> endpoint.
 /// </summary>
 /// <param name="Date">The validity date of the exchange rate to fetch (formatted as <c>yyyy-MM-dd</c>).</param>
 public sealed record QueryParameterExchangeRate(
@@ -34,8 +34,8 @@ public sealed record QueryParameterExchangeRate(
 )
 {
     /// <summary>
-    ///     The wrapped <see cref="QueryParameter" /> built from the supplied options. Returns <see langword="null" /> when no
-    ///     optional value was provided so the connection handler can skip query string composition entirely.
+    /// The wrapped <see cref="QueryParameter" /> built from the supplied options. Returns <see langword="null" /> when no
+    /// optional value was provided so the connection handler can skip query string composition entirely.
     /// </summary>
     public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Date);
 

--- a/src/BexioApiNet/Models/QueryParameterOrder.cs
+++ b/src/BexioApiNet/Models/QueryParameterOrder.cs
@@ -26,16 +26,16 @@ SOFTWARE.
 namespace BexioApiNet.Models;
 
 /// <summary>
-///     Typed query parameter wrapper for the Bexio order endpoints
-///     (<c>GET /2.0/kb_order</c>, <c>GET /2.0/kb_order/{id}</c> and <c>POST /2.0/kb_order/search</c>).
-///     Each constructor argument is optional so callers can supply only the parameters they need;
-///     <see langword="null" /> values are skipped and not serialized onto the URL.
+/// Typed query parameter wrapper for the Bexio order endpoints
+/// (<c>GET /2.0/kb_order</c>, <c>GET /2.0/kb_order/{id}</c> and <c>POST /2.0/kb_order/search</c>).
+/// Each constructor argument is optional so callers can supply only the parameters they need;
+/// <see langword="null" /> values are skipped and not serialized onto the URL.
 /// </summary>
 /// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
 /// <param name="Offset">Number of results to skip for pagination.</param>
 /// <param name="OrderBy">
-///     Sort clause — one of <c>id</c>, <c>total</c>, <c>total_net</c>, <c>total_gross</c>,
-///     <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.
+/// Sort clause — one of <c>id</c>, <c>total</c>, <c>total_net</c>, <c>total_gross</c>,
+/// <c>updated_at</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.
 /// </param>
 public sealed record QueryParameterOrder(
     int? Limit = null,
@@ -44,8 +44,8 @@ public sealed record QueryParameterOrder(
 )
 {
     /// <summary>
-    ///     The underlying <see cref="Models.QueryParameter" /> passed to <see cref="Interfaces.IBexioConnectionHandler" />.
-    ///     <see langword="null" /> when every input is <see langword="null" /> so the handler appends no query string.
+    /// The underlying <see cref="Models.QueryParameter" /> passed to <see cref="Interfaces.IBexioConnectionHandler" />.
+    /// <see langword="null" /> when every input is <see langword="null" /> so the handler appends no query string.
     /// </summary>
     public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy);
 

--- a/src/BexioApiNet/Models/QueryParameterPaymentType.cs
+++ b/src/BexioApiNet/Models/QueryParameterPaymentType.cs
@@ -26,7 +26,7 @@ SOFTWARE.
 namespace BexioApiNet.Models;
 
 /// <summary>
-///     Dictionary for optional query parameters
+/// Dictionary for optional query parameters
 /// </summary>
 public sealed record QueryParameterPaymentType(
     int Limit,

--- a/src/BexioApiNet/Services/Connectors/Accounting/BusinessYearConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/BusinessYearConfiguration.cs
@@ -26,17 +26,17 @@ SOFTWARE.
 namespace BexioApiNet.Services.Connectors.Accounting;
 
 /// <summary>
-///     Business year endpoint configuration
+/// Business year endpoint configuration
 /// </summary>
 public struct BusinessYearConfiguration
 {
     /// <summary>
-    ///     Current api version of the endpoint
+    /// Current api version of the endpoint
     /// </summary>
     public const string ApiVersion = "3.0";
 
     /// <summary>
-    ///     The request path
+    /// The request path
     /// </summary>
     public const string EndpointRoot = "accounting/business_years";
 }

--- a/src/BexioApiNet/Services/Connectors/Accounting/BusinessYearService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/BusinessYearService.cs
@@ -38,12 +38,12 @@ namespace BexioApiNet.Services.Connectors.Accounting;
 public sealed class BusinessYearService : ConnectorService, IBusinessYearService
 {
     /// <summary>
-    ///     The api endpoint version
+    /// The api endpoint version
     /// </summary>
     private const string ApiVersion = BusinessYearConfiguration.ApiVersion;
 
     /// <summary>
-    ///     The api request path
+    /// The api request path
     /// </summary>
     private const string EndpointRoot = BusinessYearConfiguration.EndpointRoot;
 

--- a/src/BexioApiNet/Services/Connectors/Accounting/CurrencyService.cs
+++ b/src/BexioApiNet/Services/Connectors/Accounting/CurrencyService.cs
@@ -39,12 +39,12 @@ namespace BexioApiNet.Services.Connectors.Accounting;
 public sealed class CurrencyService : ConnectorService, ICurrencyService
 {
     /// <summary>
-    ///     The api endpoint version
+    /// The api endpoint version
     /// </summary>
     private const string ApiVersion = CurrencyConfiguration.ApiVersion;
 
     /// <summary>
-    ///     The api request path
+    /// The api request path
     /// </summary>
     private const string EndpointRoot = CurrencyConfiguration.EndpointRoot;
 

--- a/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeConfiguration.cs
@@ -26,17 +26,17 @@ SOFTWARE.
 namespace BexioApiNet.Services.Connectors.Banking;
 
 /// <summary>
-///     Payment type endpoint configuration
+/// Payment type endpoint configuration
 /// </summary>
 public struct PaymentTypeConfiguration
 {
     /// <summary>
-    ///     Current api version of the endpoint
+    /// Current api version of the endpoint
     /// </summary>
     public const string ApiVersion = "2.0";
 
     /// <summary>
-    ///     The request path
+    /// The request path
     /// </summary>
     public const string EndpointRoot = "payment_type";
 }

--- a/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeService.cs
+++ b/src/BexioApiNet/Services/Connectors/Banking/PaymentTypeService.cs
@@ -38,12 +38,12 @@ namespace BexioApiNet.Services.Connectors.Banking;
 public sealed class PaymentTypeService : ConnectorService, IPaymentTypeService
 {
     /// <summary>
-    ///     The api endpoint version
+    /// The api endpoint version
     /// </summary>
     private const string ApiVersion = PaymentTypeConfiguration.ApiVersion;
 
     /// <summary>
-    ///     The api request path
+    /// The api request path
     /// </summary>
     private const string EndpointRoot = PaymentTypeConfiguration.EndpointRoot;
 

--- a/src/BexioApiNet/Services/Connectors/Sales/DeliveryConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/DeliveryConfiguration.cs
@@ -26,17 +26,17 @@ SOFTWARE.
 namespace BexioApiNet.Services.Connectors.Sales;
 
 /// <summary>
-///     Delivery endpoint configuration
+/// Delivery endpoint configuration
 /// </summary>
 public struct DeliveryConfiguration
 {
     /// <summary>
-    ///     Current api version of the endpoint
+    /// Current api version of the endpoint
     /// </summary>
     public const string ApiVersion = "2.0";
 
     /// <summary>
-    ///     The request path
+    /// The request path
     /// </summary>
     public const string EndpointRoot = "kb_delivery";
 }

--- a/src/BexioApiNet/Services/Connectors/Sales/OrderConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Sales/OrderConfiguration.cs
@@ -26,17 +26,17 @@ SOFTWARE.
 namespace BexioApiNet.Services.Connectors.Sales;
 
 /// <summary>
-///     Order endpoint configuration
+/// Order endpoint configuration
 /// </summary>
 public struct OrderConfiguration
 {
     /// <summary>
-    ///     Current api version of the endpoint
+    /// Current api version of the endpoint
     /// </summary>
     public const string ApiVersion = "2.0";
 
     /// <summary>
-    ///     The request path
+    /// The request path
     /// </summary>
     public const string EndpointRoot = "kb_order";
 }

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/BusinessYears/BusinessYearServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/BusinessYears/BusinessYearServiceE2eTests.cs
@@ -29,10 +29,10 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.E2eTests.Tests.Accounting.BusinessYears;
 
 /// <summary>
-///     Live end-to-end smoke tests for <see cref="BusinessYearService" />. Constructs the
-///     service directly because the <c>BexioApiClient</c> aggregate wiring for business
-///     years is tracked by a separate issue. Tests are automatically skipped when
-///     <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> are not set.
+/// Live end-to-end smoke tests for <see cref="BusinessYearService" />. Constructs the
+/// service directly because the <c>BexioApiClient</c> aggregate wiring for business
+/// years is tracked by a separate issue. Tests are automatically skipped when
+/// <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> are not set.
 /// </summary>
 [Category("E2E")]
 public sealed class BusinessYearServiceE2eTests
@@ -41,9 +41,9 @@ public sealed class BusinessYearServiceE2eTests
     private BusinessYearService? _service;
 
     /// <summary>
-    ///     Reads <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> from
-    ///     environment variables. Calls <see cref="Assert.Ignore(string)" /> if either
-    ///     is missing so the test suite does not fail CI runs that lack live credentials.
+    /// Reads <c>BexioApiNet__BaseUri</c> and <c>BexioApiNet__JwtToken</c> from
+    /// environment variables. Calls <see cref="Assert.Ignore(string)" /> if either
+    /// is missing so the test suite does not fail CI runs that lack live credentials.
     /// </summary>
     [SetUp]
     public void Setup()
@@ -68,7 +68,7 @@ public sealed class BusinessYearServiceE2eTests
     }
 
     /// <summary>
-    ///     Disposes the connection handler if one was created.
+    /// Disposes the connection handler if one was created.
     /// </summary>
     [TearDown]
     public void Teardown()
@@ -77,8 +77,8 @@ public sealed class BusinessYearServiceE2eTests
     }
 
     /// <summary>
-    ///     Fetches the full list of business years from the live tenant and asserts
-    ///     at least one entry is returned with a valid id.
+    /// Fetches the full list of business years from the live tenant and asserts
+    /// at least one entry is returned with a valid id.
     /// </summary>
     [Test]
     public async Task GetAll()
@@ -97,8 +97,8 @@ public sealed class BusinessYearServiceE2eTests
     }
 
     /// <summary>
-    ///     Fetches a single business year by id (using the first one returned by the
-    ///     list endpoint) and asserts round-trip equality on the id.
+    /// Fetches a single business year by id (using the first one returned by the
+    /// list endpoint) and asserts round-trip equality on the id.
     /// </summary>
     [Test]
     public async Task GetById()

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/CreatePatchAndDelete.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/CreatePatchAndDelete.cs
@@ -28,16 +28,16 @@ using BexioApiNet.Abstractions.Models.Accounting.Currencies.Views;
 namespace BexioApiNet.E2eTests.Tests.Accounting.Currencies;
 
 /// <summary>
-///     E2E coverage for the full create / patch / delete cycle of <c>CurrencyService</c>
-///     against the live Bexio API. The test cleans up after itself by deleting the
-///     currency it created so it can be re-run safely.
+/// E2E coverage for the full create / patch / delete cycle of <c>CurrencyService</c>
+/// against the live Bexio API. The test cleans up after itself by deleting the
+/// currency it created so it can be re-run safely.
 /// </summary>
 public class TestCreatePatchAndDelete : BexioE2eTestBase
 {
     /// <summary>
-    ///     Creates a unique throwaway currency code (<c>X??</c>), patches its round factor and
-    ///     finally deletes it. Each step asserts a successful response and the test
-    ///     guarantees the created currency is removed even when the assertion order changes.
+    /// Creates a unique throwaway currency code (<c>X??</c>), patches its round factor and
+    /// finally deletes it. Each step asserts a successful response and the test
+    /// guarantees the created currency is removed even when the assertion order changes.
     /// </summary>
     [Test]
     public async Task CreatePatchAndDelete()

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetById.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetById.cs
@@ -26,14 +26,14 @@ SOFTWARE.
 namespace BexioApiNet.E2eTests.Tests.Accounting.Currencies;
 
 /// <summary>
-///     E2E coverage for <c>CurrencyService.GetById</c> against the live Bexio API.
+/// E2E coverage for <c>CurrencyService.GetById</c> against the live Bexio API.
 /// </summary>
 public class TestGetById : BexioE2eTestBase
 {
     /// <summary>
-    ///     Fetches the first currency returned by <c>Get()</c> and asserts that
-    ///     <c>GetById</c> returns the same record. Using a discovered id keeps the
-    ///     test stable across tenants.
+    /// Fetches the first currency returned by <c>Get()</c> and asserts that
+    /// <c>GetById</c> returns the same record. Using a discovered id keeps the
+    /// test stable across tenants.
     /// </summary>
     [Test]
     public async Task GetById()

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetCodes.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetCodes.cs
@@ -26,13 +26,13 @@ SOFTWARE.
 namespace BexioApiNet.E2eTests.Tests.Accounting.Currencies;
 
 /// <summary>
-///     E2E coverage for <c>CurrencyService.GetCodes</c> against the live Bexio API.
+/// E2E coverage for <c>CurrencyService.GetCodes</c> against the live Bexio API.
 /// </summary>
 public class TestGetCodes : BexioE2eTestBase
 {
     /// <summary>
-    ///     Lists the configured ISO 4217 currency codes for the tenant. Asserts a successful
-    ///     response containing at least one code (typically <c>CHF</c>, <c>EUR</c> are present).
+    /// Lists the configured ISO 4217 currency codes for the tenant. Asserts a successful
+    /// response containing at least one code (typically <c>CHF</c>, <c>EUR</c> are present).
     /// </summary>
     [Test]
     public async Task GetCodes()

--- a/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetExchangeRates.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Accounting/Currencies/GetExchangeRates.cs
@@ -26,14 +26,14 @@ SOFTWARE.
 namespace BexioApiNet.E2eTests.Tests.Accounting.Currencies;
 
 /// <summary>
-///     E2E coverage for <c>CurrencyService.GetExchangeRates</c> against the live Bexio API.
+/// E2E coverage for <c>CurrencyService.GetExchangeRates</c> against the live Bexio API.
 /// </summary>
 public class TestGetExchangeRates : BexioE2eTestBase
 {
     /// <summary>
-    ///     Fetches the first currency returned by <c>Get()</c> and queries its configured
-    ///     exchange rates. Asserts on a successful response — the data list may be empty
-    ///     when no rates are configured for the discovered currency.
+    /// Fetches the first currency returned by <c>Get()</c> and queries its configured
+    /// exchange rates. Asserts on a successful response — the data list may be empty
+    /// when no rates are configured for the discovered currency.
     /// </summary>
     [Test]
     public async Task GetExchangeRates()

--- a/tests/BexioApiNet.E2eTests/Tests/Banking/PaymentTypes/PaymentTypeServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Banking/PaymentTypes/PaymentTypeServiceE2eTests.cs
@@ -31,11 +31,11 @@ using BexioApiNet.Services.Connectors.Banking;
 namespace BexioApiNet.E2eTests.Tests.Banking.PaymentTypes;
 
 /// <summary>
-///     Live end-to-end tests for <see cref="PaymentTypeService" />. Skipped
-///     automatically when <c>BexioApiNet__BaseUri</c> / <c>BexioApiNet__JwtToken</c>
-///     are missing. The service is instantiated directly here because wiring the
-///     connector into <see cref="IBexioApiClient" /> is deferred to the Wave 1
-///     aggregation issue (#49).
+/// Live end-to-end tests for <see cref="PaymentTypeService" />. Skipped
+/// automatically when <c>BexioApiNet__BaseUri</c> / <c>BexioApiNet__JwtToken</c>
+/// are missing. The service is instantiated directly here because wiring the
+/// connector into <see cref="IBexioApiClient" /> is deferred to the Wave 1
+/// aggregation issue (#49).
 /// </summary>
 [Category("E2E")]
 public sealed class PaymentTypeServiceE2eTests
@@ -44,10 +44,10 @@ public sealed class PaymentTypeServiceE2eTests
     private IPaymentTypeService? _paymentTypeService;
 
     /// <summary>
-    ///     Builds a dedicated <see cref="BexioConnectionHandler" /> and
-    ///     <see cref="PaymentTypeService" /> per test. Calls <see cref="Assert.Ignore(string)" />
-    ///     when credentials are not provided via environment variables so CI and
-    ///     agent runs without a Bexio tenant do not surface false failures.
+    /// Builds a dedicated <see cref="BexioConnectionHandler" /> and
+    /// <see cref="PaymentTypeService" /> per test. Calls <see cref="Assert.Ignore(string)" />
+    /// when credentials are not provided via environment variables so CI and
+    /// agent runs without a Bexio tenant do not surface false failures.
     /// </summary>
     [SetUp]
     public void Setup()
@@ -72,7 +72,7 @@ public sealed class PaymentTypeServiceE2eTests
     }
 
     /// <summary>
-    ///     Disposes the connection handler if one was created for the test.
+    /// Disposes the connection handler if one was created for the test.
     /// </summary>
     [TearDown]
     public void Teardown()
@@ -81,9 +81,9 @@ public sealed class PaymentTypeServiceE2eTests
     }
 
     /// <summary>
-    ///     <c>GET /2.0/payment_type</c> must return a non-null, non-empty list of
-    ///     payment types for a provisioned Bexio tenant. Bexio ships default entries
-    ///     (e.g., <c>Cash</c>, <c>Bank</c>) so the list is expected to be populated.
+    /// <c>GET /2.0/payment_type</c> must return a non-null, non-empty list of
+    /// payment types for a provisioned Bexio tenant. Bexio ships default entries
+    /// (e.g., <c>Cash</c>, <c>Bank</c>) so the list is expected to be populated.
     /// </summary>
     [Test]
     public async Task GetAll_ReturnsPaymentTypes()
@@ -103,9 +103,9 @@ public sealed class PaymentTypeServiceE2eTests
     }
 
     /// <summary>
-    ///     <c>POST /2.0/payment_type/search</c> with an <c>is_null=false</c>
-    ///     <c>name</c> criterion must return a non-null list of payment types
-    ///     matching the search filter.
+    /// <c>POST /2.0/payment_type/search</c> with an <c>is_null=false</c>
+    /// <c>name</c> criterion must return a non-null list of payment types
+    /// matching the search filter.
     /// </summary>
     [Test]
     public async Task Search_WithNameCriteria_ReturnsPaymentTypes()

--- a/tests/BexioApiNet.IntegrationTests/Accounting/AccountGroupServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Accounting/AccountGroupServiceIntegrationTests.cs
@@ -28,19 +28,19 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.IntegrationTests.Accounting;
 
 /// <summary>
-///     Integration tests covering the <see cref="AccountGroupService" /> entry points against
-///     WireMock stubs. Verifies the path composed from <see cref="AccountGroupConfiguration" />
-///     (<c>2.0/account_groups</c>) reaches the handler correctly and that the expected HTTP
-///     verb is used.
+/// Integration tests covering the <see cref="AccountGroupService" /> entry points against
+/// WireMock stubs. Verifies the path composed from <see cref="AccountGroupConfiguration" />
+/// (<c>2.0/account_groups</c>) reaches the handler correctly and that the expected HTTP
+/// verb is used.
 /// </summary>
 public sealed class AccountGroupServiceIntegrationTests : IntegrationTestBase
 {
     private const string AccountGroupsPath = "/2.0/account_groups";
 
     /// <summary>
-    ///     <c>AccountGroupService.Get()</c> must issue a <c>GET</c> request against
-    ///     <c>/2.0/account_groups</c> and return a successful <c>ApiResult</c> when the server
-    ///     returns an empty array.
+    /// <c>AccountGroupService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/account_groups</c> and return a successful <c>ApiResult</c> when the server
+    /// returns an empty array.
     /// </summary>
     [Test]
     public async Task AccountGroupService_Get_SendsGetRequest()

--- a/tests/BexioApiNet.IntegrationTests/Accounting/BusinessYearServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Accounting/BusinessYearServiceIntegrationTests.cs
@@ -28,10 +28,10 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.IntegrationTests.Accounting;
 
 /// <summary>
-///     Integration tests covering the <see cref="BusinessYearService" /> entry points against
-///     WireMock stubs. Verifies the path composed from <see cref="BusinessYearConfiguration" />
-///     (<c>3.0/accounting/business_years</c>) reaches the handler correctly and that the
-///     expected HTTP verbs are used.
+/// Integration tests covering the <see cref="BusinessYearService" /> entry points against
+/// WireMock stubs. Verifies the path composed from <see cref="BusinessYearConfiguration" />
+/// (<c>3.0/accounting/business_years</c>) reaches the handler correctly and that the
+/// expected HTTP verbs are used.
 /// </summary>
 public sealed class BusinessYearServiceIntegrationTests : IntegrationTestBase
 {
@@ -48,9 +48,9 @@ public sealed class BusinessYearServiceIntegrationTests : IntegrationTestBase
                                                 """;
 
     /// <summary>
-    ///     <c>BusinessYearService.Get()</c> must issue a <c>GET</c> request against
-    ///     <c>/3.0/accounting/business_years</c> and return a successful <c>ApiResult</c>
-    ///     when the server returns an empty array.
+    /// <c>BusinessYearService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/3.0/accounting/business_years</c> and return a successful <c>ApiResult</c>
+    /// when the server returns an empty array.
     /// </summary>
     [Test]
     public async Task BusinessYearService_Get_SendsGetRequest()
@@ -74,8 +74,8 @@ public sealed class BusinessYearServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>BusinessYearService.GetById</c> must issue a <c>GET</c> request that includes the
-    ///     target id in the URL path and surface the returned business year on success.
+    /// <c>BusinessYearService.GetById</c> must issue a <c>GET</c> request that includes the
+    /// target id in the URL path and surface the returned business year on success.
     /// </summary>
     [Test]
     public async Task BusinessYearService_GetById_SendsGetRequestWithIdInPath()

--- a/tests/BexioApiNet.IntegrationTests/Accounting/CalendarYearServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Accounting/CalendarYearServiceIntegrationTests.cs
@@ -30,10 +30,10 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.IntegrationTests.Accounting;
 
 /// <summary>
-///     Integration tests covering the <see cref="CalendarYearService" /> entry points against
-///     WireMock stubs. Verifies the path composed from <see cref="CalendarYearConfiguration" />
-///     (<c>3.0/accounting/calendar_years</c>) reaches the handler correctly and that the
-///     expected HTTP verbs are used.
+/// Integration tests covering the <see cref="CalendarYearService" /> entry points against
+/// WireMock stubs. Verifies the path composed from <see cref="CalendarYearConfiguration" />
+/// (<c>3.0/accounting/calendar_years</c>) reaches the handler correctly and that the
+/// expected HTTP verbs are used.
 /// </summary>
 public sealed class CalendarYearServiceIntegrationTests : IntegrationTestBase
 {
@@ -54,9 +54,9 @@ public sealed class CalendarYearServiceIntegrationTests : IntegrationTestBase
                                                 """;
 
     /// <summary>
-    ///     <c>CalendarYearService.Get()</c> must issue a <c>GET</c> request against
-    ///     <c>/3.0/accounting/calendar_years</c> and return a successful <c>ApiResult</c>
-    ///     when the server returns an empty array.
+    /// <c>CalendarYearService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/3.0/accounting/calendar_years</c> and return a successful <c>ApiResult</c>
+    /// when the server returns an empty array.
     /// </summary>
     [Test]
     public async Task CalendarYearService_Get_SendsGetRequest()
@@ -80,8 +80,8 @@ public sealed class CalendarYearServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>CalendarYearService.GetById</c> must issue a <c>GET</c> request that includes the
-    ///     target id in the URL path and surface the returned calendar year on success.
+    /// <c>CalendarYearService.GetById</c> must issue a <c>GET</c> request that includes the
+    /// target id in the URL path and surface the returned calendar year on success.
     /// </summary>
     [Test]
     public async Task CalendarYearService_GetById_SendsGetRequestWithIdInPath()
@@ -110,8 +110,8 @@ public sealed class CalendarYearServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>CalendarYearService.Create</c> must issue a <c>POST</c> request whose body is the
-    ///     serialized <see cref="CalendarYearCreate" /> payload.
+    /// <c>CalendarYearService.Create</c> must issue a <c>POST</c> request whose body is the
+    /// serialized <see cref="CalendarYearCreate" /> payload.
     /// </summary>
     [Test]
     public async Task CalendarYearService_Create_SendsPostRequest()
@@ -140,8 +140,8 @@ public sealed class CalendarYearServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>CalendarYearService.Search</c> must issue a <c>POST</c> request against
-    ///     <c>/3.0/accounting/calendar_years/search</c> with the search criteria as the JSON body.
+    /// <c>CalendarYearService.Search</c> must issue a <c>POST</c> request against
+    /// <c>/3.0/accounting/calendar_years/search</c> with the search criteria as the JSON body.
     /// </summary>
     [Test]
     public async Task CalendarYearService_Search_SendsPostRequestToSearchPath()

--- a/tests/BexioApiNet.IntegrationTests/Accounting/CurrencyServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Accounting/CurrencyServiceIntegrationTests.cs
@@ -30,10 +30,10 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.IntegrationTests.Accounting;
 
 /// <summary>
-///     Integration tests covering the <see cref="CurrencyService" /> entry points against
-///     WireMock stubs. Verifies the path composed from <see cref="CurrencyConfiguration" />
-///     (<c>3.0/currencies</c>) reaches the handler correctly and that the expected HTTP
-///     verbs and query parameters are used.
+/// Integration tests covering the <see cref="CurrencyService" /> entry points against
+/// WireMock stubs. Verifies the path composed from <see cref="CurrencyConfiguration" />
+/// (<c>3.0/currencies</c>) reaches the handler correctly and that the expected HTTP
+/// verbs and query parameters are used.
 /// </summary>
 public sealed class CurrencyServiceIntegrationTests : IntegrationTestBase
 {
@@ -48,8 +48,8 @@ public sealed class CurrencyServiceIntegrationTests : IntegrationTestBase
                                             """;
 
     /// <summary>
-    ///     <c>CurrencyService.GetCodes</c> must issue a <c>GET</c> request to
-    ///     <c>/3.0/currencies/codes</c> and surface the array of currency codes.
+    /// <c>CurrencyService.GetCodes</c> must issue a <c>GET</c> request to
+    /// <c>/3.0/currencies/codes</c> and surface the array of currency codes.
     /// </summary>
     [Test]
     public async Task CurrencyService_GetCodes_SendsGetRequestToCodesPath()
@@ -75,8 +75,8 @@ public sealed class CurrencyServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>CurrencyService.GetById</c> must issue a <c>GET</c> request that includes the
-    ///     currency id in the URL path.
+    /// <c>CurrencyService.GetById</c> must issue a <c>GET</c> request that includes the
+    /// currency id in the URL path.
     /// </summary>
     [Test]
     public async Task CurrencyService_GetById_SendsGetRequestWithIdInPath()
@@ -105,9 +105,9 @@ public sealed class CurrencyServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>CurrencyService.GetExchangeRates</c> must issue a <c>GET</c> request to the nested
-    ///     <c>/3.0/currencies/{id}/exchange_rates</c> path and forward an optional <c>date</c>
-    ///     query parameter when supplied.
+    /// <c>CurrencyService.GetExchangeRates</c> must issue a <c>GET</c> request to the nested
+    /// <c>/3.0/currencies/{id}/exchange_rates</c> path and forward an optional <c>date</c>
+    /// query parameter when supplied.
     /// </summary>
     [Test]
     public async Task CurrencyService_GetExchangeRates_WithDate_AppendsDateQuery()
@@ -138,8 +138,8 @@ public sealed class CurrencyServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>CurrencyService.Create</c> must issue a <c>POST</c> request whose body is the
-    ///     serialized <see cref="CurrencyCreate" /> payload.
+    /// <c>CurrencyService.Create</c> must issue a <c>POST</c> request whose body is the
+    /// serialized <see cref="CurrencyCreate" /> payload.
     /// </summary>
     [Test]
     public async Task CurrencyService_Create_SendsPostRequest()
@@ -168,8 +168,8 @@ public sealed class CurrencyServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>CurrencyService.Patch</c> must issue a <c>PATCH</c> request that includes the id in
-    ///     the URL path and serializes the payload as the body.
+    /// <c>CurrencyService.Patch</c> must issue a <c>PATCH</c> request that includes the id in
+    /// the URL path and serializes the payload as the body.
     /// </summary>
     [Test]
     public async Task CurrencyService_Patch_SendsPatchRequestWithIdInPath()
@@ -201,8 +201,8 @@ public sealed class CurrencyServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>CurrencyService.Delete</c> must issue a <c>DELETE</c> request that includes the
-    ///     target id in the URL path and surface a successful <c>ApiResult</c>.
+    /// <c>CurrencyService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    /// target id in the URL path and surface a successful <c>ApiResult</c>.
     /// </summary>
     [Test]
     public async Task CurrencyService_Delete_SendsDeleteRequest()

--- a/tests/BexioApiNet.IntegrationTests/Accounting/ReportServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Accounting/ReportServiceIntegrationTests.cs
@@ -29,19 +29,19 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.IntegrationTests.Accounting;
 
 /// <summary>
-///     Integration tests covering the <see cref="ReportService" /> entry points against WireMock
-///     stubs. Verifies the path composed from <see cref="ReportConfiguration" />
-///     (<c>3.0/accounting/journal</c>) reaches the handler correctly and that the expected
-///     HTTP verb and query parameters are used.
+/// Integration tests covering the <see cref="ReportService" /> entry points against WireMock
+/// stubs. Verifies the path composed from <see cref="ReportConfiguration" />
+/// (<c>3.0/accounting/journal</c>) reaches the handler correctly and that the expected
+/// HTTP verb and query parameters are used.
 /// </summary>
 public sealed class ReportServiceIntegrationTests : IntegrationTestBase
 {
     private const string JournalPath = "/3.0/accounting/journal";
 
     /// <summary>
-    ///     <c>ReportService.GetJournal()</c> must issue a <c>GET</c> request against
-    ///     <c>/3.0/accounting/journal</c> and return a successful <c>ApiResult</c> when the
-    ///     server returns an empty array.
+    /// <c>ReportService.GetJournal()</c> must issue a <c>GET</c> request against
+    /// <c>/3.0/accounting/journal</c> and return a successful <c>ApiResult</c> when the
+    /// server returns an empty array.
     /// </summary>
     [Test]
     public async Task ReportService_GetJournal_SendsGetRequest()
@@ -65,8 +65,8 @@ public sealed class ReportServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ReportService.GetJournal</c> with a <see cref="QueryParameterJournal" /> must
-    ///     forward the <c>from</c> and <c>to</c> query parameters onto the URL.
+    /// <c>ReportService.GetJournal</c> with a <see cref="QueryParameterJournal" /> must
+    /// forward the <c>from</c> and <c>to</c> query parameters onto the URL.
     /// </summary>
     [Test]
     public async Task ReportService_GetJournal_WithDateRange_AppendsQueryParameters()

--- a/tests/BexioApiNet.IntegrationTests/Accounting/TaxServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Accounting/TaxServiceIntegrationTests.cs
@@ -28,9 +28,9 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.IntegrationTests.Accounting;
 
 /// <summary>
-///     Integration tests covering the <see cref="TaxService" /> entry points against WireMock stubs.
-///     Verifies the path composed from <see cref="TaxConfiguration" /> (<c>3.0/taxes</c>)
-///     reaches the handler correctly and that the expected HTTP verbs are used.
+/// Integration tests covering the <see cref="TaxService" /> entry points against WireMock stubs.
+/// Verifies the path composed from <see cref="TaxConfiguration" /> (<c>3.0/taxes</c>)
+/// reaches the handler correctly and that the expected HTTP verbs are used.
 /// </summary>
 public sealed class TaxServiceIntegrationTests : IntegrationTestBase
 {
@@ -58,8 +58,8 @@ public sealed class TaxServiceIntegrationTests : IntegrationTestBase
                                        """;
 
     /// <summary>
-    ///     <c>TaxService.Get()</c> must issue a <c>GET</c> request against <c>/3.0/taxes</c>
-    ///     and return a successful <c>ApiResult</c> when the server returns an empty array.
+    /// <c>TaxService.Get()</c> must issue a <c>GET</c> request against <c>/3.0/taxes</c>
+    /// and return a successful <c>ApiResult</c> when the server returns an empty array.
     /// </summary>
     [Test]
     public async Task TaxService_Get_SendsGetRequest()
@@ -83,8 +83,8 @@ public sealed class TaxServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>TaxService.GetById</c> must issue a <c>GET</c> request that includes the target id
-    ///     in the URL path and surface the returned tax on success.
+    /// <c>TaxService.GetById</c> must issue a <c>GET</c> request that includes the target id
+    /// in the URL path and surface the returned tax on success.
     /// </summary>
     [Test]
     public async Task TaxService_GetById_SendsGetRequestWithIdInPath()
@@ -113,8 +113,8 @@ public sealed class TaxServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>TaxService.Delete</c> must issue a <c>DELETE</c> request that includes the target id
-    ///     in the URL path.
+    /// <c>TaxService.Delete</c> must issue a <c>DELETE</c> request that includes the target id
+    /// in the URL path.
     /// </summary>
     [Test]
     public async Task TaxService_Delete_SendsDeleteRequest()

--- a/tests/BexioApiNet.IntegrationTests/Accounting/VatPeriodServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Accounting/VatPeriodServiceIntegrationTests.cs
@@ -28,10 +28,10 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.IntegrationTests.Accounting;
 
 /// <summary>
-///     Integration tests covering the <see cref="VatPeriodService" /> entry points against WireMock
-///     stubs. Verifies the path composed from <see cref="VatPeriodConfiguration" />
-///     (<c>3.0/accounting/vat_periods</c>) reaches the handler correctly and that the expected
-///     HTTP verbs are used.
+/// Integration tests covering the <see cref="VatPeriodService" /> entry points against WireMock
+/// stubs. Verifies the path composed from <see cref="VatPeriodConfiguration" />
+/// (<c>3.0/accounting/vat_periods</c>) reaches the handler correctly and that the expected
+/// HTTP verbs are used.
 /// </summary>
 public sealed class VatPeriodServiceIntegrationTests : IntegrationTestBase
 {
@@ -49,9 +49,9 @@ public sealed class VatPeriodServiceIntegrationTests : IntegrationTestBase
                                              """;
 
     /// <summary>
-    ///     <c>VatPeriodService.Get()</c> must issue a <c>GET</c> request against
-    ///     <c>/3.0/accounting/vat_periods</c> and return a successful <c>ApiResult</c> when the
-    ///     server returns an empty array.
+    /// <c>VatPeriodService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/3.0/accounting/vat_periods</c> and return a successful <c>ApiResult</c> when the
+    /// server returns an empty array.
     /// </summary>
     [Test]
     public async Task VatPeriodService_Get_SendsGetRequest()
@@ -75,8 +75,8 @@ public sealed class VatPeriodServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>VatPeriodService.GetById</c> must issue a <c>GET</c> request that includes the
-    ///     target id in the URL path and surface the returned vat period on success.
+    /// <c>VatPeriodService.GetById</c> must issue a <c>GET</c> request that includes the
+    /// target id in the URL path and surface the returned vat period on success.
     /// </summary>
     [Test]
     public async Task VatPeriodService_GetById_SendsGetRequestWithIdInPath()

--- a/tests/BexioApiNet.IntegrationTests/Banking/OutgoingPaymentServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Banking/OutgoingPaymentServiceIntegrationTests.cs
@@ -31,11 +31,11 @@ using BexioApiNet.Services.Connectors.Banking;
 namespace BexioApiNet.IntegrationTests.Banking;
 
 /// <summary>
-///     Integration tests covering the CRUD entry points of <see cref="OutgoingPaymentService" /> against
-///     WireMock stubs. Verifies the path composed from <see cref="OutgoingPaymentConfiguration" />
-///     (<c>4.0/purchase/outgoing-payments</c>) reaches the handler correctly and that the expected
-///     HTTP verbs are used for each operation (Get, GetById, Create, Update, Delete).
-///     Note: Update uses <c>PUT</c> on the collection path (no <c>/{id}</c>) per the Bexio API spec.
+/// Integration tests covering the CRUD entry points of <see cref="OutgoingPaymentService" /> against
+/// WireMock stubs. Verifies the path composed from <see cref="OutgoingPaymentConfiguration" />
+/// (<c>4.0/purchase/outgoing-payments</c>) reaches the handler correctly and that the expected
+/// HTTP verbs are used for each operation (Get, GetById, Create, Update, Delete).
+/// Note: Update uses <c>PUT</c> on the collection path (no <c>/{id}</c>) per the Bexio API spec.
 /// </summary>
 public sealed class OutgoingPaymentServiceIntegrationTests : IntegrationTestBase
 {
@@ -102,9 +102,9 @@ public sealed class OutgoingPaymentServiceIntegrationTests : IntegrationTestBase
     private static readonly Guid TestBillId = Guid.Parse("c3d4e5f6-a7b8-9012-cdef-123456789012");
 
     /// <summary>
-    ///     <c>OutgoingPaymentService.Get</c> must issue a <c>GET</c> against
-    ///     <c>/4.0/purchase/outgoing-payments</c> with the required <c>bill_id</c> query parameter
-    ///     and return a successful <c>ApiResult</c> when the server responds with an empty page.
+    /// <c>OutgoingPaymentService.Get</c> must issue a <c>GET</c> against
+    /// <c>/4.0/purchase/outgoing-payments</c> with the required <c>bill_id</c> query parameter
+    /// and return a successful <c>ApiResult</c> when the server responds with an empty page.
     /// </summary>
     [Test]
     public async Task OutgoingPaymentService_Get_SendsGetRequestWithBillIdQueryParameter()
@@ -132,8 +132,8 @@ public sealed class OutgoingPaymentServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>OutgoingPaymentService.GetById</c> must issue a <c>GET</c> request that includes the target
-    ///     <see cref="Guid" /> in the URL path and surface the returned outgoing payment on success.
+    /// <c>OutgoingPaymentService.GetById</c> must issue a <c>GET</c> request that includes the target
+    /// <see cref="Guid" /> in the URL path and surface the returned outgoing payment on success.
     /// </summary>
     [Test]
     public async Task OutgoingPaymentService_GetById_SendsGetRequestWithIdInPath()
@@ -161,9 +161,9 @@ public sealed class OutgoingPaymentServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>OutgoingPaymentService.Create</c> must send a <c>POST</c> request whose body is the
-    ///     serialized <see cref="OutgoingPaymentCreate" /> payload, and must surface the returned
-    ///     outgoing payment on success.
+    /// <c>OutgoingPaymentService.Create</c> must send a <c>POST</c> request whose body is the
+    /// serialized <see cref="OutgoingPaymentCreate" /> payload, and must surface the returned
+    /// outgoing payment on success.
     /// </summary>
     [Test]
     public async Task OutgoingPaymentService_Create_SendsPostRequestWithPayload()
@@ -201,10 +201,10 @@ public sealed class OutgoingPaymentServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>OutgoingPaymentService.Update</c> must send a <c>PUT</c> request against
-    ///     <c>/4.0/purchase/outgoing-payments</c> (collection path, no <c>/{id}</c>) whose body is the
-    ///     serialized <see cref="OutgoingPaymentUpdate" /> payload containing the <c>payment_id</c>.
-    ///     This is correct per the Bexio API spec.
+    /// <c>OutgoingPaymentService.Update</c> must send a <c>PUT</c> request against
+    /// <c>/4.0/purchase/outgoing-payments</c> (collection path, no <c>/{id}</c>) whose body is the
+    /// serialized <see cref="OutgoingPaymentUpdate" /> payload containing the <c>payment_id</c>.
+    /// This is correct per the Bexio API spec.
     /// </summary>
     [Test]
     public async Task OutgoingPaymentService_Update_SendsPutRequestToCollectionPath()
@@ -236,8 +236,8 @@ public sealed class OutgoingPaymentServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>OutgoingPaymentService.Delete</c> must issue a <c>DELETE</c> request that includes the
-    ///     target <see cref="Guid" /> in the URL path.
+    /// <c>OutgoingPaymentService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    /// target <see cref="Guid" /> in the URL path.
     /// </summary>
     [Test]
     public async Task OutgoingPaymentService_Delete_SendsDeleteRequestWithIdInPath()

--- a/tests/BexioApiNet.IntegrationTests/Banking/PaymentServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Banking/PaymentServiceIntegrationTests.cs
@@ -31,10 +31,10 @@ using BexioApiNet.Services.Connectors.Banking;
 namespace BexioApiNet.IntegrationTests.Banking;
 
 /// <summary>
-///     Integration tests covering the CRUD and Cancel entry points of <see cref="PaymentService" /> against
-///     WireMock stubs. Verifies the path composed from <see cref="PaymentConfiguration" />
-///     (<c>4.0/banking/payments</c>) reaches the handler correctly and that the expected HTTP verbs
-///     are used for each operation (Get, GetById, Create, Cancel, Update, Delete).
+/// Integration tests covering the CRUD and Cancel entry points of <see cref="PaymentService" /> against
+/// WireMock stubs. Verifies the path composed from <see cref="PaymentConfiguration" />
+/// (<c>4.0/banking/payments</c>) reaches the handler correctly and that the expected HTTP verbs
+/// are used for each operation (Get, GetById, Create, Cancel, Update, Delete).
 /// </summary>
 public sealed class PaymentServiceIntegrationTests : IntegrationTestBase
 {
@@ -67,9 +67,9 @@ public sealed class PaymentServiceIntegrationTests : IntegrationTestBase
     private static readonly Guid TestPaymentId = Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
 
     /// <summary>
-    ///     <c>PaymentService.Get()</c> must issue a <c>GET</c> against
-    ///     <c>/4.0/banking/payments</c> and return a successful <c>ApiResult</c> when the
-    ///     server responds with an empty collection.
+    /// <c>PaymentService.Get()</c> must issue a <c>GET</c> against
+    /// <c>/4.0/banking/payments</c> and return a successful <c>ApiResult</c> when the
+    /// server responds with an empty collection.
     /// </summary>
     [Test]
     public async Task PaymentService_Get_SendsGetRequestToCorrectPath()
@@ -93,8 +93,8 @@ public sealed class PaymentServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>PaymentService.GetById</c> must issue a <c>GET</c> request that includes the target
-    ///     <see cref="Guid" /> in the URL path and surface the returned payment on success.
+    /// <c>PaymentService.GetById</c> must issue a <c>GET</c> request that includes the target
+    /// <see cref="Guid" /> in the URL path and surface the returned payment on success.
     /// </summary>
     [Test]
     public async Task PaymentService_GetById_SendsGetRequestWithIdInPath()
@@ -121,8 +121,8 @@ public sealed class PaymentServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>PaymentService.Create</c> must send a <c>POST</c> request whose body is the serialized
-    ///     <see cref="PaymentCreate" /> payload, and must surface the returned payment on success.
+    /// <c>PaymentService.Create</c> must send a <c>POST</c> request whose body is the serialized
+    /// <see cref="PaymentCreate" /> payload, and must surface the returned payment on success.
     /// </summary>
     [Test]
     public async Task PaymentService_Create_SendsPostRequestWithPayload()
@@ -166,8 +166,8 @@ public sealed class PaymentServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>PaymentService.Cancel</c> must send a <c>POST</c> request against
-    ///     <c>/4.0/banking/payments/{id}/cancel</c> with no body — Bexio uses POST for this action.
+    /// <c>PaymentService.Cancel</c> must send a <c>POST</c> request against
+    /// <c>/4.0/banking/payments/{id}/cancel</c> with no body — Bexio uses POST for this action.
     /// </summary>
     [Test]
     public async Task PaymentService_Cancel_SendsPostRequestToCancelPath()
@@ -194,8 +194,8 @@ public sealed class PaymentServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>PaymentService.Delete</c> must issue a <c>DELETE</c> request that includes the target
-    ///     <see cref="Guid" /> in the URL path.
+    /// <c>PaymentService.Delete</c> must issue a <c>DELETE</c> request that includes the target
+    /// <see cref="Guid" /> in the URL path.
     /// </summary>
     [Test]
     public async Task PaymentService_Delete_SendsDeleteRequestWithIdInPath()

--- a/tests/BexioApiNet.IntegrationTests/Banking/PaymentTypeServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Banking/PaymentTypeServiceIntegrationTests.cs
@@ -29,18 +29,18 @@ using BexioApiNet.Services.Connectors.Banking;
 namespace BexioApiNet.IntegrationTests.Banking;
 
 /// <summary>
-///     Integration tests covering <see cref="PaymentTypeService" />. The request path is composed from
-///     <see cref="PaymentTypeConfiguration" /> (<c>2.0/payment_type</c>) and must reach WireMock
-///     intact when the service is driven through the real connection handler.
+/// Integration tests covering <see cref="PaymentTypeService" />. The request path is composed from
+/// <see cref="PaymentTypeConfiguration" /> (<c>2.0/payment_type</c>) and must reach WireMock
+/// intact when the service is driven through the real connection handler.
 /// </summary>
 public sealed class PaymentTypeServiceIntegrationTests : IntegrationTestBase
 {
     private const string PaymentTypesPath = "/2.0/payment_type";
 
     /// <summary>
-    ///     <c>PaymentTypeService.Get()</c> must issue a <c>GET</c> against
-    ///     <c>/2.0/payment_type</c> and return a successful <c>ApiResult</c> when the
-    ///     server responds with an empty collection.
+    /// <c>PaymentTypeService.Get()</c> must issue a <c>GET</c> against
+    /// <c>/2.0/payment_type</c> and return a successful <c>ApiResult</c> when the
+    /// server responds with an empty collection.
     /// </summary>
     [Test]
     public async Task PaymentTypeService_Get_SendsGetRequestToCorrectPath()
@@ -66,8 +66,8 @@ public sealed class PaymentTypeServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>PaymentTypeService.Search</c> must send a <c>POST</c> request against
-    ///     <c>/2.0/payment_type/search</c> with the <see cref="SearchCriteria" /> list as the JSON body.
+    /// <c>PaymentTypeService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/payment_type/search</c> with the <see cref="SearchCriteria" /> list as the JSON body.
     /// </summary>
     [Test]
     public async Task PaymentTypeService_Search_SendsPostRequestToSearchPath()

--- a/tests/BexioApiNet.IntegrationTests/Contacts/AdditionalAddressServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Contacts/AdditionalAddressServiceIntegrationTests.cs
@@ -30,12 +30,12 @@ using BexioApiNet.Services.Connectors.Contacts;
 namespace BexioApiNet.IntegrationTests.Contacts;
 
 /// <summary>
-///     Integration tests covering the CRUD entry points of <see cref="AdditionalAddressService" /> against
-///     WireMock stubs. Additional addresses are nested under a parent contact, so all routes follow the
-///     pattern <c>2.0/contact/{contactId}/additional_address</c> (see
-///     <see cref="AdditionalAddressConfiguration" />). Verifies URL construction with the parent contact
-///     id, that the expected HTTP verbs are used (including the Bexio-specific <c>POST</c> for edits),
-///     and that payloads are serialized with the expected snake_case field names.
+/// Integration tests covering the CRUD entry points of <see cref="AdditionalAddressService" /> against
+/// WireMock stubs. Additional addresses are nested under a parent contact, so all routes follow the
+/// pattern <c>2.0/contact/{contactId}/additional_address</c> (see
+/// <see cref="AdditionalAddressConfiguration" />). Verifies URL construction with the parent contact
+/// id, that the expected HTTP verbs are used (including the Bexio-specific <c>POST</c> for edits),
+/// and that payloads are serialized with the expected snake_case field names.
 /// </summary>
 public sealed class AdditionalAddressServiceIntegrationTests : IntegrationTestBase
 {
@@ -60,9 +60,9 @@ public sealed class AdditionalAddressServiceIntegrationTests : IntegrationTestBa
                                                      """;
 
     /// <summary>
-    ///     <c>AdditionalAddressService.Get()</c> must issue a <c>GET</c> request against
-    ///     <c>/2.0/contact/{contactId}/additional_address</c> and return a successful <c>ApiResult</c>
-    ///     when the server returns an empty array.
+    /// <c>AdditionalAddressService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/contact/{contactId}/additional_address</c> and return a successful <c>ApiResult</c>
+    /// when the server returns an empty array.
     /// </summary>
     [Test]
     public async Task AdditionalAddressService_Get_SendsGetRequest()
@@ -86,8 +86,8 @@ public sealed class AdditionalAddressServiceIntegrationTests : IntegrationTestBa
     }
 
     /// <summary>
-    ///     <c>AdditionalAddressService.GetById</c> must issue a <c>GET</c> request that includes both
-    ///     the parent contact id and the address id in the URL path.
+    /// <c>AdditionalAddressService.GetById</c> must issue a <c>GET</c> request that includes both
+    /// the parent contact id and the address id in the URL path.
     /// </summary>
     [Test]
     public async Task AdditionalAddressService_GetById_SendsGetRequest()
@@ -116,9 +116,9 @@ public sealed class AdditionalAddressServiceIntegrationTests : IntegrationTestBa
     }
 
     /// <summary>
-    ///     <c>AdditionalAddressService.Create</c> must send a <c>POST</c> request whose body is the
-    ///     serialized <see cref="AdditionalAddressCreate" /> payload, and must surface the returned
-    ///     additional address on success.
+    /// <c>AdditionalAddressService.Create</c> must send a <c>POST</c> request whose body is the
+    /// serialized <see cref="AdditionalAddressCreate" /> payload, and must surface the returned
+    /// additional address on success.
     /// </summary>
     [Test]
     public async Task AdditionalAddressService_Create_SendsPostRequest()
@@ -158,9 +158,9 @@ public sealed class AdditionalAddressServiceIntegrationTests : IntegrationTestBa
     }
 
     /// <summary>
-    ///     <c>AdditionalAddressService.Search</c> must send a <c>POST</c> request against
-    ///     <c>/2.0/contact/{contactId}/additional_address/search</c> with the <see cref="SearchCriteria" />
-    ///     list as the JSON body.
+    /// <c>AdditionalAddressService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/contact/{contactId}/additional_address/search</c> with the <see cref="SearchCriteria" />
+    /// list as the JSON body.
     /// </summary>
     [Test]
     public async Task AdditionalAddressService_Search_SendsPostRequest_ToSearchPath()
@@ -194,9 +194,9 @@ public sealed class AdditionalAddressServiceIntegrationTests : IntegrationTestBa
     }
 
     /// <summary>
-    ///     <c>AdditionalAddressService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request
-    ///     against <c>/2.0/contact/{contactId}/additional_address/{id}</c> — Bexio uses POST for
-    ///     full-replacement edits on v2.0 resources.
+    /// <c>AdditionalAddressService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request
+    /// against <c>/2.0/contact/{contactId}/additional_address/{id}</c> — Bexio uses POST for
+    /// full-replacement edits on v2.0 resources.
     /// </summary>
     [Test]
     public async Task AdditionalAddressService_Update_SendsPostRequest_WithIdInPath()
@@ -237,8 +237,8 @@ public sealed class AdditionalAddressServiceIntegrationTests : IntegrationTestBa
     }
 
     /// <summary>
-    ///     <c>AdditionalAddressService.Delete</c> must issue a <c>DELETE</c> request that includes
-    ///     both the parent contact id and the address id in the URL path.
+    /// <c>AdditionalAddressService.Delete</c> must issue a <c>DELETE</c> request that includes
+    /// both the parent contact id and the address id in the URL path.
     /// </summary>
     [Test]
     public async Task AdditionalAddressService_Delete_SendsDeleteRequest()

--- a/tests/BexioApiNet.IntegrationTests/Contacts/ContactGroupServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Contacts/ContactGroupServiceIntegrationTests.cs
@@ -30,11 +30,11 @@ using BexioApiNet.Services.Connectors.Contacts;
 namespace BexioApiNet.IntegrationTests.Contacts;
 
 /// <summary>
-///     Integration tests covering the CRUD entry points of <see cref="ContactGroupService" /> against
-///     WireMock stubs. Verifies the path composed from <see cref="ContactGroupConfiguration" />
-///     (<c>2.0/contact_group</c>) reaches the handler correctly, that the expected HTTP verbs are used
-///     (including the Bexio-specific <c>POST</c> for edits), and that payloads are serialized with the
-///     expected snake_case field names.
+/// Integration tests covering the CRUD entry points of <see cref="ContactGroupService" /> against
+/// WireMock stubs. Verifies the path composed from <see cref="ContactGroupConfiguration" />
+/// (<c>2.0/contact_group</c>) reaches the handler correctly, that the expected HTTP verbs are used
+/// (including the Bexio-specific <c>POST</c> for edits), and that payloads are serialized with the
+/// expected snake_case field names.
 /// </summary>
 public sealed class ContactGroupServiceIntegrationTests : IntegrationTestBase
 {
@@ -48,9 +48,9 @@ public sealed class ContactGroupServiceIntegrationTests : IntegrationTestBase
                                                 """;
 
     /// <summary>
-    ///     <c>ContactGroupService.Get()</c> must issue a <c>GET</c> request against
-    ///     <c>/2.0/contact_group</c> and return a successful <c>ApiResult</c> when the server
-    ///     returns an empty array.
+    /// <c>ContactGroupService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/contact_group</c> and return a successful <c>ApiResult</c> when the server
+    /// returns an empty array.
     /// </summary>
     [Test]
     public async Task ContactGroupService_Get_SendsGetRequest()
@@ -74,8 +74,8 @@ public sealed class ContactGroupServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactGroupService.GetById</c> must issue a <c>GET</c> request that includes the target
-    ///     id in the URL path and surface the returned contact group on success.
+    /// <c>ContactGroupService.GetById</c> must issue a <c>GET</c> request that includes the target
+    /// id in the URL path and surface the returned contact group on success.
     /// </summary>
     [Test]
     public async Task ContactGroupService_GetById_SendsGetRequest()
@@ -104,9 +104,9 @@ public sealed class ContactGroupServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactGroupService.Create</c> must send a <c>POST</c> request whose body is the
-    ///     serialized <see cref="ContactGroupCreate" /> payload, and must surface the returned contact
-    ///     group on success.
+    /// <c>ContactGroupService.Create</c> must send a <c>POST</c> request whose body is the
+    /// serialized <see cref="ContactGroupCreate" /> payload, and must surface the returned contact
+    /// group on success.
     /// </summary>
     [Test]
     public async Task ContactGroupService_Create_SendsPostRequest()
@@ -135,8 +135,8 @@ public sealed class ContactGroupServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactGroupService.Search</c> must send a <c>POST</c> request against
-    ///     <c>/2.0/contact_group/search</c> with the <see cref="SearchCriteria" /> list as the JSON body.
+    /// <c>ContactGroupService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/contact_group/search</c> with the <see cref="SearchCriteria" /> list as the JSON body.
     /// </summary>
     [Test]
     public async Task ContactGroupService_Search_SendsPostRequest_ToSearchPath()
@@ -169,8 +169,8 @@ public sealed class ContactGroupServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactGroupService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request against
-    ///     <c>/2.0/contact_group/{id}</c> — Bexio uses POST for full-replacement edits on v2.0 resources.
+    /// <c>ContactGroupService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request against
+    /// <c>/2.0/contact_group/{id}</c> — Bexio uses POST for full-replacement edits on v2.0 resources.
     /// </summary>
     [Test]
     public async Task ContactGroupService_Update_SendsPostRequest_WithIdInPath()
@@ -201,8 +201,8 @@ public sealed class ContactGroupServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactGroupService.Delete</c> must issue a <c>DELETE</c> request that includes the
-    ///     target id in the URL path.
+    /// <c>ContactGroupService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    /// target id in the URL path.
     /// </summary>
     [Test]
     public async Task ContactGroupService_Delete_SendsDeleteRequest()

--- a/tests/BexioApiNet.IntegrationTests/Contacts/ContactRelationServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Contacts/ContactRelationServiceIntegrationTests.cs
@@ -30,11 +30,11 @@ using BexioApiNet.Services.Connectors.Contacts;
 namespace BexioApiNet.IntegrationTests.Contacts;
 
 /// <summary>
-///     Integration tests covering the CRUD entry points of <see cref="ContactRelationService" /> against
-///     WireMock stubs. Verifies the path composed from <see cref="ContactRelationConfiguration" />
-///     (<c>2.0/contact_relation</c>) reaches the handler correctly, that the expected HTTP verbs are
-///     used (including the Bexio-specific <c>POST</c> for edits), and that payloads are serialized with
-///     the expected snake_case field names.
+/// Integration tests covering the CRUD entry points of <see cref="ContactRelationService" /> against
+/// WireMock stubs. Verifies the path composed from <see cref="ContactRelationConfiguration" />
+/// (<c>2.0/contact_relation</c>) reaches the handler correctly, that the expected HTTP verbs are
+/// used (including the Bexio-specific <c>POST</c> for edits), and that payloads are serialized with
+/// the expected snake_case field names.
 /// </summary>
 public sealed class ContactRelationServiceIntegrationTests : IntegrationTestBase
 {
@@ -51,9 +51,9 @@ public sealed class ContactRelationServiceIntegrationTests : IntegrationTestBase
                                                    """;
 
     /// <summary>
-    ///     <c>ContactRelationService.Get()</c> must issue a <c>GET</c> request against
-    ///     <c>/2.0/contact_relation</c> and return a successful <c>ApiResult</c> when the server
-    ///     returns an empty array.
+    /// <c>ContactRelationService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/contact_relation</c> and return a successful <c>ApiResult</c> when the server
+    /// returns an empty array.
     /// </summary>
     [Test]
     public async Task ContactRelationService_Get_SendsGetRequest()
@@ -77,8 +77,8 @@ public sealed class ContactRelationServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactRelationService.GetById</c> must issue a <c>GET</c> request that includes the
-    ///     target id in the URL path and surface the returned contact relation on success.
+    /// <c>ContactRelationService.GetById</c> must issue a <c>GET</c> request that includes the
+    /// target id in the URL path and surface the returned contact relation on success.
     /// </summary>
     [Test]
     public async Task ContactRelationService_GetById_SendsGetRequest()
@@ -107,9 +107,9 @@ public sealed class ContactRelationServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactRelationService.Create</c> must send a <c>POST</c> request whose body is the
-    ///     serialized <see cref="ContactRelationCreate" /> payload, and must surface the returned
-    ///     contact relation on success.
+    /// <c>ContactRelationService.Create</c> must send a <c>POST</c> request whose body is the
+    /// serialized <see cref="ContactRelationCreate" /> payload, and must surface the returned
+    /// contact relation on success.
     /// </summary>
     [Test]
     public async Task ContactRelationService_Create_SendsPostRequest()
@@ -142,9 +142,9 @@ public sealed class ContactRelationServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactRelationService.Search</c> must send a <c>POST</c> request against
-    ///     <c>/2.0/contact_relation/search</c> with the <see cref="SearchCriteria" /> list as the
-    ///     JSON body.
+    /// <c>ContactRelationService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/contact_relation/search</c> with the <see cref="SearchCriteria" /> list as the
+    /// JSON body.
     /// </summary>
     [Test]
     public async Task ContactRelationService_Search_SendsPostRequest_ToSearchPath()
@@ -177,9 +177,9 @@ public sealed class ContactRelationServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactRelationService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request
-    ///     against <c>/2.0/contact_relation/{id}</c> — Bexio uses POST for full-replacement edits on
-    ///     v2.0 resources.
+    /// <c>ContactRelationService.Update</c> must send a <c>POST</c> (not <c>PUT</c>) request
+    /// against <c>/2.0/contact_relation/{id}</c> — Bexio uses POST for full-replacement edits on
+    /// v2.0 resources.
     /// </summary>
     [Test]
     public async Task ContactRelationService_Update_SendsPostRequest_WithIdInPath()
@@ -213,8 +213,8 @@ public sealed class ContactRelationServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactRelationService.Delete</c> must issue a <c>DELETE</c> request that includes the
-    ///     target id in the URL path.
+    /// <c>ContactRelationService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    /// target id in the URL path.
     /// </summary>
     [Test]
     public async Task ContactRelationService_Delete_SendsDeleteRequest()

--- a/tests/BexioApiNet.IntegrationTests/Contacts/ContactSectorServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Contacts/ContactSectorServiceIntegrationTests.cs
@@ -29,11 +29,11 @@ using BexioApiNet.Services.Connectors.Contacts;
 namespace BexioApiNet.IntegrationTests.Contacts;
 
 /// <summary>
-///     Integration tests covering the read-only entry points of <see cref="ContactSectorService" /> against
-///     WireMock stubs. The Bexio API exposes contact sectors under the legacy path
-///     <c>2.0/contact_branch</c> (see <see cref="ContactSectorConfiguration" />). This fixture verifies
-///     that the URL is built correctly and that the expected HTTP verbs are used. The service only
-///     supports <c>Get</c> and <c>Search</c> — there are no Create, Update, or Delete endpoints.
+/// Integration tests covering the read-only entry points of <see cref="ContactSectorService" /> against
+/// WireMock stubs. The Bexio API exposes contact sectors under the legacy path
+/// <c>2.0/contact_branch</c> (see <see cref="ContactSectorConfiguration" />). This fixture verifies
+/// that the URL is built correctly and that the expected HTTP verbs are used. The service only
+/// supports <c>Get</c> and <c>Search</c> — there are no Create, Update, or Delete endpoints.
 /// </summary>
 public sealed class ContactSectorServiceIntegrationTests : IntegrationTestBase
 {
@@ -47,9 +47,9 @@ public sealed class ContactSectorServiceIntegrationTests : IntegrationTestBase
                                                  """;
 
     /// <summary>
-    ///     <c>ContactSectorService.Get()</c> must issue a <c>GET</c> request against
-    ///     <c>/2.0/contact_branch</c> and return a successful <c>ApiResult</c> when the server
-    ///     returns an empty array.
+    /// <c>ContactSectorService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/contact_branch</c> and return a successful <c>ApiResult</c> when the server
+    /// returns an empty array.
     /// </summary>
     [Test]
     public async Task ContactSectorService_Get_SendsGetRequest()
@@ -73,9 +73,9 @@ public sealed class ContactSectorServiceIntegrationTests : IntegrationTestBase
     }
 
     /// <summary>
-    ///     <c>ContactSectorService.Search</c> must send a <c>POST</c> request against
-    ///     <c>/2.0/contact_branch/search</c> with the <see cref="SearchCriteria" /> list as the JSON
-    ///     body.
+    /// <c>ContactSectorService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/contact_branch/search</c> with the <see cref="SearchCriteria" /> list as the JSON
+    /// body.
     /// </summary>
     [Test]
     public async Task ContactSectorService_Search_SendsPostRequest_ToSearchPath()

--- a/tests/BexioApiNet.IntegrationTests/Sales/OrderServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Sales/OrderServiceIntegrationTests.cs
@@ -23,8 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
 using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
 using BexioApiNet.Abstractions.Models.Sales.Orders.Views;
 using BexioApiNet.Services.Connectors.Sales;
 
@@ -468,10 +468,9 @@ public sealed class OrderServiceIntegrationTests : IntegrationTestBase
 
         var service = new OrderService(ConnectionHandler);
 
-        using var repetition = JsonDocument.Parse("""{"type":"daily","interval":1}""");
         var payload = new OrderRepetitionCreate(
             Start: "2026-04-01",
-            Repetition: repetition.RootElement.Clone());
+            Repetition: new OrderRepetitionDaily { Interval = 1 });
 
         var result = await service.CreateRepetition(id, payload, TestContext.CurrentContext.CancellationToken);
 

--- a/tests/BexioApiNet.UnitTests/Accounting/BusinessYearServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/BusinessYearServiceTests.cs
@@ -33,9 +33,9 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.UnitTests.Accounting;
 
 /// <summary>
-///     Offline unit tests for <see cref="BusinessYearService" />. Verifies the connector
-///     builds the right request path, forwards cancellation tokens, and surfaces the
-///     connection handler's <see cref="ApiResult{T}" /> back to the caller unchanged.
+/// Offline unit tests for <see cref="BusinessYearService" />. Verifies the connector
+/// builds the right request path, forwards cancellation tokens, and surfaces the
+/// connection handler's <see cref="ApiResult{T}" /> back to the caller unchanged.
 /// </summary>
 [TestFixture]
 public sealed class BusinessYearServiceTests : ServiceTestBase
@@ -43,9 +43,9 @@ public sealed class BusinessYearServiceTests : ServiceTestBase
     private const string ExpectedListPath = "3.0/accounting/business_years";
 
     /// <summary>
-    ///     With no parameters the service hits <c>3.0/accounting/business_years</c>
-    ///     exactly once with a <see langword="null" /> query parameter and returns the
-    ///     connection handler's <see cref="ApiResult{T}" /> as-is.
+    /// With no parameters the service hits <c>3.0/accounting/business_years</c>
+    /// exactly once with a <see langword="null" /> query parameter and returns the
+    /// connection handler's <see cref="ApiResult{T}" /> as-is.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
@@ -71,8 +71,8 @@ public sealed class BusinessYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     When a <see cref="QueryParameterBusinessYear" /> is passed, its serialized
-    ///     <see cref="QueryParameter" /> is forwarded to the connection handler.
+    /// When a <see cref="QueryParameterBusinessYear" /> is passed, its serialized
+    /// <see cref="QueryParameter" /> is forwarded to the connection handler.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_ForwardsQueryParameterToConnectionHandler()
@@ -93,8 +93,8 @@ public sealed class BusinessYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     The cancellation token supplied by the caller must be forwarded to the
-    ///     connection handler so cooperative cancellation flows end-to-end.
+    /// The cancellation token supplied by the caller must be forwarded to the
+    /// connection handler so cooperative cancellation flows end-to-end.
     /// </summary>
     [Test]
     public async Task Get_ForwardsCancellationTokenToConnectionHandler()
@@ -115,8 +115,8 @@ public sealed class BusinessYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     A failing <see cref="ApiResult{T}" /> from the connection handler must
-    ///     surface to the caller untouched — the service may not swallow errors.
+    /// A failing <see cref="ApiResult{T}" /> from the connection handler must
+    /// surface to the caller untouched — the service may not swallow errors.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResultFromConnectionHandlerUnchanged()
@@ -141,8 +141,8 @@ public sealed class BusinessYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <see cref="BusinessYearService.GetById" /> must substitute the id into the
-    ///     path and call <c>GetAsync</c> with a null query parameter.
+    /// <see cref="BusinessYearService.GetById" /> must substitute the id into the
+    /// path and call <c>GetAsync</c> with a null query parameter.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsyncWithIdInPath()
@@ -169,8 +169,8 @@ public sealed class BusinessYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <see cref="BusinessYearService.GetById" /> forwards the caller's cancellation
-    ///     token to the connection handler.
+    /// <see cref="BusinessYearService.GetById" /> forwards the caller's cancellation
+    /// token to the connection handler.
     /// </summary>
     [Test]
     public async Task GetById_ForwardsCancellationTokenToConnectionHandler()

--- a/tests/BexioApiNet.UnitTests/Accounting/CalendarYearServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/CalendarYearServiceTests.cs
@@ -34,16 +34,16 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.UnitTests.Accounting;
 
 /// <summary>
-///     Offline unit tests for <see cref="CalendarYearService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="CalendarYearService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class CalendarYearServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="CalendarYearService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="CalendarYearService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -56,8 +56,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     private CalendarYearService _sut = null!;
 
     /// <summary>
-    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
-    ///     the expected endpoint path and a null query parameter.
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    /// the expected endpoint path and a null query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsync()
@@ -79,8 +79,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the <see cref="QueryParameterCalendarYear" /> to the connection handler so
-    ///     limit/offset reach the server.
+    /// Get forwards the <see cref="QueryParameterCalendarYear" /> to the connection handler so
+    /// limit/offset reach the server.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_ForwardsQueryParameter()
@@ -103,9 +103,9 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
-    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
-    ///     the full result set.
+    /// Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    /// the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    /// the full result set.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -147,8 +147,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
-    ///     auto-paging is not requested (no additional FetchAll round-trip, result passes through).
+    /// Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    /// auto-paging is not requested (no additional FetchAll round-trip, result passes through).
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResult()
@@ -167,8 +167,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected path
-    ///     containing the id and no query parameter.
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected path
+    /// containing the id and no query parameter.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsync()
@@ -191,8 +191,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without
-    ///     modification.
+    /// GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    /// modification.
     /// </summary>
     [Test]
     public async Task GetById_ReturnsApiResultFromConnectionHandler()
@@ -211,8 +211,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create forwards the payload and the expected endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// Create forwards the payload and the expected endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsync()
@@ -235,8 +235,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without
-    ///     modification.
+    /// Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    /// modification.
     /// </summary>
     [Test]
     public async Task Create_ReturnsApiResultFromConnectionHandler()
@@ -256,8 +256,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the criteria list, the expected <c>/search</c> endpoint and the optional
-    ///     query parameter to <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// Search forwards the criteria list, the expected <c>/search</c> endpoint and the optional
+    /// query parameter to <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task Search_CallsPostSearchAsync()
@@ -285,8 +285,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the <see cref="QueryParameterCalendarYear" /> to the connection handler so
-    ///     limit/offset reach the server alongside the search body.
+    /// Search forwards the <see cref="QueryParameterCalendarYear" /> to the connection handler so
+    /// limit/offset reach the server alongside the search body.
     /// </summary>
     [Test]
     public async Task Search_WithQueryParameter_ForwardsQueryParameter()
@@ -315,8 +315,8 @@ public sealed class CalendarYearServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search returns the <see cref="ApiResult{T}" /> produced by the connection handler without
-    ///     modification.
+    /// Search returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    /// modification.
     /// </summary>
     [Test]
     public async Task Search_ReturnsApiResultFromConnectionHandler()

--- a/tests/BexioApiNet.UnitTests/Accounting/CurrencyServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/CurrencyServiceTests.cs
@@ -33,16 +33,16 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.UnitTests.Accounting;
 
 /// <summary>
-///     Offline unit tests for <see cref="CurrencyService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's <see cref="ApiResult{T}" /> unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="CurrencyService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's <see cref="ApiResult{T}" /> unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class CurrencyServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="CurrencyService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="CurrencyService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -55,9 +55,9 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     private CurrencyService _sut = null!;
 
     /// <summary>
-    ///     With no parameters the service hits <c>3.0/currencies</c> exactly once
-    ///     with a <see langword="null" /> query parameter and returns the connection
-    ///     handler's <see cref="ApiResult{T}" /> as-is.
+    /// With no parameters the service hits <c>3.0/currencies</c> exactly once
+    /// with a <see langword="null" /> query parameter and returns the connection
+    /// handler's <see cref="ApiResult{T}" /> as-is.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
@@ -81,8 +81,8 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     The cancellation token supplied by the caller must be forwarded to the
-    ///     connection handler so cooperative cancellation flows end-to-end.
+    /// The cancellation token supplied by the caller must be forwarded to the
+    /// connection handler so cooperative cancellation flows end-to-end.
     /// </summary>
     [Test]
     public async Task Get_ForwardsCancellationTokenToConnectionHandler()
@@ -101,8 +101,8 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     A failing <see cref="ApiResult{T}" /> from the connection handler must
-    ///     surface to the caller untouched — the service may not swallow errors.
+    /// A failing <see cref="ApiResult{T}" /> from the connection handler must
+    /// surface to the caller untouched — the service may not swallow errors.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResultFromConnectionHandlerUnchanged()
@@ -125,8 +125,8 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <c>GetCodes</c> must hit <c>3.0/currencies/codes</c> exactly once
-    ///     with a <see langword="null" /> query parameter.
+    /// <c>GetCodes</c> must hit <c>3.0/currencies/codes</c> exactly once
+    /// with a <see langword="null" /> query parameter.
     /// </summary>
     [Test]
     public async Task GetCodes_CallsGetAsyncWithCodesPath()
@@ -150,7 +150,7 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <c>GetCodes</c> forwards the supplied cancellation token to the connection handler.
+    /// <c>GetCodes</c> forwards the supplied cancellation token to the connection handler.
     /// </summary>
     [Test]
     public async Task GetCodes_ForwardsCancellationTokenToConnectionHandler()
@@ -169,8 +169,8 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <c>GetById</c> must build the request path with the currency id appended to the endpoint
-    ///     root and hit the handler exactly once.
+    /// <c>GetById</c> must build the request path with the currency id appended to the endpoint
+    /// root and hit the handler exactly once.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsyncWithIdInPath()
@@ -195,9 +195,9 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <c>GetExchangeRates</c> calls the handler with the nested
-    ///     <c>3.0/currencies/{id}/exchange_rates</c> path and a <see langword="null" /> query parameter
-    ///     when no date filter is supplied.
+    /// <c>GetExchangeRates</c> calls the handler with the nested
+    /// <c>3.0/currencies/{id}/exchange_rates</c> path and a <see langword="null" /> query parameter
+    /// when no date filter is supplied.
     /// </summary>
     [Test]
     public async Task GetExchangeRates_WithNoQueryParameter_CallsGetAsyncWithExpectedPath()
@@ -222,9 +222,9 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     When a <see cref="QueryParameterExchangeRate" /> is supplied with a date, the wrapped
-    ///     <see cref="QueryParameter" /> must be passed through to the connection handler so the
-    ///     <c>date</c> filter reaches the API.
+    /// When a <see cref="QueryParameterExchangeRate" /> is supplied with a date, the wrapped
+    /// <see cref="QueryParameter" /> must be passed through to the connection handler so the
+    /// <c>date</c> filter reaches the API.
     /// </summary>
     [Test]
     public async Task GetExchangeRates_WithDateQueryParameter_PassesQueryParameterToHandler()
@@ -249,8 +249,8 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <c>Create</c> forwards the payload and the <c>3.0/currencies</c> endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// <c>Create</c> forwards the payload and the <c>3.0/currencies</c> endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsyncWithExpectedPath()
@@ -278,8 +278,8 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <c>Patch</c> forwards the patch payload and the <c>3.0/currencies/{id}</c> endpoint path
-    ///     to <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}" />.
+    /// <c>Patch</c> forwards the patch payload and the <c>3.0/currencies/{id}</c> endpoint path
+    /// to <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}" />.
     /// </summary>
     [Test]
     public async Task Patch_CallsPatchAsyncWithIdInPath()
@@ -308,8 +308,8 @@ public sealed class CurrencyServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     <c>Delete</c> forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly
-    ///     once, building the path with the currency id.
+    /// <c>Delete</c> forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly
+    /// once, building the path with the currency id.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()

--- a/tests/BexioApiNet.UnitTests/Accounting/ManualEntryServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Accounting/ManualEntryServiceTests.cs
@@ -34,16 +34,16 @@ using BexioApiNet.Services.Connectors.Accounting;
 namespace BexioApiNet.UnitTests.Accounting;
 
 /// <summary>
-///     Offline unit tests for <see cref="ManualEntryService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="ManualEntryService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class ManualEntryServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="ManualEntryService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="ManualEntryService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -56,8 +56,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     private ManualEntryService _sut = null!;
 
     /// <summary>
-    ///     Create forwards the payload and the expected endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// Create forwards the payload and the expected endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsync()
@@ -80,8 +80,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without
-    ///     modification.
+    /// Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    /// modification.
     /// </summary>
     [Test]
     public async Task Create_ReturnsApiResultFromConnectionHandler()
@@ -101,8 +101,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     AddAttachment (MemoryStream overload) forwards the provided file tuples to
-    ///     <see cref="IBexioConnectionHandler.PostMultiPartFileAsync{TResult}" />.
+    /// AddAttachment (MemoryStream overload) forwards the provided file tuples to
+    /// <see cref="IBexioConnectionHandler.PostMultiPartFileAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task AddAttachment_WithStreams_CallsPostMultiPartFileAsync()
@@ -132,8 +132,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     AddAttachment builds the request path from the root manual-entries id and the nested
-    ///     manual-entry id. Both identifiers must be present in the final URL.
+    /// AddAttachment builds the request path from the root manual-entries id and the nested
+    /// manual-entry id. Both identifiers must be present in the final URL.
     /// </summary>
     [Test]
     public async Task AddAttachment_PathContainsManuelEntriesIdAndManuelEntryId()
@@ -163,8 +163,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
-    ///     the expected endpoint path and a null query parameter.
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    /// the expected endpoint path and a null query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsync()
@@ -186,9 +186,9 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
-    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
-    ///     the full result set.
+    /// Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    /// the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    /// the full result set.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -230,8 +230,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
-    ///     auto-paging is not requested (no additional FetchAll round-trip, result passes through).
+    /// Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    /// auto-paging is not requested (no additional FetchAll round-trip, result passes through).
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResult()
@@ -250,7 +250,7 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly once.
+    /// Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly once.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDelete()
@@ -268,7 +268,7 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete builds the request path with the manual-entry id appended to the endpoint root.
+    /// Delete builds the request path with the manual-entry id appended to the endpoint root.
     /// </summary>
     [Test]
     public async Task Delete_PathContainsId()
@@ -288,8 +288,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Put forwards the payload and builds the path <c>{endpoint}/{manualEntryId}</c> via
-    ///     <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}" />.
+    /// Put forwards the payload and builds the path <c>{endpoint}/{manualEntryId}</c> via
+    /// <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}" />.
     /// </summary>
     [Test]
     public async Task Put_CallsPutAsyncWithExpectedPath()
@@ -315,7 +315,7 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Put returns the <see cref="ApiResult{T}" /> produced by the connection handler unchanged.
+    /// Put returns the <see cref="ApiResult{T}" /> produced by the connection handler unchanged.
     /// </summary>
     [Test]
     public async Task Put_ReturnsApiResultFromConnectionHandler()
@@ -335,8 +335,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetNextRefNr builds <c>{endpoint}/next_ref_nr</c> and forwards to
-    ///     <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with a null query parameter.
+    /// GetNextRefNr builds <c>{endpoint}/next_ref_nr</c> and forwards to
+    /// <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with a null query parameter.
     /// </summary>
     [Test]
     public async Task GetNextRefNr_CallsGetAsyncWithExpectedPath()
@@ -358,8 +358,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetFiles (no auto-page) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once
-    ///     with the expected compound-entry file listing path and does not trigger FetchAll.
+    /// GetFiles (no auto-page) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once
+    /// with the expected compound-entry file listing path and does not trigger FetchAll.
     /// </summary>
     [Test]
     public async Task GetFiles_WithoutAutoPage_CallsGetAsyncWithExpectedPath()
@@ -388,9 +388,9 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetFiles (autoPage = true) triggers
-    ///     <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when the <c>X-Total-Count</c>
-    ///     header is present and the initial response only returned a page.
+    /// GetFiles (autoPage = true) triggers
+    /// <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when the <c>X-Total-Count</c>
+    /// header is present and the initial response only returned a page.
     /// </summary>
     [Test]
     public async Task GetFiles_WithAutoPage_CallsFetchAll()
@@ -433,8 +433,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetFileById builds <c>{endpoint}/{manualEntryId}/files/{fileId}</c> and forwards via
-    ///     <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
+    /// GetFileById builds <c>{endpoint}/{manualEntryId}/files/{fileId}</c> and forwards via
+    /// <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task GetFileById_CallsGetAsyncWithExpectedPath()
@@ -458,8 +458,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetEntryFiles builds <c>{endpoint}/{manualEntryId}/entries/{entryId}/files</c> and forwards
-    ///     via <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
+    /// GetEntryFiles builds <c>{endpoint}/{manualEntryId}/entries/{entryId}/files</c> and forwards
+    /// via <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task GetEntryFiles_CallsGetAsyncWithExpectedPath()
@@ -483,8 +483,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetEntryFiles (autoPage = true) triggers
-    ///     <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> on the entry-files path.
+    /// GetEntryFiles (autoPage = true) triggers
+    /// <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> on the entry-files path.
     /// </summary>
     [Test]
     public async Task GetEntryFiles_WithAutoPage_CallsFetchAllOnEntryPath()
@@ -528,8 +528,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetEntryFileById builds <c>{endpoint}/{manualEntryId}/entries/{entryId}/files/{fileId}</c>
-    ///     and forwards via <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
+    /// GetEntryFileById builds <c>{endpoint}/{manualEntryId}/entries/{entryId}/files/{fileId}</c>
+    /// and forwards via <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task GetEntryFileById_CallsGetAsyncWithExpectedPath()
@@ -554,8 +554,8 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     DeleteFile builds the request path <c>{endpoint}/{manualEntryId}/files/{fileId}</c> and
-    ///     forwards to <see cref="IBexioConnectionHandler.Delete" />.
+    /// DeleteFile builds the request path <c>{endpoint}/{manualEntryId}/files/{fileId}</c> and
+    /// forwards to <see cref="IBexioConnectionHandler.Delete" />.
     /// </summary>
     [Test]
     public async Task DeleteFile_CallsDeleteWithExpectedPath()
@@ -575,9 +575,9 @@ public sealed class ManualEntryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     DeleteEntryFile builds the request path
-    ///     <c>{endpoint}/{manualEntryId}/entries/{entryId}/files/{fileId}</c> and forwards to
-    ///     <see cref="IBexioConnectionHandler.Delete" />.
+    /// DeleteEntryFile builds the request path
+    /// <c>{endpoint}/{manualEntryId}/entries/{entryId}/files/{fileId}</c> and forwards to
+    /// <see cref="IBexioConnectionHandler.Delete" />.
     /// </summary>
     [Test]
     public async Task DeleteEntryFile_CallsDeleteWithExpectedPath()

--- a/tests/BexioApiNet.UnitTests/Banking/PaymentTypeServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Banking/PaymentTypeServiceTests.cs
@@ -33,10 +33,10 @@ using BexioApiNet.Services.Connectors.Banking;
 namespace BexioApiNet.UnitTests.Banking;
 
 /// <summary>
-///     Offline unit tests for <see cref="PaymentTypeService" />. The service is a
-///     thin pass-through over <see cref="IBexioConnectionHandler.GetAsync{T}" /> and
-///     <see cref="IBexioConnectionHandler.PostSearchAsync{T}" />, so verification
-///     focuses on path, verb, body, query parameter, and pass-through semantics.
+/// Offline unit tests for <see cref="PaymentTypeService" />. The service is a
+/// thin pass-through over <see cref="IBexioConnectionHandler.GetAsync{T}" /> and
+/// <see cref="IBexioConnectionHandler.PostSearchAsync{T}" />, so verification
+/// focuses on path, verb, body, query parameter, and pass-through semantics.
 /// </summary>
 [TestFixture]
 public sealed class PaymentTypeServiceTests : ServiceTestBase
@@ -45,9 +45,9 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     private const string ExpectedSearchPath = "2.0/payment_type/search";
 
     /// <summary>
-    ///     With no parameters the service hits <c>2.0/payment_type</c> exactly once
-    ///     with a <see langword="null" /> query parameter and returns the connection
-    ///     handler's <see cref="ApiResult{T}" /> as-is.
+    /// With no parameters the service hits <c>2.0/payment_type</c> exactly once
+    /// with a <see langword="null" /> query parameter and returns the connection
+    /// handler's <see cref="ApiResult{T}" /> as-is.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
@@ -73,9 +73,9 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     When a <see cref="QueryParameterPaymentType" /> is supplied, its inner
-    ///     <see cref="QueryParameter" /> instance is forwarded to the connection
-    ///     handler verbatim — the service must not rewrap or substitute it.
+    /// When a <see cref="QueryParameterPaymentType" /> is supplied, its inner
+    /// <see cref="QueryParameter" /> instance is forwarded to the connection
+    /// handler verbatim — the service must not rewrap or substitute it.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
@@ -96,10 +96,10 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     When <c>autoPage</c> is on and the first response advertises a
-    ///     <c>X-Total-Count</c> header, the service must call <c>FetchAll</c> with
-    ///     the count of already-fetched items, the total, the same path, and the
-    ///     same query parameter.
+    /// When <c>autoPage</c> is on and the first response advertises a
+    /// <c>X-Total-Count</c> header, the service must call <c>FetchAll</c> with
+    /// the count of already-fetched items, the total, the same path, and the
+    /// same query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
@@ -137,9 +137,9 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     When <c>autoPage</c> is requested but the response carries no
-    ///     <c>X-Total-Count</c> header, the service must not invoke <c>FetchAll</c>
-    ///     — there is nothing more to fetch.
+    /// When <c>autoPage</c> is requested but the response carries no
+    /// <c>X-Total-Count</c> header, the service must not invoke <c>FetchAll</c>
+    /// — there is nothing more to fetch.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
@@ -168,8 +168,8 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     The cancellation token supplied by the caller must be forwarded to the
-    ///     connection handler so cooperative cancellation flows end-to-end.
+    /// The cancellation token supplied by the caller must be forwarded to the
+    /// connection handler so cooperative cancellation flows end-to-end.
     /// </summary>
     [Test]
     public async Task Get_ForwardsCancellationTokenToConnectionHandler()
@@ -190,8 +190,8 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     A failing <see cref="ApiResult{T}" /> from the connection handler must
-    ///     surface to the caller untouched — the service may not swallow errors.
+    /// A failing <see cref="ApiResult{T}" /> from the connection handler must
+    /// surface to the caller untouched — the service may not swallow errors.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResultFromConnectionHandlerUnchanged()
@@ -216,10 +216,10 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     With a search body and no query parameter, the service POSTs the criteria
-    ///     list to <c>2.0/payment_type/search</c> with a <see langword="null" /> query
-    ///     parameter and returns the connection handler's <see cref="ApiResult{T}" />
-    ///     unchanged.
+    /// With a search body and no query parameter, the service POSTs the criteria
+    /// list to <c>2.0/payment_type/search</c> with a <see langword="null" /> query
+    /// parameter and returns the connection handler's <see cref="ApiResult{T}" />
+    /// unchanged.
     /// </summary>
     [Test]
     public async Task Search_WithCriteria_CallsPostSearchAsyncWithExpectedPath()
@@ -251,10 +251,10 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     When a <see cref="QueryParameterPaymentType" /> is supplied to
-    ///     <see cref="PaymentTypeService.Search" />, its inner <see cref="QueryParameter" />
-    ///     must flow to the connection handler verbatim so pagination and sort flags
-    ///     are preserved on the wire.
+    /// When a <see cref="QueryParameterPaymentType" /> is supplied to
+    /// <see cref="PaymentTypeService.Search" />, its inner <see cref="QueryParameter" />
+    /// must flow to the connection handler verbatim so pagination and sort flags
+    /// are preserved on the wire.
     /// </summary>
     [Test]
     public async Task Search_WithQueryParameter_PassesQueryParameterToConnectionHandler()
@@ -281,8 +281,8 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     The cancellation token supplied by the caller to <see cref="PaymentTypeService.Search" />
-    ///     must be forwarded to the connection handler unchanged.
+    /// The cancellation token supplied by the caller to <see cref="PaymentTypeService.Search" />
+    /// must be forwarded to the connection handler unchanged.
     /// </summary>
     [Test]
     public async Task Search_ForwardsCancellationTokenToConnectionHandler()
@@ -309,9 +309,9 @@ public sealed class PaymentTypeServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     A failing <see cref="ApiResult{T}" /> from the connection handler must
-    ///     surface to the caller untouched — <see cref="PaymentTypeService.Search" />
-    ///     may not swallow or remap errors.
+    /// A failing <see cref="ApiResult{T}" /> from the connection handler must
+    /// surface to the caller untouched — <see cref="PaymentTypeService.Search" />
+    /// may not swallow or remap errors.
     /// </summary>
     [Test]
     public async Task Search_ReturnsApiResultFromConnectionHandlerUnchanged()

--- a/tests/BexioApiNet.UnitTests/Contacts/AdditionalAddressServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Contacts/AdditionalAddressServiceTests.cs
@@ -33,10 +33,10 @@ using BexioApiNet.Services.Connectors.Contacts;
 namespace BexioApiNet.UnitTests.Contacts;
 
 /// <summary>
-///     Offline unit tests for <see cref="AdditionalAddressService" />. Each test verifies that the
-///     service forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected
-///     arguments (including the nested <c>contact_id</c> segment) and returns the handler's
-///     result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="AdditionalAddressService" />. Each test verifies that the
+/// service forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected
+/// arguments (including the nested <c>contact_id</c> segment) and returns the handler's
+/// result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class AdditionalAddressServiceTests : ServiceTestBase
@@ -48,8 +48,8 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     private AdditionalAddressService _sut = null!;
 
     /// <summary>
-    ///     Creates a fresh <see cref="AdditionalAddressService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="AdditionalAddressService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -58,8 +58,8 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the expected nested path to <see cref="IBexioConnectionHandler.GetAsync{T}" />
-    ///     and returns the handler's <see cref="ApiResult{T}" /> unchanged.
+    /// Get forwards the expected nested path to <see cref="IBexioConnectionHandler.GetAsync{T}" />
+    /// and returns the handler's <see cref="ApiResult{T}" /> unchanged.
     /// </summary>
     [Test]
     public async Task Get_CallsGetAsyncWithExpectedPath()
@@ -79,7 +79,7 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the inner <see cref="QueryParameter" /> from the typed wrapper verbatim.
+    /// Get forwards the inner <see cref="QueryParameter" /> from the typed wrapper verbatim.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_ForwardsInnerQueryParameter()
@@ -98,8 +98,8 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get with <c>autoPage=true</c> triggers <see cref="IBexioConnectionHandler.FetchAll{T}" />
-    ///     when the response carries a non-null <c>X-Total-Count</c> header.
+    /// Get with <c>autoPage=true</c> triggers <see cref="IBexioConnectionHandler.FetchAll{T}" />
+    /// when the response carries a non-null <c>X-Total-Count</c> header.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -133,7 +133,7 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById hits the single-resource path with both the contact id and the address id.
+    /// GetById hits the single-resource path with both the contact id and the address id.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsyncWithExpectedPath()
@@ -154,8 +154,8 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create forwards the payload to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />
-    ///     against the collection path.
+    /// Create forwards the payload to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />
+    /// against the collection path.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsyncWithExpectedPathAndPayload()
@@ -179,8 +179,8 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search hits the nested <c>/search</c> path via
-    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> with the provided criteria.
+    /// Search hits the nested <c>/search</c> path via
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> with the provided criteria.
     /// </summary>
     [Test]
     public async Task Search_CallsPostSearchAsyncWithExpectedPathAndCriteria()
@@ -209,7 +209,7 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the optional typed query parameter to the handler (for limit/offset).
+    /// Search forwards the optional typed query parameter to the handler (for limit/offset).
     /// </summary>
     [Test]
     public async Task Search_WithQueryParameter_ForwardsInnerQueryParameter()
@@ -237,8 +237,8 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Update forwards the payload to the single-resource path via the connection handler's
-    ///     update hook. The Bexio edit endpoint uses HTTP <c>POST</c> rather than <c>PUT</c>.
+    /// Update forwards the payload to the single-resource path via the connection handler's
+    /// update hook. The Bexio edit endpoint uses HTTP <c>POST</c> rather than <c>PUT</c>.
     /// </summary>
     [Test]
     public async Task Update_CallsUpdateWithExpectedPathAndPayload()
@@ -264,8 +264,8 @@ public sealed class AdditionalAddressServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with both
-    ///     the parent contact id and the address id in the path.
+    /// Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with both
+    /// the parent contact id and the address id in the path.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDelete()

--- a/tests/BexioApiNet.UnitTests/Contacts/ContactRelationServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Contacts/ContactRelationServiceTests.cs
@@ -33,9 +33,9 @@ using BexioApiNet.Services.Connectors.Contacts;
 namespace BexioApiNet.UnitTests.Contacts;
 
 /// <summary>
-///     Offline unit tests for <see cref="ContactRelationService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="ContactRelationService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class ContactRelationServiceTests : ServiceTestBase
@@ -45,8 +45,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     private ContactRelationService _sut = null!;
 
     /// <summary>
-    ///     Creates a fresh <see cref="ContactRelationService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="ContactRelationService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -55,8 +55,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
-    ///     the expected endpoint path and a null query parameter.
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    /// the expected endpoint path and a null query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsync()
@@ -78,8 +78,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the wrapped <see cref="QueryParameter"/> from a typed
-    ///     <see cref="QueryParameterContactRelation"/> to the connection handler.
+    /// Get forwards the wrapped <see cref="QueryParameter"/> from a typed
+    /// <see cref="QueryParameterContactRelation"/> to the connection handler.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_ForwardsQueryParameter()
@@ -102,9 +102,9 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
-    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
-    ///     the full result set.
+    /// Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    /// the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    /// the full result set.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -146,8 +146,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
-    ///     auto-paging is not requested.
+    /// Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    /// auto-paging is not requested.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResult()
@@ -166,8 +166,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById forwards the call to <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with
-    ///     the endpoint path that includes the supplied id.
+    /// GetById forwards the call to <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with
+    /// the endpoint path that includes the supplied id.
     /// </summary>
     [Test]
     public async Task GetById_PathContainsId()
@@ -188,8 +188,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without
-    ///     modification.
+    /// GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    /// modification.
     /// </summary>
     [Test]
     public async Task GetById_ReturnsApiResultFromConnectionHandler()
@@ -212,8 +212,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create forwards the payload and the expected endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// Create forwards the payload and the expected endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsync()
@@ -236,8 +236,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without
-    ///     modification.
+    /// Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    /// modification.
     /// </summary>
     [Test]
     public async Task Create_ReturnsApiResultFromConnectionHandler()
@@ -257,8 +257,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the provided criteria list to
-    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> with the search endpoint path.
+    /// Search forwards the provided criteria list to
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> with the search endpoint path.
     /// </summary>
     [Test]
     public async Task Search_CallsPostSearchAsync()
@@ -286,8 +286,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the optional <see cref="QueryParameterContactRelation"/> through to the
-    ///     connection handler as a <see cref="QueryParameter"/>.
+    /// Search forwards the optional <see cref="QueryParameterContactRelation"/> through to the
+    /// connection handler as a <see cref="QueryParameter"/>.
     /// </summary>
     [Test]
     public async Task Search_WithQueryParameter_ForwardsQueryParameter()
@@ -316,9 +316,9 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Update forwards the payload and the id-scoped endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />. Bexio v2.0 endpoints
-    ///     use HTTP POST on the resource URL to perform an edit.
+    /// Update forwards the payload and the id-scoped endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />. Bexio v2.0 endpoints
+    /// use HTTP POST on the resource URL to perform an edit.
     /// </summary>
     [Test]
     public async Task Update_CallsPostAsync_WithIdInPath()
@@ -344,8 +344,8 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Update returns the <see cref="ApiResult{T}" /> produced by the connection handler without
-    ///     modification.
+    /// Update returns the <see cref="ApiResult{T}" /> produced by the connection handler without
+    /// modification.
     /// </summary>
     [Test]
     public async Task Update_ReturnsApiResultFromConnectionHandler()
@@ -365,7 +365,7 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly once.
+    /// Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly once.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDelete()
@@ -383,7 +383,7 @@ public sealed class ContactRelationServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete builds the request path with the contact-relation id appended to the endpoint root.
+    /// Delete builds the request path with the contact-relation id appended to the endpoint root.
     /// </summary>
     [Test]
     public async Task Delete_PathContainsId()

--- a/tests/BexioApiNet.UnitTests/Contacts/ContactServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Contacts/ContactServiceTests.cs
@@ -33,16 +33,16 @@ using BexioApiNet.Services.Connectors.Contacts;
 namespace BexioApiNet.UnitTests.Contacts;
 
 /// <summary>
-///     Offline unit tests for <see cref="ContactService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="ContactService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class ContactServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="ContactService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="ContactService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -55,8 +55,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     private ContactService _sut = null!;
 
     /// <summary>
-    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
-    ///     the expected endpoint path and a null query parameter.
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    /// the expected endpoint path and a null query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsync()
@@ -78,8 +78,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the <see cref="QueryParameterContact" />'s underlying <see cref="QueryParameter" />
-    ///     to the connection handler so the caller's filters (limit/offset/order_by/show_archived) reach the API.
+    /// Get forwards the <see cref="QueryParameterContact" />'s underlying <see cref="QueryParameter" />
+    /// to the connection handler so the caller's filters (limit/offset/order_by/show_archived) reach the API.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
@@ -102,9 +102,9 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
-    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
-    ///     the full result set.
+    /// Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    /// the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    /// the full result set.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -146,8 +146,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
-    ///     auto-paging is not requested (no additional FetchAll round-trip, result passes through).
+    /// Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    /// auto-paging is not requested (no additional FetchAll round-trip, result passes through).
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResult()
@@ -166,8 +166,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
-    ///     endpoint path including the contact id.
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    /// endpoint path including the contact id.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsync_WithIdInPath()
@@ -188,7 +188,7 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without modification.
+    /// GetById returns the <see cref="ApiResult{T}" /> produced by the connection handler without modification.
     /// </summary>
     [Test]
     public async Task GetById_ReturnsApiResultFromConnectionHandler()
@@ -207,8 +207,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create forwards the payload and the expected endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// Create forwards the payload and the expected endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsync()
@@ -231,7 +231,7 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without modification.
+    /// Create returns the <see cref="ApiResult{T}" /> produced by the connection handler without modification.
     /// </summary>
     [Test]
     public async Task Create_ReturnsApiResultFromConnectionHandler()
@@ -251,8 +251,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     BulkCreate forwards the list of payloads and the <c>/_bulk_create</c> path to
-    ///     <see cref="IBexioConnectionHandler.PostBulkAsync{TResult,TCreate}" />.
+    /// BulkCreate forwards the list of payloads and the <c>/_bulk_create</c> path to
+    /// <see cref="IBexioConnectionHandler.PostBulkAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task BulkCreate_CallsPostBulkAsync()
@@ -275,8 +275,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
-    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task Search_CallsPostSearchAsync()
@@ -305,8 +305,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
-    ///     <c>/2.0/contact/{id}</c> — Bexio edits contacts via POST on this resource.
+    /// Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
+    /// <c>/2.0/contact/{id}</c> — Bexio edits contacts via POST on this resource.
     /// </summary>
     [Test]
     public async Task Update_CallsPostAsync_WithIdInPath()
@@ -332,8 +332,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Restore calls <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}" /> at
-    ///     <c>/2.0/contact/{id}/restore</c> with a <see langword="null" /> payload (no request body).
+    /// Restore calls <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}" /> at
+    /// <c>/2.0/contact/{id}/restore</c> with a <see langword="null" /> payload (no request body).
     /// </summary>
     [Test]
     public async Task Restore_CallsPatchAsync_WithRestoreInPath_AndNullPayload()
@@ -358,8 +358,8 @@ public sealed class ContactServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the contact id
-    ///     appended to the endpoint root.
+    /// Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the contact id
+    /// appended to the endpoint root.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()

--- a/tests/BexioApiNet.UnitTests/Infrastructure/BexioConnectionHandlerTests.cs
+++ b/tests/BexioApiNet.UnitTests/Infrastructure/BexioConnectionHandlerTests.cs
@@ -33,12 +33,12 @@ using BexioApiNet.Models;
 namespace BexioApiNet.UnitTests.Infrastructure;
 
 /// <summary>
-///     Unit tests for <see cref="BexioConnectionHandler" />. These tests exercise the real
-///     implementation with a hand-rolled stub <see cref="HttpMessageHandler" /> so no network
-///     traffic occurs. They cover request construction, query-parameter serialization,
-///     <see cref="ApiResult{T}" /> mapping for success/error/redirect responses, response
-///     header extraction, cancellation propagation and the <see cref="IDisposable" /> contract
-///     including the owned-vs-borrowed <see cref="HttpClient" /> branching.
+/// Unit tests for <see cref="BexioConnectionHandler" />. These tests exercise the real
+/// implementation with a hand-rolled stub <see cref="HttpMessageHandler" /> so no network
+/// traffic occurs. They cover request construction, query-parameter serialization,
+/// <see cref="ApiResult{T}" /> mapping for success/error/redirect responses, response
+/// header extraction, cancellation propagation and the <see cref="IDisposable" /> contract
+/// including the owned-vs-borrowed <see cref="HttpClient" /> branching.
 /// </summary>
 [TestFixture]
 [Category("Unit")]
@@ -47,22 +47,22 @@ public class BexioConnectionHandlerTests
     private const string BaseUri = "https://api.example.local/";
 
     /// <summary>
-    ///     Fake payload record used for JSON serialization / deserialization assertions.
+    /// Fake payload record used for JSON serialization / deserialization assertions.
     /// </summary>
     /// <param name="Id">Arbitrary identifier.</param>
     private sealed record TestItem(int Id);
 
     /// <summary>
-    ///     Minimal request body used by the POST serialization test.
+    /// Minimal request body used by the POST serialization test.
     /// </summary>
     /// <param name="Name">A name-like field.</param>
     /// <param name="Value">A numeric field.</param>
     private sealed record TestPayload(string Name, int Value);
 
     /// <summary>
-    ///     Test double for <see cref="HttpMessageHandler" />. Captures the last request, honours
-    ///     the supplied cancellation token (so cancellation tests propagate correctly) and returns
-    ///     a configurable <see cref="HttpResponseMessage" />.
+    /// Test double for <see cref="HttpMessageHandler" />. Captures the last request, honours
+    /// the supplied cancellation token (so cancellation tests propagate correctly) and returns
+    /// a configurable <see cref="HttpResponseMessage" />.
     /// </summary>
     private sealed class StubHandler : HttpMessageHandler
     {
@@ -89,9 +89,9 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     Builds a <see cref="BexioConnectionHandler" /> wired to the supplied stub message handler
-    ///     via an externally managed <see cref="HttpClient" />. Uses the DI-style two-argument
-    ///     constructor so disposal of the returned handler does not dispose the HTTP client.
+    /// Builds a <see cref="BexioConnectionHandler" /> wired to the supplied stub message handler
+    /// via an externally managed <see cref="HttpClient" />. Uses the DI-style two-argument
+    /// constructor so disposal of the returned handler does not dispose the HTTP client.
     /// </summary>
     private static (BexioConnectionHandler handler, HttpClient httpClient, StubHandler stub) CreateHandler()
     {
@@ -112,8 +112,8 @@ public class BexioConnectionHandlerTests
     // -----------------------------------------------------------------------
 
     /// <summary>
-    ///     A GET call must emit an HTTP GET request to the path provided, joined with the configured
-    ///     base URI.
+    /// A GET call must emit an HTTP GET request to the path provided, joined with the configured
+    /// base URI.
     /// </summary>
     [Test]
     public async Task GetAsync_SendsGetRequest_ToCorrectPath()
@@ -136,7 +136,7 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     A POST call must emit an HTTP POST request to the path provided.
+    /// A POST call must emit an HTTP POST request to the path provided.
     /// </summary>
     [Test]
     public async Task PostAsync_SendsPostRequest_ToCorrectPath()
@@ -158,7 +158,7 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     A Delete call must emit an HTTP DELETE request to the path provided.
+    /// A Delete call must emit an HTTP DELETE request to the path provided.
     /// </summary>
     [Test]
     public async Task Delete_SendsDeleteRequest_ToCorrectPath()
@@ -179,8 +179,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     Multipart uploads must emit an HTTP POST request whose content is a
-    ///     <see cref="MultipartFormDataContent" /> instance.
+    /// Multipart uploads must emit an HTTP POST request whose content is a
+    /// <see cref="MultipartFormDataContent" /> instance.
     /// </summary>
     [Test]
     public async Task PostMultiPartFileAsync_SendsPostRequest()
@@ -211,8 +211,8 @@ public class BexioConnectionHandlerTests
     // -----------------------------------------------------------------------
 
     /// <summary>
-    ///     Parameters supplied via <see cref="QueryParameter" /> must be appended to the request URI
-    ///     as a percent-encoded query string.
+    /// Parameters supplied via <see cref="QueryParameter" /> must be appended to the request URI
+    /// as a percent-encoded query string.
     /// </summary>
     [Test]
     public async Task GetAsync_WithQueryParameter_AppendsToUri()
@@ -241,7 +241,7 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     When no <see cref="QueryParameter" /> is supplied the request URI must have no query string.
+    /// When no <see cref="QueryParameter" /> is supplied the request URI must have no query string.
     /// </summary>
     [Test]
     public async Task GetAsync_WithNullQueryParameter_HasNoQueryString()
@@ -266,8 +266,8 @@ public class BexioConnectionHandlerTests
     // -----------------------------------------------------------------------
 
     /// <summary>
-    ///     POST must serialize the supplied payload to JSON using System.Text.Json defaults
-    ///     (PascalCase property names) and send it as the request body.
+    /// POST must serialize the supplied payload to JSON using System.Text.Json defaults
+    /// (PascalCase property names) and send it as the request body.
     /// </summary>
     [Test]
     public async Task PostAsync_SerializesPayloadAsJson()
@@ -298,8 +298,8 @@ public class BexioConnectionHandlerTests
     // -----------------------------------------------------------------------
 
     /// <summary>
-    ///     A 200 response must produce an <see cref="ApiResult{T}" /> with
-    ///     <c>IsSuccess == true</c> and a deserialized payload.
+    /// A 200 response must produce an <see cref="ApiResult{T}" /> with
+    /// <c>IsSuccess == true</c> and a deserialized payload.
     /// </summary>
     [Test]
     public async Task GetAsync_On200_ReturnsIsSuccessTrue_WithDeserializedData()
@@ -329,8 +329,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     A 400 response must produce an <see cref="ApiResult{T}" /> with
-    ///     <c>IsSuccess == false</c>, a populated <see cref="ApiError" /> and null <c>Data</c>.
+    /// A 400 response must produce an <see cref="ApiResult{T}" /> with
+    /// <c>IsSuccess == false</c>, a populated <see cref="ApiError" /> and null <c>Data</c>.
     /// </summary>
     [Test]
     public async Task GetAsync_On400_ReturnsIsSuccessFalse_WithApiError()
@@ -361,10 +361,10 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     A 302 Found response is non-successful: the status code is outside the 2xx range, so
-    ///     <c>IsSuccess</c> is false and <c>Data</c> is null. The redirect target (<c>Location</c>
-    ///     header) is not followed — auto-redirect is disabled on the underlying <see cref="HttpClient"/>
-    ///     to prevent the bearer token from leaking to a different host.
+    /// A 302 Found response is non-successful: the status code is outside the 2xx range, so
+    /// <c>IsSuccess</c> is false and <c>Data</c> is null. The redirect target (<c>Location</c>
+    /// header) is not followed — auto-redirect is disabled on the underlying <see cref="HttpClient"/>
+    /// to prevent the bearer token from leaking to a different host.
     /// </summary>
     [Test]
     public async Task GetAsync_On302Found_ReturnsIsSuccessFalse_WithNullData()
@@ -392,9 +392,9 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     Standard Bexio pagination headers on the response must be parsed into the
-    ///     <see cref="ApiResult.ResponseHeaders" /> dictionary using the documented
-    ///     <see cref="ApiHeaderNames" /> keys.
+    /// Standard Bexio pagination headers on the response must be parsed into the
+    /// <see cref="ApiResult.ResponseHeaders" /> dictionary using the documented
+    /// <see cref="ApiHeaderNames" /> keys.
     /// </summary>
     [Test]
     public async Task GetAsync_ResponseHeaders_AreMappedCorrectly()
@@ -429,9 +429,9 @@ public class BexioConnectionHandlerTests
     // -----------------------------------------------------------------------
 
     /// <summary>
-    ///     When constructed with a configuration only the handler owns its <see cref="HttpClient" />,
-    ///     so disposing the handler must dispose the client. A subsequent HTTP call must therefore
-    ///     fail with <see cref="ObjectDisposedException" />.
+    /// When constructed with a configuration only the handler owns its <see cref="HttpClient" />,
+    /// so disposing the handler must dispose the client. A subsequent HTTP call must therefore
+    /// fail with <see cref="ObjectDisposedException" />.
     /// </summary>
     [Test]
     public void Dispose_WhenOwnsHttpClient_DisposesClient()
@@ -451,8 +451,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     When constructed with an externally supplied <see cref="HttpClient" /> the handler must
-    ///     leave the client alone on dispose so DI-managed clients keep working for their owner.
+    /// When constructed with an externally supplied <see cref="HttpClient" /> the handler must
+    /// leave the client alone on dispose so DI-managed clients keep working for their owner.
     /// </summary>
     [Test]
     public async Task Dispose_WhenDoesNotOwnHttpClient_DoesNotDisposeClient()
@@ -475,8 +475,8 @@ public class BexioConnectionHandlerTests
     // -----------------------------------------------------------------------
 
     /// <summary>
-    ///     An already-cancelled <see cref="CancellationToken" /> must propagate through the handler
-    ///     as an <see cref="OperationCanceledException" /> (or a derived <see cref="TaskCanceledException" />).
+    /// An already-cancelled <see cref="CancellationToken" /> must propagate through the handler
+    /// as an <see cref="OperationCanceledException" /> (or a derived <see cref="TaskCanceledException" />).
     /// </summary>
     [Test]
     public void GetAsync_WhenCancelled_ThrowsOperationCanceledException()
@@ -498,8 +498,8 @@ public class BexioConnectionHandlerTests
     // -----------------------------------------------------------------------
 
     /// <summary>
-    ///     A PUT call must emit an HTTP PUT request to the path provided and carry the serialized
-    ///     payload as JSON body.
+    /// A PUT call must emit an HTTP PUT request to the path provided and carry the serialized
+    /// payload as JSON body.
     /// </summary>
     [Test]
     public async Task PutAsync_SendsPutRequest_ToCorrectPath()
@@ -528,8 +528,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     A PATCH call must emit an HTTP PATCH request to the path provided and carry the
-    ///     serialized payload as JSON body.
+    /// A PATCH call must emit an HTTP PATCH request to the path provided and carry the
+    /// serialized payload as JSON body.
     /// </summary>
     [Test]
     public async Task PatchAsync_SendsPatchRequest_ToCorrectPath()
@@ -556,8 +556,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     The typed overload of <see cref="BexioConnectionHandler.PostActionAsync{TResult}" /> must
-    ///     emit a POST with no body to the supplied action endpoint path.
+    /// The typed overload of <see cref="BexioConnectionHandler.PostActionAsync{TResult}" /> must
+    /// emit a POST with no body to the supplied action endpoint path.
     /// </summary>
     [Test]
     public async Task PostActionAsync_WithTResult_SendsPostRequest_ToCorrectPath()
@@ -579,8 +579,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     The void overload of <see cref="BexioConnectionHandler.PostActionAsync" /> must emit a
-    ///     POST with no body and surface success through the untyped <see cref="ApiResult{T}" />.
+    /// The void overload of <see cref="BexioConnectionHandler.PostActionAsync" /> must emit a
+    /// POST with no body and surface success through the untyped <see cref="ApiResult{T}" />.
     /// </summary>
     [Test]
     public async Task PostActionAsync_WithVoid_SendsPostRequest_ToCorrectPath()
@@ -604,9 +604,9 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     <see cref="BexioConnectionHandler.GetBinaryAsync" /> must emit a GET and return the raw
-    ///     response bytes verbatim in <see cref="ApiResult{T}.Data" /> instead of attempting JSON
-    ///     deserialisation.
+    /// <see cref="BexioConnectionHandler.GetBinaryAsync" /> must emit a GET and return the raw
+    /// response bytes verbatim in <see cref="ApiResult{T}.Data" /> instead of attempting JSON
+    /// deserialisation.
     /// </summary>
     [Test]
     public async Task GetBinaryAsync_SendsGetRequest_AndReturnsByteArrayData()
@@ -641,8 +641,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     A non-success response from <see cref="BexioConnectionHandler.GetBinaryAsync" /> must
-    ///     leave <see cref="ApiResult{T}.Data" /> null and populate <see cref="ApiResult.ApiError" />.
+    /// A non-success response from <see cref="BexioConnectionHandler.GetBinaryAsync" /> must
+    /// leave <see cref="ApiResult{T}.Data" /> null and populate <see cref="ApiResult.ApiError" />.
     /// </summary>
     [Test]
     public async Task GetBinaryAsync_On404_ReturnsIsSuccessFalse_WithApiError()
@@ -672,9 +672,9 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     <see cref="BexioConnectionHandler.PostSearchAsync{TResult}" /> must POST the search
-    ///     criteria as a JSON array body and append supplied <see cref="QueryParameter" /> values
-    ///     to the request URI as a query string.
+    /// <see cref="BexioConnectionHandler.PostSearchAsync{TResult}" /> must POST the search
+    /// criteria as a JSON array body and append supplied <see cref="QueryParameter" /> values
+    /// to the request URI as a query string.
     /// </summary>
     [Test]
     public async Task PostSearchAsync_SendsPostRequest_WithBodyAndQueryParameters()
@@ -719,8 +719,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     When no <see cref="QueryParameter" /> is supplied to <see cref="BexioConnectionHandler.PostSearchAsync{TResult}" />
-    ///     the request URI must carry no query string.
+    /// When no <see cref="QueryParameter" /> is supplied to <see cref="BexioConnectionHandler.PostSearchAsync{TResult}" />
+    /// the request URI must carry no query string.
     /// </summary>
     [Test]
     public async Task PostSearchAsync_WithoutQueryParameter_HasNoQueryString()
@@ -747,8 +747,8 @@ public class BexioConnectionHandlerTests
     }
 
     /// <summary>
-    ///     <see cref="BexioConnectionHandler.PostBulkAsync{TResult, TCreate}" /> must POST the full
-    ///     payload list as a JSON array body to the supplied bulk endpoint path.
+    /// <see cref="BexioConnectionHandler.PostBulkAsync{TResult, TCreate}" /> must POST the full
+    /// payload list as a JSON array body to the supplied bulk endpoint path.
     /// </summary>
     [Test]
     public async Task PostBulkAsync_SendsPostRequest_WithArrayBody()

--- a/tests/BexioApiNet.UnitTests/Sales/DeliveryServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/DeliveryServiceTests.cs
@@ -32,16 +32,16 @@ using BexioApiNet.Services.Connectors.Sales;
 namespace BexioApiNet.UnitTests.Sales;
 
 /// <summary>
-///     Offline unit tests for <see cref="DeliveryService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="DeliveryService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class DeliveryServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="DeliveryService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="DeliveryService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -54,8 +54,8 @@ public sealed class DeliveryServiceTests : ServiceTestBase
     private DeliveryService _sut = null!;
 
     /// <summary>
-    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
-    ///     the expected endpoint path and a null query parameter.
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    /// the expected endpoint path and a null query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsync()
@@ -77,8 +77,8 @@ public sealed class DeliveryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the <see cref="QueryParameterDelivery" />'s underlying <see cref="QueryParameter" />
-    ///     to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
+    /// Get forwards the <see cref="QueryParameterDelivery" />'s underlying <see cref="QueryParameter" />
+    /// to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
@@ -101,9 +101,9 @@ public sealed class DeliveryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
-    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
-    ///     the full result set.
+    /// Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    /// the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    /// the full result set.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -145,8 +145,8 @@ public sealed class DeliveryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
-    ///     auto-paging is not requested.
+    /// Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    /// auto-paging is not requested.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResult()
@@ -165,8 +165,8 @@ public sealed class DeliveryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
-    ///     endpoint path including the delivery id.
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    /// endpoint path including the delivery id.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsync_WithIdInPath()
@@ -187,7 +187,7 @@ public sealed class DeliveryServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
+    /// Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task Issue_CallsPostActionAsync_WithIssuePath()

--- a/tests/BexioApiNet.UnitTests/Sales/InvoiceReminderServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/InvoiceReminderServiceTests.cs
@@ -32,17 +32,17 @@ using BexioApiNet.Services.Connectors.Sales;
 namespace BexioApiNet.UnitTests.Sales;
 
 /// <summary>
-///     Offline unit tests for <see cref="InvoiceReminderService" />. Each test verifies that the
-///     service forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected
-///     arguments (including the owning invoice id in every path) and returns the handler's result
-///     unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="InvoiceReminderService" />. Each test verifies that the
+/// service forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected
+/// arguments (including the owning invoice id in every path) and returns the handler's result
+/// unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class InvoiceReminderServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="InvoiceReminderService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="InvoiceReminderService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -57,8 +57,8 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     private InvoiceReminderService _sut = null!;
 
     /// <summary>
-    ///     Get forwards the call to <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the
-    ///     nested <c>/{invoiceId}/kb_reminder</c> path.
+    /// Get forwards the call to <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the
+    /// nested <c>/{invoiceId}/kb_reminder</c> path.
     /// </summary>
     [Test]
     public async Task Get_CallsGetAsync_WithInvoiceIdInPath()
@@ -78,8 +78,8 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
-    ///     <c>/{invoiceId}/kb_reminder/{reminderId}</c>.
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
+    /// <c>/{invoiceId}/kb_reminder/{reminderId}</c>.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsync_WithReminderIdInPath()
@@ -100,8 +100,8 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
-    ///     <c>/{reminderId}/pdf</c> sub-resource.
+    /// GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
+    /// <c>/{reminderId}/pdf</c> sub-resource.
     /// </summary>
     [Test]
     public async Task GetPdf_CallsGetBinaryAsync_WithPdfPath()
@@ -121,8 +121,8 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create forwards the payload and the nested endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// Create forwards the payload and the nested endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsync_WithReminderPath()
@@ -145,8 +145,8 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
-    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task Search_CallsPostSearchAsync()
@@ -175,8 +175,8 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Send posts the <see cref="InvoiceReminderSendRequest"/> body to the <c>/{reminderId}/send</c>
-    ///     endpoint.
+    /// Send posts the <see cref="InvoiceReminderSendRequest"/> body to the <c>/{reminderId}/send</c>
+    /// endpoint.
     /// </summary>
     [Test]
     public async Task Send_CallsPostAsync_WithSendPath()
@@ -201,7 +201,7 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     MarkAsSent posts to the <c>/{reminderId}/mark_as_sent</c> action endpoint with no request body.
+    /// MarkAsSent posts to the <c>/{reminderId}/mark_as_sent</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task MarkAsSent_CallsPostActionAsync_WithMarkAsSentPath()
@@ -221,7 +221,7 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     MarkAsUnsent posts to the <c>/{reminderId}/mark_as_unsent</c> action endpoint with no request body.
+    /// MarkAsUnsent posts to the <c>/{reminderId}/mark_as_unsent</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task MarkAsUnsent_CallsPostActionAsync_WithMarkAsUnsentPath()
@@ -241,8 +241,8 @@ public sealed class InvoiceReminderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the nested
-    ///     <c>/{invoiceId}/kb_reminder/{reminderId}</c> path.
+    /// Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the nested
+    /// <c>/{invoiceId}/kb_reminder/{reminderId}</c> path.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDelete_WithReminderIdInPath()

--- a/tests/BexioApiNet.UnitTests/Sales/InvoiceServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/InvoiceServiceTests.cs
@@ -33,16 +33,16 @@ using BexioApiNet.Services.Connectors.Sales;
 namespace BexioApiNet.UnitTests.Sales;
 
 /// <summary>
-///     Offline unit tests for <see cref="InvoiceService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="InvoiceService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class InvoiceServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="InvoiceService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="InvoiceService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -55,8 +55,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     private InvoiceService _sut = null!;
 
     /// <summary>
-    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
-    ///     the expected endpoint path and a null query parameter.
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    /// the expected endpoint path and a null query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsync()
@@ -78,8 +78,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the <see cref="QueryParameterInvoice" />'s underlying <see cref="QueryParameter" />
-    ///     to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
+    /// Get forwards the <see cref="QueryParameterInvoice" />'s underlying <see cref="QueryParameter" />
+    /// to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
@@ -102,9 +102,9 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
-    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
-    ///     the full result set.
+    /// Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    /// the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    /// the full result set.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -146,8 +146,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
-    ///     auto-paging is not requested.
+    /// Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    /// auto-paging is not requested.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResult()
@@ -166,8 +166,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
-    ///     endpoint path including the invoice id.
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    /// endpoint path including the invoice id.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsync_WithIdInPath()
@@ -188,8 +188,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
-    ///     <c>/{id}/pdf</c> sub-resource.
+    /// GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
+    /// <c>/{id}/pdf</c> sub-resource.
     /// </summary>
     [Test]
     public async Task GetPdf_CallsGetBinaryAsync_WithIdInPath()
@@ -209,8 +209,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create forwards the payload and the expected endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// Create forwards the payload and the expected endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsync()
@@ -233,8 +233,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
-    ///     <c>/2.0/kb_invoice/{id}</c> — Bexio edits invoices via POST on this resource.
+    /// Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
+    /// <c>/2.0/kb_invoice/{id}</c> — Bexio edits invoices via POST on this resource.
     /// </summary>
     [Test]
     public async Task Update_CallsPostAsync_WithIdInPath()
@@ -256,8 +256,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the invoice id
-    ///     appended to the endpoint root.
+    /// Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the invoice id
+    /// appended to the endpoint root.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
@@ -277,8 +277,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
-    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task Search_CallsPostSearchAsync()
@@ -307,7 +307,7 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
+    /// Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task Issue_CallsPostActionAsync_WithIssuePath()
@@ -327,7 +327,7 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     RevertIssue posts to the <c>/{id}/revert_issue</c> action endpoint with no request body.
+    /// RevertIssue posts to the <c>/{id}/revert_issue</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task RevertIssue_CallsPostActionAsync_WithRevertIssuePath()
@@ -347,7 +347,7 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Cancel posts to the <c>/{id}/cancel</c> action endpoint with no request body.
+    /// Cancel posts to the <c>/{id}/cancel</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task Cancel_CallsPostActionAsync_WithCancelPath()
@@ -367,7 +367,7 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     MarkAsSent posts to the <c>/{id}/mark_as_sent</c> action endpoint with no request body.
+    /// MarkAsSent posts to the <c>/{id}/mark_as_sent</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task MarkAsSent_CallsPostActionAsync_WithMarkAsSentPath()
@@ -387,7 +387,7 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Copy posts the <see cref="InvoiceCopyRequest"/> body to the <c>/{id}/copy</c> endpoint.
+    /// Copy posts the <see cref="InvoiceCopyRequest"/> body to the <c>/{id}/copy</c> endpoint.
     /// </summary>
     [Test]
     public async Task Copy_CallsPostAsync_WithCopyPath()
@@ -413,7 +413,7 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Send posts the <see cref="InvoiceSendRequest"/> body to the <c>/{id}/send</c> endpoint.
+    /// Send posts the <see cref="InvoiceSendRequest"/> body to the <c>/{id}/send</c> endpoint.
     /// </summary>
     [Test]
     public async Task Send_CallsPostAsync_WithSendPath()
@@ -438,8 +438,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetPayments calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
-    ///     <c>/{invoiceId}/payment</c>.
+    /// GetPayments calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
+    /// <c>/{invoiceId}/payment</c>.
     /// </summary>
     [Test]
     public async Task GetPayments_CallsGetAsync_WithPaymentPath()
@@ -460,8 +460,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetPaymentById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
-    ///     <c>/{invoiceId}/payment/{paymentId}</c>.
+    /// GetPaymentById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> against
+    /// <c>/{invoiceId}/payment/{paymentId}</c>.
     /// </summary>
     [Test]
     public async Task GetPaymentById_CallsGetAsync_WithPaymentIdInPath()
@@ -483,8 +483,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     CreatePayment posts the <see cref="InvoicePaymentCreate"/> body to the <c>/{invoiceId}/payment</c>
-    ///     endpoint.
+    /// CreatePayment posts the <see cref="InvoicePaymentCreate"/> body to the <c>/{invoiceId}/payment</c>
+    /// endpoint.
     /// </summary>
     [Test]
     public async Task CreatePayment_CallsPostAsync_WithPaymentPath()
@@ -510,8 +510,8 @@ public sealed class InvoiceServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     DeletePayment forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the
-    ///     nested <c>/payment/{paymentId}</c> path.
+    /// DeletePayment forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the
+    /// nested <c>/payment/{paymentId}</c> path.
     /// </summary>
     [Test]
     public async Task DeletePayment_CallsConnectionHandlerDelete_WithPaymentPath()

--- a/tests/BexioApiNet.UnitTests/Sales/OrderServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/OrderServiceTests.cs
@@ -35,16 +35,16 @@ using BexioApiNet.Services.Connectors.Sales;
 namespace BexioApiNet.UnitTests.Sales;
 
 /// <summary>
-///     Offline unit tests for <see cref="OrderService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="OrderService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class OrderServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="OrderService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="OrderService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -57,8 +57,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     private OrderService _sut = null!;
 
     /// <summary>
-    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
-    ///     the expected endpoint path and a null query parameter.
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    /// the expected endpoint path and a null query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsync()
@@ -80,8 +80,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the <see cref="QueryParameterOrder" />'s underlying <see cref="QueryParameter" />
-    ///     to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
+    /// Get forwards the <see cref="QueryParameterOrder" />'s underlying <see cref="QueryParameter" />
+    /// to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
@@ -104,9 +104,9 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
-    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
-    ///     the full result set.
+    /// Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    /// the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    /// the full result set.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -148,8 +148,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
-    ///     auto-paging is not requested.
+    /// Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    /// auto-paging is not requested.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResult()
@@ -168,8 +168,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
-    ///     endpoint path including the order id.
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    /// endpoint path including the order id.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsync_WithIdInPath()
@@ -190,8 +190,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
-    ///     <c>/{id}/pdf</c> sub-resource.
+    /// GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
+    /// <c>/{id}/pdf</c> sub-resource.
     /// </summary>
     [Test]
     public async Task GetPdf_CallsGetBinaryAsync_WithIdInPath()
@@ -211,8 +211,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetRepetition calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the
-    ///     expected endpoint path including the order id and the <c>/repetition</c> sub-resource.
+    /// GetRepetition calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the
+    /// expected endpoint path including the order id and the <c>/repetition</c> sub-resource.
     /// </summary>
     [Test]
     public async Task GetRepetition_CallsGetAsync_WithRepetitionPath()
@@ -233,8 +233,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create forwards the payload and the expected endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// Create forwards the payload and the expected endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsync()
@@ -257,8 +257,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
-    ///     <c>/2.0/kb_order/{id}</c> — Bexio edits orders via POST on this resource.
+    /// Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
+    /// <c>/2.0/kb_order/{id}</c> — Bexio edits orders via POST on this resource.
     /// </summary>
     [Test]
     public async Task Update_CallsPostAsync_WithIdInPath()
@@ -280,8 +280,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the order id
-    ///     appended to the endpoint root.
+    /// Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the order id
+    /// appended to the endpoint root.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
@@ -301,8 +301,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
-    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task Search_CallsPostSearchAsync()
@@ -331,8 +331,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     CreateDeliveryFromOrder posts the optional <see cref="OrderConvertRequest" /> body to the
-    ///     <c>/{id}/delivery</c> endpoint and returns the newly created <see cref="Delivery" />.
+    /// CreateDeliveryFromOrder posts the optional <see cref="OrderConvertRequest" /> body to the
+    /// <c>/{id}/delivery</c> endpoint and returns the newly created <see cref="Delivery" />.
     /// </summary>
     [Test]
     public async Task CreateDeliveryFromOrder_CallsPostAsync_WithDeliveryPath()
@@ -354,8 +354,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     CreateInvoiceFromOrder posts the optional <see cref="OrderConvertRequest" /> body to the
-    ///     <c>/{id}/invoice</c> endpoint and returns the newly created <see cref="Invoice" />.
+    /// CreateInvoiceFromOrder posts the optional <see cref="OrderConvertRequest" /> body to the
+    /// <c>/{id}/invoice</c> endpoint and returns the newly created <see cref="Invoice" />.
     /// </summary>
     [Test]
     public async Task CreateInvoiceFromOrder_CallsPostAsync_WithInvoicePath()
@@ -377,8 +377,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     CreateRepetition posts the <see cref="OrderRepetitionCreate" /> body to the
-    ///     <c>/{id}/repetition</c> endpoint and returns the resulting <see cref="OrderRepetition" />.
+    /// CreateRepetition posts the <see cref="OrderRepetitionCreate" /> body to the
+    /// <c>/{id}/repetition</c> endpoint and returns the resulting <see cref="OrderRepetition" />.
     /// </summary>
     [Test]
     public async Task CreateRepetition_CallsPostAsync_WithRepetitionPath()
@@ -404,8 +404,8 @@ public sealed class OrderServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     DeleteRepetition calls <see cref="IBexioConnectionHandler.Delete" /> against the
-    ///     <c>/{id}/repetition</c> sub-resource.
+    /// DeleteRepetition calls <see cref="IBexioConnectionHandler.Delete" /> against the
+    /// <c>/{id}/repetition</c> sub-resource.
     /// </summary>
     [Test]
     public async Task DeleteRepetition_CallsConnectionHandlerDelete_WithRepetitionPath()

--- a/tests/BexioApiNet.UnitTests/Sales/OrderServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/OrderServiceTests.cs
@@ -23,7 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-using System.Text.Json;
 using BexioApiNet.Abstractions.Enums.Api;
 using BexioApiNet.Abstractions.Models.Api;
 using BexioApiNet.Abstractions.Models.Sales.Deliveries;
@@ -437,10 +436,9 @@ public sealed class OrderServiceTests : ServiceTestBase
 
     private static OrderRepetitionCreate BuildRepetitionCreatePayload()
     {
-        using var doc = JsonDocument.Parse("""{"type":"daily","interval":1}""");
         return new OrderRepetitionCreate(
             "2026-01-01",
-            doc.RootElement.Clone(),
+            new OrderRepetitionDaily { Interval = 1 },
             "2026-12-31");
     }
 

--- a/tests/BexioApiNet.UnitTests/Sales/Orders/OrderRepetitionScheduleJsonConverterTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/Orders/OrderRepetitionScheduleJsonConverterTests.cs
@@ -1,0 +1,163 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Orders;
+
+namespace BexioApiNet.UnitTests.Sales.Orders;
+
+/// <summary>
+///     Round-trip tests for the polymorphic <see cref="OrderRepetitionSchedule" /> union. Each of
+///     the four concrete schedules must serialize with the lowercase <c>type</c> discriminator the
+///     Bexio API expects and must deserialize back into the same subtype when read from a response.
+/// </summary>
+[TestFixture]
+public sealed class OrderRepetitionScheduleJsonConverterTests
+{
+    /// <summary>
+    ///     An <see cref="OrderRepetitionDaily" /> round-trips through <see cref="JsonSerializer" />
+    ///     carrying the <c>daily</c> discriminator and the <see cref="OrderRepetitionSchedule.Interval" />.
+    /// </summary>
+    [Test]
+    public void OrderRepetitionDaily_RoundTrips_PreservesFields()
+    {
+        var original = new OrderRepetitionDaily { Interval = 3 };
+
+        var json = JsonSerializer.Serialize<OrderRepetitionSchedule>(original);
+        var roundTripped = JsonSerializer.Deserialize<OrderRepetitionSchedule>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"daily\""));
+            Assert.That(json, Does.Contain("\"interval\":3"));
+            Assert.That(roundTripped, Is.InstanceOf<OrderRepetitionDaily>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     An <see cref="OrderRepetitionWeekly" /> round-trips carrying the <c>weekly</c>
+    ///     discriminator, the interval and the weekday list.
+    /// </summary>
+    [Test]
+    public void OrderRepetitionWeekly_RoundTrips_PreservesFields()
+    {
+        var original = new OrderRepetitionWeekly
+        {
+            Interval = 2,
+            Weekdays = ["monday", "wednesday", "friday"]
+        };
+
+        var json = JsonSerializer.Serialize<OrderRepetitionSchedule>(original);
+        var roundTripped = JsonSerializer.Deserialize<OrderRepetitionSchedule>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"weekly\""));
+            Assert.That(json, Does.Contain("\"interval\":2"));
+            Assert.That(json, Does.Contain("\"weekdays\":[\"monday\",\"wednesday\",\"friday\"]"));
+            Assert.That(roundTripped, Is.InstanceOf<OrderRepetitionWeekly>());
+        });
+
+        var weekly = (OrderRepetitionWeekly)roundTripped!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(weekly.Interval, Is.EqualTo(original.Interval));
+            Assert.That(weekly.Weekdays, Is.EqualTo(original.Weekdays).AsCollection);
+        });
+    }
+
+    /// <summary>
+    ///     An <see cref="OrderRepetitionMonthly" /> round-trips carrying the <c>monthly</c>
+    ///     discriminator, the interval and the day-of-month selector.
+    /// </summary>
+    [Test]
+    public void OrderRepetitionMonthly_RoundTrips_PreservesFields()
+    {
+        var original = new OrderRepetitionMonthly
+        {
+            Interval = 1,
+            Schedule = "fixed_day"
+        };
+
+        var json = JsonSerializer.Serialize<OrderRepetitionSchedule>(original);
+        var roundTripped = JsonSerializer.Deserialize<OrderRepetitionSchedule>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"monthly\""));
+            Assert.That(json, Does.Contain("\"interval\":1"));
+            Assert.That(json, Does.Contain("\"schedule\":\"fixed_day\""));
+            Assert.That(roundTripped, Is.InstanceOf<OrderRepetitionMonthly>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     An <see cref="OrderRepetitionYearly" /> round-trips carrying the <c>yearly</c>
+    ///     discriminator and the interval.
+    /// </summary>
+    [Test]
+    public void OrderRepetitionYearly_RoundTrips_PreservesFields()
+    {
+        var original = new OrderRepetitionYearly { Interval = 4 };
+
+        var json = JsonSerializer.Serialize<OrderRepetitionSchedule>(original);
+        var roundTripped = JsonSerializer.Deserialize<OrderRepetitionSchedule>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"yearly\""));
+            Assert.That(json, Does.Contain("\"interval\":4"));
+            Assert.That(roundTripped, Is.InstanceOf<OrderRepetitionYearly>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     Deserializing an order repetition payload whose <c>type</c> discriminator is unknown to
+    ///     the converter must surface a <see cref="JsonException" /> — a payload the Bexio API should
+    ///     never emit, but worth failing fast on.
+    /// </summary>
+    [Test]
+    public void UnknownDiscriminator_ThrowsJsonException()
+    {
+        const string payload = """{"type":"hourly","interval":1}""";
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<OrderRepetitionSchedule>(payload));
+    }
+
+    /// <summary>
+    ///     Deserializing an order repetition payload missing the <c>type</c> discriminator altogether
+    ///     must surface a <see cref="JsonException" />.
+    /// </summary>
+    [Test]
+    public void MissingDiscriminator_ThrowsJsonException()
+    {
+        const string payload = """{"interval":1}""";
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<OrderRepetitionSchedule>(payload));
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Sales/Orders/OrderRepetitionScheduleJsonConverterTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/Orders/OrderRepetitionScheduleJsonConverterTests.cs
@@ -29,16 +29,16 @@ using BexioApiNet.Abstractions.Models.Sales.Orders;
 namespace BexioApiNet.UnitTests.Sales.Orders;
 
 /// <summary>
-///     Round-trip tests for the polymorphic <see cref="OrderRepetitionSchedule" /> union. Each of
-///     the four concrete schedules must serialize with the lowercase <c>type</c> discriminator the
-///     Bexio API expects and must deserialize back into the same subtype when read from a response.
+/// Round-trip tests for the polymorphic <see cref="OrderRepetitionSchedule" /> union. Each of
+/// the four concrete schedules must serialize with the lowercase <c>type</c> discriminator the
+/// Bexio API expects and must deserialize back into the same subtype when read from a response.
 /// </summary>
 [TestFixture]
 public sealed class OrderRepetitionScheduleJsonConverterTests
 {
     /// <summary>
-    ///     An <see cref="OrderRepetitionDaily" /> round-trips through <see cref="JsonSerializer" />
-    ///     carrying the <c>daily</c> discriminator and the <see cref="OrderRepetitionSchedule.Interval" />.
+    /// An <see cref="OrderRepetitionDaily" /> round-trips through <see cref="JsonSerializer" />
+    /// carrying the <c>daily</c> discriminator and the <see cref="OrderRepetitionSchedule.Interval" />.
     /// </summary>
     [Test]
     public void OrderRepetitionDaily_RoundTrips_PreservesFields()
@@ -58,8 +58,8 @@ public sealed class OrderRepetitionScheduleJsonConverterTests
     }
 
     /// <summary>
-    ///     An <see cref="OrderRepetitionWeekly" /> round-trips carrying the <c>weekly</c>
-    ///     discriminator, the interval and the weekday list.
+    /// An <see cref="OrderRepetitionWeekly" /> round-trips carrying the <c>weekly</c>
+    /// discriminator, the interval and the weekday list.
     /// </summary>
     [Test]
     public void OrderRepetitionWeekly_RoundTrips_PreservesFields()
@@ -90,8 +90,8 @@ public sealed class OrderRepetitionScheduleJsonConverterTests
     }
 
     /// <summary>
-    ///     An <see cref="OrderRepetitionMonthly" /> round-trips carrying the <c>monthly</c>
-    ///     discriminator, the interval and the day-of-month selector.
+    /// An <see cref="OrderRepetitionMonthly" /> round-trips carrying the <c>monthly</c>
+    /// discriminator, the interval and the day-of-month selector.
     /// </summary>
     [Test]
     public void OrderRepetitionMonthly_RoundTrips_PreservesFields()
@@ -116,8 +116,8 @@ public sealed class OrderRepetitionScheduleJsonConverterTests
     }
 
     /// <summary>
-    ///     An <see cref="OrderRepetitionYearly" /> round-trips carrying the <c>yearly</c>
-    ///     discriminator and the interval.
+    /// An <see cref="OrderRepetitionYearly" /> round-trips carrying the <c>yearly</c>
+    /// discriminator and the interval.
     /// </summary>
     [Test]
     public void OrderRepetitionYearly_RoundTrips_PreservesFields()
@@ -137,9 +137,9 @@ public sealed class OrderRepetitionScheduleJsonConverterTests
     }
 
     /// <summary>
-    ///     Deserializing an order repetition payload whose <c>type</c> discriminator is unknown to
-    ///     the converter must surface a <see cref="JsonException" /> — a payload the Bexio API should
-    ///     never emit, but worth failing fast on.
+    /// Deserializing an order repetition payload whose <c>type</c> discriminator is unknown to
+    /// the converter must surface a <see cref="JsonException" /> — a payload the Bexio API should
+    /// never emit, but worth failing fast on.
     /// </summary>
     [Test]
     public void UnknownDiscriminator_ThrowsJsonException()
@@ -150,8 +150,8 @@ public sealed class OrderRepetitionScheduleJsonConverterTests
     }
 
     /// <summary>
-    ///     Deserializing an order repetition payload missing the <c>type</c> discriminator altogether
-    ///     must surface a <see cref="JsonException" />.
+    /// Deserializing an order repetition payload missing the <c>type</c> discriminator altogether
+    /// must surface a <see cref="JsonException" />.
     /// </summary>
     [Test]
     public void MissingDiscriminator_ThrowsJsonException()

--- a/tests/BexioApiNet.UnitTests/Sales/Positions/PositionJsonConverterTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/Positions/PositionJsonConverterTests.cs
@@ -1,0 +1,301 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Sales.Positions;
+
+namespace BexioApiNet.UnitTests.Sales.Positions;
+
+/// <summary>
+///     Round-trip tests for the polymorphic <see cref="Position" /> union. Each concrete variant
+///     must serialize to the JSON shape Bexio expects (including the <c>type</c> discriminator) and
+///     must deserialize back into the same concrete subtype when read from a Bexio response.
+/// </summary>
+[TestFixture]
+public sealed class PositionJsonConverterTests
+{
+    /// <summary>
+    ///     A <see cref="PositionArticle" /> round-trips through
+    ///     <see cref="JsonSerializer" /> preserving every field and the <c>KbPositionArticle</c>
+    ///     discriminator.
+    /// </summary>
+    [Test]
+    public void PositionArticle_RoundTrips_PreservesAllFields()
+    {
+        var original = new PositionArticle
+        {
+            Id = 1,
+            ParentId = null,
+            Amount = "2.000000",
+            UnitId = 3,
+            AccountId = 4,
+            TaxId = 5,
+            Text = "Line item",
+            UnitPrice = "99.500000",
+            DiscountInPercent = "10.000000",
+            Pos = "1",
+            InternalPos = 1,
+            IsOptional = false,
+            ArticleId = 42
+        };
+
+        var json = JsonSerializer.Serialize<Position>(original);
+        var roundTripped = JsonSerializer.Deserialize<Position>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"KbPositionArticle\""));
+            Assert.That(roundTripped, Is.InstanceOf<PositionArticle>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     A <see cref="PositionCustom" /> round-trips preserving its fields and its
+    ///     <c>KbPositionCustom</c> discriminator.
+    /// </summary>
+    [Test]
+    public void PositionCustom_RoundTrips_PreservesAllFields()
+    {
+        var original = new PositionCustom
+        {
+            Id = 2,
+            Amount = "1.000000",
+            UnitId = 1,
+            AccountId = 1,
+            TaxId = 1,
+            Text = "Custom line",
+            UnitPrice = "50.000000",
+            DiscountInPercent = null,
+            Pos = "2",
+            InternalPos = 2,
+            IsOptional = null
+        };
+
+        var json = JsonSerializer.Serialize<Position>(original);
+        var roundTripped = JsonSerializer.Deserialize<Position>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"KbPositionCustom\""));
+            Assert.That(roundTripped, Is.InstanceOf<PositionCustom>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     A <see cref="PositionText" /> round-trips preserving its fields and its
+    ///     <c>KbPositionText</c> discriminator.
+    /// </summary>
+    [Test]
+    public void PositionText_RoundTrips_PreservesAllFields()
+    {
+        var original = new PositionText
+        {
+            Id = 3,
+            Text = "Some paragraph",
+            ShowPosNr = true,
+            Pos = "3",
+            InternalPos = 3,
+            IsOptional = false
+        };
+
+        var json = JsonSerializer.Serialize<Position>(original);
+        var roundTripped = JsonSerializer.Deserialize<Position>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"KbPositionText\""));
+            Assert.That(roundTripped, Is.InstanceOf<PositionText>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     A <see cref="PositionSubposition" /> round-trips preserving its fields and its
+    ///     <c>KbPositionSubposition</c> discriminator.
+    /// </summary>
+    [Test]
+    public void PositionSubposition_RoundTrips_PreservesAllFields()
+    {
+        var original = new PositionSubposition
+        {
+            Id = 4,
+            Text = "Group heading",
+            Pos = "4",
+            InternalPos = 4,
+            ShowPosNr = true,
+            IsOptional = false,
+            TotalSum = "150.00",
+            ShowPosPrices = true
+        };
+
+        var json = JsonSerializer.Serialize<Position>(original);
+        var roundTripped = JsonSerializer.Deserialize<Position>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"KbPositionSubposition\""));
+            Assert.That(roundTripped, Is.InstanceOf<PositionSubposition>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     A <see cref="PositionSubtotal" /> round-trips preserving its fields and its
+    ///     <c>KbPositionSubtotal</c> discriminator.
+    /// </summary>
+    [Test]
+    public void PositionSubtotal_RoundTrips_PreservesAllFields()
+    {
+        var original = new PositionSubtotal
+        {
+            Id = 5,
+            Text = "Subtotal",
+            Value = "300.00",
+            InternalPos = 5,
+            IsOptional = false
+        };
+
+        var json = JsonSerializer.Serialize<Position>(original);
+        var roundTripped = JsonSerializer.Deserialize<Position>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"KbPositionSubtotal\""));
+            Assert.That(roundTripped, Is.InstanceOf<PositionSubtotal>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     A <see cref="PositionPagebreak" /> round-trips preserving its fields and its
+    ///     <c>KbPositionPagebreak</c> discriminator.
+    /// </summary>
+    [Test]
+    public void PositionPagebreak_RoundTrips_PreservesAllFields()
+    {
+        var original = new PositionPagebreak
+        {
+            Id = 6,
+            InternalPos = 6,
+            IsOptional = false,
+            Pagebreak = true
+        };
+
+        var json = JsonSerializer.Serialize<Position>(original);
+        var roundTripped = JsonSerializer.Deserialize<Position>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"KbPositionPagebreak\""));
+            Assert.That(roundTripped, Is.InstanceOf<PositionPagebreak>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     A <see cref="PositionDiscount" /> round-trips preserving its fields and its
+    ///     <c>KbPositionDiscount</c> discriminator.
+    /// </summary>
+    [Test]
+    public void PositionDiscount_RoundTrips_PreservesAllFields()
+    {
+        var original = new PositionDiscount
+        {
+            Id = 7,
+            Text = "Loyalty discount",
+            IsPercentual = true,
+            Value = "10.000000",
+            DiscountTotal = "15.00"
+        };
+
+        var json = JsonSerializer.Serialize<Position>(original);
+        var roundTripped = JsonSerializer.Deserialize<Position>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"type\":\"KbPositionDiscount\""));
+            Assert.That(roundTripped, Is.InstanceOf<PositionDiscount>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     A mixed list of <see cref="Position" /> variants round-trips through serialization
+    ///     preserving order, runtime types and field values — the path exercised by Bexio's document
+    ///     responses, which return a heterogeneous <c>positions</c> array.
+    /// </summary>
+    [Test]
+    public void MixedPositionList_RoundTrips_PreservesRuntimeTypes()
+    {
+        var original = new List<Position>
+        {
+            new PositionArticle { Id = 1, Text = "Article", Amount = "1.000000", UnitPrice = "10.000000" },
+            new PositionText { Id = 2, Text = "Notes" },
+            new PositionSubtotal { Id = 3, Text = "Running subtotal", Value = "10.00" },
+            new PositionDiscount { Id = 4, Text = "-5%", IsPercentual = true, Value = "5.000000" }
+        };
+
+        var json = JsonSerializer.Serialize<IReadOnlyList<Position>>(original);
+        var roundTripped = JsonSerializer.Deserialize<IReadOnlyList<Position>>(json);
+
+        Assert.That(roundTripped, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(roundTripped!, Has.Count.EqualTo(4));
+            Assert.That(roundTripped[0], Is.InstanceOf<PositionArticle>());
+            Assert.That(roundTripped[1], Is.InstanceOf<PositionText>());
+            Assert.That(roundTripped[2], Is.InstanceOf<PositionSubtotal>());
+            Assert.That(roundTripped[3], Is.InstanceOf<PositionDiscount>());
+            Assert.That(roundTripped, Is.EqualTo(original));
+        });
+    }
+
+    /// <summary>
+    ///     Deserializing a position payload whose <c>type</c> discriminator is unknown to the
+    ///     converter must surface a <see cref="JsonException" /> rather than silently returning a
+    ///     default instance — a payload Bexio should never emit, but worth failing fast on.
+    /// </summary>
+    [Test]
+    public void UnknownDiscriminator_ThrowsJsonException()
+    {
+        const string payload = """{"type":"KbPositionUnknown","id":1}""";
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Position>(payload));
+    }
+
+    /// <summary>
+    ///     Deserializing a position payload missing the <c>type</c> discriminator altogether must
+    ///     surface a <see cref="JsonException" /> rather than silently returning a default instance.
+    /// </summary>
+    [Test]
+    public void MissingDiscriminator_ThrowsJsonException()
+    {
+        const string payload = """{"id":1,"text":"no type"}""";
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Position>(payload));
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Sales/Positions/PositionJsonConverterTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/Positions/PositionJsonConverterTests.cs
@@ -29,17 +29,17 @@ using BexioApiNet.Abstractions.Models.Sales.Positions;
 namespace BexioApiNet.UnitTests.Sales.Positions;
 
 /// <summary>
-///     Round-trip tests for the polymorphic <see cref="Position" /> union. Each concrete variant
-///     must serialize to the JSON shape Bexio expects (including the <c>type</c> discriminator) and
-///     must deserialize back into the same concrete subtype when read from a Bexio response.
+/// Round-trip tests for the polymorphic <see cref="Position" /> union. Each concrete variant
+/// must serialize to the JSON shape Bexio expects (including the <c>type</c> discriminator) and
+/// must deserialize back into the same concrete subtype when read from a Bexio response.
 /// </summary>
 [TestFixture]
 public sealed class PositionJsonConverterTests
 {
     /// <summary>
-    ///     A <see cref="PositionArticle" /> round-trips through
-    ///     <see cref="JsonSerializer" /> preserving every field and the <c>KbPositionArticle</c>
-    ///     discriminator.
+    /// A <see cref="PositionArticle" /> round-trips through
+    /// <see cref="JsonSerializer" /> preserving every field and the <c>KbPositionArticle</c>
+    /// discriminator.
     /// </summary>
     [Test]
     public void PositionArticle_RoundTrips_PreservesAllFields()
@@ -73,8 +73,8 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     A <see cref="PositionCustom" /> round-trips preserving its fields and its
-    ///     <c>KbPositionCustom</c> discriminator.
+    /// A <see cref="PositionCustom" /> round-trips preserving its fields and its
+    /// <c>KbPositionCustom</c> discriminator.
     /// </summary>
     [Test]
     public void PositionCustom_RoundTrips_PreservesAllFields()
@@ -106,8 +106,8 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     A <see cref="PositionText" /> round-trips preserving its fields and its
-    ///     <c>KbPositionText</c> discriminator.
+    /// A <see cref="PositionText" /> round-trips preserving its fields and its
+    /// <c>KbPositionText</c> discriminator.
     /// </summary>
     [Test]
     public void PositionText_RoundTrips_PreservesAllFields()
@@ -134,8 +134,8 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     A <see cref="PositionSubposition" /> round-trips preserving its fields and its
-    ///     <c>KbPositionSubposition</c> discriminator.
+    /// A <see cref="PositionSubposition" /> round-trips preserving its fields and its
+    /// <c>KbPositionSubposition</c> discriminator.
     /// </summary>
     [Test]
     public void PositionSubposition_RoundTrips_PreservesAllFields()
@@ -164,8 +164,8 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     A <see cref="PositionSubtotal" /> round-trips preserving its fields and its
-    ///     <c>KbPositionSubtotal</c> discriminator.
+    /// A <see cref="PositionSubtotal" /> round-trips preserving its fields and its
+    /// <c>KbPositionSubtotal</c> discriminator.
     /// </summary>
     [Test]
     public void PositionSubtotal_RoundTrips_PreservesAllFields()
@@ -191,8 +191,8 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     A <see cref="PositionPagebreak" /> round-trips preserving its fields and its
-    ///     <c>KbPositionPagebreak</c> discriminator.
+    /// A <see cref="PositionPagebreak" /> round-trips preserving its fields and its
+    /// <c>KbPositionPagebreak</c> discriminator.
     /// </summary>
     [Test]
     public void PositionPagebreak_RoundTrips_PreservesAllFields()
@@ -217,8 +217,8 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     A <see cref="PositionDiscount" /> round-trips preserving its fields and its
-    ///     <c>KbPositionDiscount</c> discriminator.
+    /// A <see cref="PositionDiscount" /> round-trips preserving its fields and its
+    /// <c>KbPositionDiscount</c> discriminator.
     /// </summary>
     [Test]
     public void PositionDiscount_RoundTrips_PreservesAllFields()
@@ -244,9 +244,9 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     A mixed list of <see cref="Position" /> variants round-trips through serialization
-    ///     preserving order, runtime types and field values — the path exercised by Bexio's document
-    ///     responses, which return a heterogeneous <c>positions</c> array.
+    /// A mixed list of <see cref="Position" /> variants round-trips through serialization
+    /// preserving order, runtime types and field values — the path exercised by Bexio's document
+    /// responses, which return a heterogeneous <c>positions</c> array.
     /// </summary>
     [Test]
     public void MixedPositionList_RoundTrips_PreservesRuntimeTypes()
@@ -275,9 +275,9 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     Deserializing a position payload whose <c>type</c> discriminator is unknown to the
-    ///     converter must surface a <see cref="JsonException" /> rather than silently returning a
-    ///     default instance — a payload Bexio should never emit, but worth failing fast on.
+    /// Deserializing a position payload whose <c>type</c> discriminator is unknown to the
+    /// converter must surface a <see cref="JsonException" /> rather than silently returning a
+    /// default instance — a payload Bexio should never emit, but worth failing fast on.
     /// </summary>
     [Test]
     public void UnknownDiscriminator_ThrowsJsonException()
@@ -288,8 +288,8 @@ public sealed class PositionJsonConverterTests
     }
 
     /// <summary>
-    ///     Deserializing a position payload missing the <c>type</c> discriminator altogether must
-    ///     surface a <see cref="JsonException" /> rather than silently returning a default instance.
+    /// Deserializing a position payload missing the <c>type</c> discriminator altogether must
+    /// surface a <see cref="JsonException" /> rather than silently returning a default instance.
     /// </summary>
     [Test]
     public void MissingDiscriminator_ThrowsJsonException()

--- a/tests/BexioApiNet.UnitTests/Sales/QuoteServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Sales/QuoteServiceTests.cs
@@ -35,16 +35,16 @@ using BexioApiNet.Services.Connectors.Sales;
 namespace BexioApiNet.UnitTests.Sales;
 
 /// <summary>
-///     Offline unit tests for <see cref="QuoteService" />. Each test verifies that the service
-///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
-///     returns the handler's result unchanged. No network, no filesystem access.
+/// Offline unit tests for <see cref="QuoteService" />. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected arguments and
+/// returns the handler's result unchanged. No network, no filesystem access.
 /// </summary>
 [TestFixture]
 public sealed class QuoteServiceTests : ServiceTestBase
 {
     /// <summary>
-    ///     Creates a fresh <see cref="QuoteService" /> per test, bound to the
-    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// Creates a fresh <see cref="QuoteService" /> per test, bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
     /// </summary>
     [SetUp]
     public void CreateSut()
@@ -57,8 +57,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     private QuoteService _sut = null!;
 
     /// <summary>
-    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
-    ///     the expected endpoint path and a null query parameter.
+    /// Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once with
+    /// the expected endpoint path and a null query parameter.
     /// </summary>
     [Test]
     public async Task Get_WithNoParams_CallsGetAsync()
@@ -80,8 +80,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get forwards the <see cref="QueryParameterQuote" />'s underlying <see cref="QueryParameter" />
-    ///     to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
+    /// Get forwards the <see cref="QueryParameterQuote" />'s underlying <see cref="QueryParameter" />
+    /// to the connection handler so the caller's filters (limit/offset/order_by) reach the API.
     /// </summary>
     [Test]
     public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
@@ -104,9 +104,9 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
-    ///     the <c>X-Total-Count</c> header is present and the initial response only returned a page of
-    ///     the full result set.
+    /// Get (autoPage = true) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" /> when
+    /// the <c>X-Total-Count</c> header is present and the initial response only returned a page of
+    /// the full result set.
     /// </summary>
     [Test]
     public async Task Get_WithAutoPage_CallsFetchAll()
@@ -148,8 +148,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
-    ///     auto-paging is not requested.
+    /// Get returns the <see cref="ApiResult{T}" /> produced by the connection handler when
+    /// auto-paging is not requested.
     /// </summary>
     [Test]
     public async Task Get_ReturnsApiResult()
@@ -168,8 +168,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
-    ///     endpoint path including the quote id.
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with the expected
+    /// endpoint path including the quote id.
     /// </summary>
     [Test]
     public async Task GetById_CallsGetAsync_WithIdInPath()
@@ -190,8 +190,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
-    ///     <c>/{id}/pdf</c> sub-resource.
+    /// GetPdf calls <see cref="IBexioConnectionHandler.GetBinaryAsync" /> against the
+    /// <c>/{id}/pdf</c> sub-resource.
     /// </summary>
     [Test]
     public async Task GetPdf_CallsGetBinaryAsync_WithIdInPath()
@@ -211,8 +211,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Create forwards the payload and the expected endpoint path to
-    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// Create forwards the payload and the expected endpoint path to
+    /// <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
     /// </summary>
     [Test]
     public async Task Create_CallsPostAsync()
@@ -235,8 +235,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
-    ///     <c>/2.0/kb_offer/{id}</c> — Bexio edits quotes via POST on this resource.
+    /// Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}" /> (not PUT) at
+    /// <c>/2.0/kb_offer/{id}</c> — Bexio edits quotes via POST on this resource.
     /// </summary>
     [Test]
     public async Task Update_CallsPostAsync_WithIdInPath()
@@ -258,8 +258,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the quote id
-    ///     appended to the endpoint root.
+    /// Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the quote id
+    /// appended to the endpoint root.
     /// </summary>
     [Test]
     public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
@@ -279,8 +279,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
-    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
+    /// Search forwards the criteria, the <c>/search</c> path and the optional query parameter to
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" />.
     /// </summary>
     [Test]
     public async Task Search_CallsPostSearchAsync()
@@ -309,7 +309,7 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
+    /// Issue posts to the <c>/{id}/issue</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task Issue_CallsPostActionAsync_WithIssuePath()
@@ -329,9 +329,9 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     RevertIssue posts to the <c>/{id}/revertIssue</c> action endpoint with no request body. Note
-    ///     that Bexio uses camelCase <c>revertIssue</c> on quotes (different from the snake_case used on
-    ///     invoices).
+    /// RevertIssue posts to the <c>/{id}/revertIssue</c> action endpoint with no request body. Note
+    /// that Bexio uses camelCase <c>revertIssue</c> on quotes (different from the snake_case used on
+    /// invoices).
     /// </summary>
     [Test]
     public async Task RevertIssue_CallsPostActionAsync_WithRevertIssuePath()
@@ -351,7 +351,7 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Accept posts to the <c>/{id}/accept</c> action endpoint with no request body.
+    /// Accept posts to the <c>/{id}/accept</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task Accept_CallsPostActionAsync_WithAcceptPath()
@@ -371,8 +371,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Reject posts to the <c>/{id}/reject</c> action endpoint with no request body. Bexio names
-    ///     the method "decline" but exposes it at <c>/reject</c>.
+    /// Reject posts to the <c>/{id}/reject</c> action endpoint with no request body. Bexio names
+    /// the method "decline" but exposes it at <c>/reject</c>.
     /// </summary>
     [Test]
     public async Task Reject_CallsPostActionAsync_WithRejectPath()
@@ -392,7 +392,7 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Reissue posts to the <c>/{id}/reissue</c> action endpoint with no request body.
+    /// Reissue posts to the <c>/{id}/reissue</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task Reissue_CallsPostActionAsync_WithReissuePath()
@@ -412,7 +412,7 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     MarkAsSent posts to the <c>/{id}/mark_as_sent</c> action endpoint with no request body.
+    /// MarkAsSent posts to the <c>/{id}/mark_as_sent</c> action endpoint with no request body.
     /// </summary>
     [Test]
     public async Task MarkAsSent_CallsPostActionAsync_WithMarkAsSentPath()
@@ -432,7 +432,7 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Send posts the <see cref="QuoteSendRequest"/> body to the <c>/{id}/send</c> endpoint.
+    /// Send posts the <see cref="QuoteSendRequest"/> body to the <c>/{id}/send</c> endpoint.
     /// </summary>
     [Test]
     public async Task Send_CallsPostAsync_WithSendPath()
@@ -457,7 +457,7 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     Copy posts the <see cref="QuoteCopyRequest"/> body to the <c>/{id}/copy</c> endpoint.
+    /// Copy posts the <see cref="QuoteCopyRequest"/> body to the <c>/{id}/copy</c> endpoint.
     /// </summary>
     [Test]
     public async Task Copy_CallsPostAsync_WithCopyPath()
@@ -483,8 +483,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     CreateOrderFromQuote posts the optional <see cref="QuoteConvertRequest"/> body to the
-    ///     <c>/{id}/order</c> endpoint and returns the newly created <see cref="Order"/>.
+    /// CreateOrderFromQuote posts the optional <see cref="QuoteConvertRequest"/> body to the
+    /// <c>/{id}/order</c> endpoint and returns the newly created <see cref="Order"/>.
     /// </summary>
     [Test]
     public async Task CreateOrderFromQuote_CallsPostAsync_WithOrderPath()
@@ -506,8 +506,8 @@ public sealed class QuoteServiceTests : ServiceTestBase
     }
 
     /// <summary>
-    ///     CreateInvoiceFromQuote posts the optional <see cref="QuoteConvertRequest"/> body to the
-    ///     <c>/{id}/invoice</c> endpoint and returns the newly created <see cref="Invoice"/>.
+    /// CreateInvoiceFromQuote posts the optional <see cref="QuoteConvertRequest"/> body to the
+    /// <c>/{id}/invoice</c> endpoint and returns the newly created <see cref="Invoice"/>.
     /// </summary>
     [Test]
     public async Task CreateInvoiceFromQuote_CallsPostAsync_WithInvoicePath()


### PR DESCRIPTION
## Summary

Resolves #59 — removes raw `JsonElement` from the two polymorphic union surfaces in the Sales Documents API and replaces them with a fully-typed discriminated-union hierarchy backed by custom `System.Text.Json` converters.

### Part A — Position union (`anyOf` over `kb_position_*`)
- New `Position` abstract record + 7 sealed concrete subtypes: `PositionArticle`, `PositionCustom`, `PositionDiscount`, `PositionPagebreak`, `PositionSubposition`, `PositionSubtotal`, `PositionText`
- `PositionJsonConverter` dispatches on the `type` discriminator field
- All 7 affected DTO `Positions` properties changed from `IReadOnlyList<JsonElement>?` → `IReadOnlyList<Position>?`

### Part B — OrderRepetition union (`oneOf` over repetition schedules)
- New `OrderRepetitionSchedule` abstract record + 4 sealed concrete subtypes: `OrderRepetitionDaily`, `OrderRepetitionWeekly`, `OrderRepetitionMonthly`, `OrderRepetitionYearly`
- `OrderRepetitionScheduleJsonConverter` dispatches on the `type` discriminator
- `OrderRepetition.Repetition` and `OrderRepetitionCreate.Repetition` changed from `JsonElement?`/`JsonElement` to the strongly-typed union

### Shared infrastructure
- `DiscriminatedJsonConverter<TBase>` base class in `BexioApiNet.Abstractions.Json` — avoids write-recursion pitfall, registered once via `[JsonConverter]` on the abstract base

### Tests
- Round-trip serialize → deserialize → `Equals` tests for every variant (7 Position + 4 OrderRepetition subtypes)
- Mixed-list test verifying runtime types survive list deserialization
- Negative cases: unknown discriminator, missing discriminator → `JsonException`
- All 444 offline tests pass (0 failures)

### Breaking change
- Callers that previously read `JsonElement` fields must migrate to pattern-match on the concrete subtypes. Migration guide in `doc/ai-readiness.md`.

## Verification
- Build: `dotnet build` → 0 errors, 0 warnings
- Tests: `dotnet test --filter "TestCategory!=E2E"` → 444 passed, 0 failed
- Verification agent: **VERDICT: APPROVED**

## Documentation
- Migration note added to `doc/ai-readiness.md`
- ADR-003 added at `doc/architecture/decisions/003-polymorphic-unions.md`
- `ai_instructions.md` Rule 8 added: use `DiscriminatedJsonConverter<TBase>` for `anyOf`/`oneOf` types

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)