### PR TITLE
feat: Wave 5 — Purchase, Expenses & Payroll (31 endpoints, 6 services)

### DIFF
--- a/doc/ai-readiness.md
+++ b/doc/ai-readiness.md
@@ -5,7 +5,7 @@ tags: [readiness, ai, assessment]
 
 # AI Readiness Assessment
 
-_Last updated: 2026-04-19 (Issue #59 — typed polymorphic positions and order-repetition schedules)_
+_Last updated: 2026-04-24 (Issue #28 — Wave 5 Purchase, Expenses & Payroll services)_
 
 ## Section 1: Documentation Quality
 The documentation landscape for this project is formal and AI-aware.
@@ -33,16 +33,17 @@ Three-tier testing strategy now in place: offline unit tests, offline integratio
     - Live E2E only: `dotnet test --filter TestCategory=E2E` (requires `BexioApiNet__BaseUri` + `BexioApiNet__JwtToken`)
     - CI-safe default (Offline only): `dotnet test --filter TestCategory!=E2E`
 - **What IS covered today**:
-  - **Unit tests**: AccountService, CurrencyService, TaxService, BankAccountService, ManualEntryService, BexioConnectionHandler, Item-related services, Position-related services
-  - **Integration tests**: Cancellation, Concurrency, ErrorResponse, Pagination, ParamValidation, per-service integration tests (Accounting / Banking / Contacts / Items / Sales domains)
+  - **Unit tests**: AccountService, CurrencyService, TaxService, BankAccountService, ManualEntryService, BexioConnectionHandler, Item-related services, Position-related services, Wave 5 services (BillService, PurchaseOrderService, ExpenseService, EmployeeService, AbsenceService, PaystubService)
+  - **Integration tests**: Cancellation, Concurrency, ErrorResponse, Pagination, ParamValidation, per-service integration tests (Accounting / Banking / Contacts / Items / Sales / Purchases / Expenses / Payroll domains)
   - **E2E tests**:
     - `Accounting/Accounts/GetAll`
     - `Accounting/Currencies/GetAll`
     - `Accounting/ManualEntries` (Create, CreateAndAddFile, CreateAndAddFileFromStream, GetAll, GetAllAndDelete)
     - `Accounting/Taxes/GetAll`
     - `Banking/BankAccount/GetAll`
+    - `Purchases/Bills`, `Purchases/PurchaseOrders`, `Expenses/Expenses`, `Payroll/Employees`, `Payroll/Absences`, `Payroll/Paystubs` (Wave 5 — graceful skip when no creds)
 - **What is NOT covered**:
-  - Significant portions of the Bexio API (Projects, Timesheets, Payroll, etc.) are not yet implemented.
+  - Remaining Bexio domains not yet implemented (Files & Documents, Master Data & Settings — Waves 6).
 - **Test quality assessment**:
   - Offline tests are comprehensive and fast. The E2E test suite skips gracefully, unblocking agents and CI that lack credentials. The E2E base class `BexioE2eTestBase` is categorized `[Category("E2E")]`, and offline test classes are categorized `[Category("Unit")]` or `[Category("Integration")]`.
 - **Rate**: Partial Coverage (ready to expand; infrastructure is in place)
@@ -99,6 +100,4 @@ Three-tier testing strategy now in place: offline unit tests, offline integratio
 | Vendor Bexio OpenAPI Spec | Issue #8 — `doc/openapi/bexio-v3.json` committed (OpenAPI 3.0.2, API v3.0.0, 355 paths, retrieved 2026-04-18). Refresh procedure in `doc/openapi/README.md`. |
 | Typed polymorphic positions and repetition schedules | Issue #59 — `IReadOnlyList<JsonElement>? Positions` replaced by `IReadOnlyList<Position>?` on 9 DTOs; `JsonElement? Repetition` replaced by `OrderRepetitionSchedule?` on 2 DTOs. Round-trip tests cover every variant. |
 | API Doc Comparison & Audit | Issue #71 — Wave 3 implementation audited against OpenAPI spec. 36 connector services fully compliant. Zero discrepancies found. |
-trip tests cover every variant. |
-over every variant. |
-trip tests cover every variant. |
+| Wave 5 — Purchase, Expenses & Payroll | Issue #28 — 6 new connector services: `BillService` (#86, `/4.0/purchase/bills`), `PurchaseOrderService` (#87, `/3.0/purchase_orders`), `ExpenseService` (#88, `/4.0/expenses`), `EmployeeService` (#89, `/4.0/payroll/employees`, PATCH verb), `AbsenceService` (#90, nested under employees), and `PaystubService` (#91, binary PDF). Total 31 new endpoint methods → implemented coverage 62.1% → 72.2%. |

--- a/doc/analysis/api-completeness-audit.md
+++ b/doc/analysis/api-completeness-audit.md
@@ -10,8 +10,8 @@ status: tracking
 Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implementation status. Source of truth: vendored OpenAPI spec at `doc/openapi/bexio-v3.json`.
 
 **Total endpoint methods:** 309  
-**Implemented:** 192 (62.1%)  
-**Remaining:** 117 (37.9%)
+**Implemented:** 223 (72.2%)  
+**Remaining:** 86 (27.8%)
 
 ---
 
@@ -29,11 +29,11 @@ Full inventory of the Bexio REST API v3.0.0 mapped against BexioApiNet implement
 | 8 | Document Positions | 7 | 35 | 35 | 0 | 3 |
 | 9 | Projects | 1 | 20 | 0 | 20 | 4 |
 | 10 | Timesheets & Tasks | 3 | 18 | 0 | 18 | 4 |
-| 11 | Purchase & Expenses | 3 | 21 | 0 | 21 | 5 |
-| 12 | Payroll | 3 | 10 | 0 | 10 | 5 |
+| 11 | Purchase & Expenses | 3 | 21 | 21 | 0 | 5 |
+| 12 | Payroll | 3 | 10 | 10 | 0 | 5 |
 | 13 | Files & Documents | 3 | 11 | 0 | 11 | 6 |
 | 14 | Master Data & Settings | 9 | 42 | 0 | 42 | 6 |
-| | **TOTAL** | **56** | **309** | **192** | **117** | |
+| | **TOTAL** | **56** | **309** | **223** | **86** | |
 
 ---
 
@@ -489,72 +489,72 @@ All position types share the same polymorphic pattern: CRUD on `/{kb_document_ty
 
 ---
 
-## Domain Group 11: Purchase & Expenses — Wave 5
+## Domain Group 11: Purchase & Expenses — Wave 5 — DONE
 
-### Tag: Bills (8 endpoints)
-
-| Method | Path | Status | Service |
-|--------|------|--------|---------|
-| GET | `/4.0/purchase/bills` | TODO | BillService |
-| GET | `/4.0/purchase/bills/{id}` | TODO | BillService |
-| GET | `/4.0/purchase/documentnumbers/bills` | TODO | BillService |
-| POST | `/4.0/purchase/bills` | TODO | BillService |
-| POST | `/4.0/purchase/bills/{id}/actions` | TODO | BillService |
-| PUT | `/4.0/purchase/bills/{id}` | TODO | BillService |
-| PUT | `/4.0/purchase/bills/{id}/bookings/{status}` | TODO | BillService |
-| DELETE | `/4.0/purchase/bills/{id}` | TODO | BillService |
-
-### Tag: Purchase Orders (5 endpoints)
+### Tag: Bills (8 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/3.0/purchase_orders` | TODO | PurchaseOrderService |
-| GET | `/3.0/purchase_orders/{purchase_order_id}` | TODO | PurchaseOrderService |
-| POST | `/3.0/purchase_orders` | TODO | PurchaseOrderService |
-| PUT | `/3.0/purchase_orders/{purchase_order_id}` | TODO | PurchaseOrderService |
-| DELETE | `/3.0/purchase_orders/{purchase_order_id}` | TODO | PurchaseOrderService |
+| GET | `/4.0/purchase/bills` | DONE | BillService |
+| GET | `/4.0/purchase/bills/{id}` | DONE | BillService |
+| GET | `/4.0/purchase/documentnumbers/bills` | DONE | BillService |
+| POST | `/4.0/purchase/bills` | DONE | BillService |
+| POST | `/4.0/purchase/bills/{id}/actions` | DONE | BillService |
+| PUT | `/4.0/purchase/bills/{id}` | DONE | BillService |
+| PUT | `/4.0/purchase/bills/{id}/bookings/{status}` | DONE | BillService |
+| DELETE | `/4.0/purchase/bills/{id}` | DONE | BillService |
 
-### Tag: Expenses (8 endpoints)
+### Tag: Purchase Orders (5 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/4.0/expenses` | TODO | ExpenseService |
-| GET | `/4.0/expenses/{id}` | TODO | ExpenseService |
-| GET | `/4.0/expenses/documentnumbers` | TODO | ExpenseService |
-| POST | `/4.0/expenses` | TODO | ExpenseService |
-| POST | `/4.0/expenses/{id}/actions` | TODO | ExpenseService |
-| PUT | `/4.0/expenses/{id}` | TODO | ExpenseService |
-| PUT | `/4.0/expenses/{id}/bookings/{status}` | TODO | ExpenseService |
-| DELETE | `/4.0/expenses/{id}` | TODO | ExpenseService |
+| GET | `/3.0/purchase_orders` | DONE | PurchaseOrderService |
+| GET | `/3.0/purchase_orders/{purchase_order_id}` | DONE | PurchaseOrderService |
+| POST | `/3.0/purchase_orders` | DONE | PurchaseOrderService |
+| PUT | `/3.0/purchase_orders/{purchase_order_id}` | DONE | PurchaseOrderService |
+| DELETE | `/3.0/purchase_orders/{purchase_order_id}` | DONE | PurchaseOrderService |
+
+### Tag: Expenses (8 endpoints) — DONE
+
+| Method | Path | Status | Service |
+|--------|------|--------|---------|
+| GET | `/4.0/expenses` | DONE | ExpenseService |
+| GET | `/4.0/expenses/{id}` | DONE | ExpenseService |
+| GET | `/4.0/expenses/documentnumbers` | DONE | ExpenseService |
+| POST | `/4.0/expenses` | DONE | ExpenseService |
+| POST | `/4.0/expenses/{id}/actions` | DONE | ExpenseService |
+| PUT | `/4.0/expenses/{id}` | DONE | ExpenseService |
+| PUT | `/4.0/expenses/{id}/bookings/{status}` | DONE | ExpenseService |
+| DELETE | `/4.0/expenses/{id}` | DONE | ExpenseService |
 
 ---
 
-## Domain Group 12: Payroll — Wave 5
+## Domain Group 12: Payroll — Wave 5 — DONE
 
-### Tag: Employees (4 endpoints)
-
-| Method | Path | Status | Service |
-|--------|------|--------|---------|
-| GET | `/4.0/payroll/employees` | TODO | EmployeeService |
-| GET | `/4.0/payroll/employees/{employeeId}` | TODO | EmployeeService |
-| POST | `/4.0/payroll/employees` | TODO | EmployeeService |
-| PATCH | `/4.0/payroll/employees/{employeeId}` | TODO | EmployeeService |
-
-### Tag: Absences (5 endpoints)
+### Tag: Employees (4 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/4.0/payroll/employees/{employeeId}/absences` | TODO | AbsenceService |
-| GET | `/4.0/payroll/employees/{employeeId}/absences/{absenceId}` | TODO | AbsenceService |
-| POST | `/4.0/payroll/employees/{employeeId}/absences` | TODO | AbsenceService |
-| PUT | `/4.0/payroll/employees/{employeeId}/absences/{absenceId}` | TODO | AbsenceService |
-| DELETE | `/4.0/payroll/employees/{employeeId}/absences/{absenceId}` | TODO | AbsenceService |
+| GET | `/4.0/payroll/employees` | DONE | EmployeeService |
+| GET | `/4.0/payroll/employees/{employeeId}` | DONE | EmployeeService |
+| POST | `/4.0/payroll/employees` | DONE | EmployeeService |
+| PATCH | `/4.0/payroll/employees/{employeeId}` | DONE | EmployeeService |
 
-### Tag: Documents/Paystubs (1 endpoint)
+### Tag: Absences (5 endpoints) — DONE
 
 | Method | Path | Status | Service |
 |--------|------|--------|---------|
-| GET | `/4.0/payroll/employees/{employeeId}/paystub-pdf/{year}/{month}` | TODO | PaystubService |
+| GET | `/4.0/payroll/employees/{employeeId}/absences` | DONE | AbsenceService |
+| GET | `/4.0/payroll/employees/{employeeId}/absences/{absenceId}` | DONE | AbsenceService |
+| POST | `/4.0/payroll/employees/{employeeId}/absences` | DONE | AbsenceService |
+| PUT | `/4.0/payroll/employees/{employeeId}/absences/{absenceId}` | DONE | AbsenceService |
+| DELETE | `/4.0/payroll/employees/{employeeId}/absences/{absenceId}` | DONE | AbsenceService |
+
+### Tag: Documents/Paystubs (1 endpoint) — DONE
+
+| Method | Path | Status | Service |
+|--------|------|--------|---------|
+| GET | `/4.0/payroll/employees/{employeeId}/paystub-pdf/{year}/{month}` | DONE | PaystubService |
 
 ---
 

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Enums/ExpenseAction.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Enums/ExpenseAction.cs
@@ -1,0 +1,40 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+
+/// <summary>
+/// Actions accepted by <c>POST /4.0/expenses/expenses/{id}/actions</c>.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ExpenseAction
+{
+    /// <summary>
+    /// Duplicate the expense and return the newly created duplicate.
+    /// </summary>
+    DUPLICATE
+}

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Enums/ExpenseAddressType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Enums/ExpenseAddressType.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+
+/// <summary>
+/// Expense address contact type.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ExpenseAddressType
+{
+    /// <summary>
+    /// Private (natural person) contact type.
+    /// </summary>
+    PRIVATE,
+
+    /// <summary>
+    /// Company (legal entity) contact type.
+    /// </summary>
+    COMPANY
+}

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Enums/ExpenseBookingStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Enums/ExpenseBookingStatus.cs
@@ -1,0 +1,47 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+
+/// <summary>
+/// Target status for the <c>PUT /4.0/expenses/expenses/{id}/bookings/{status}</c> endpoint.
+/// Only <c>DRAFT</c> and <c>BOOKED</c> are accepted as booking transition targets.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ExpenseBookingStatus
+{
+    /// <summary>
+    /// Transition the expense back to <c>DRAFT</c> status. Only allowed from <c>BOOKED</c>.
+    /// </summary>
+    DRAFT,
+
+    /// <summary>
+    /// Transition the expense to <c>BOOKED</c> status. Only allowed from <c>DRAFT</c> and
+    /// triggers the full set of booking validations in the Bexio API.
+    /// </summary>
+    BOOKED
+}

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Enums/ExpenseStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Enums/ExpenseStatus.cs
@@ -1,0 +1,95 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+
+/// <summary>
+/// Expense status as returned by the Bexio v4.0 <c>/expenses/expenses</c> endpoints.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ExpenseStatus
+{
+    /// <summary>
+    /// Expense is a draft and has not yet been booked.
+    /// </summary>
+    DRAFT,
+
+    /// <summary>
+    /// Expense has been booked.
+    /// </summary>
+    BOOKED,
+
+    /// <summary>
+    /// Payment has been partially created for this expense.
+    /// </summary>
+    PARTIALLY_CREATED,
+
+    /// <summary>
+    /// Payment has been fully created for this expense.
+    /// </summary>
+    CREATED,
+
+    /// <summary>
+    /// Payment has been partially sent.
+    /// </summary>
+    PARTIALLY_SENT,
+
+    /// <summary>
+    /// Payment has been sent.
+    /// </summary>
+    SENT,
+
+    /// <summary>
+    /// Payment has been partially downloaded.
+    /// </summary>
+    PARTIALLY_DOWNLOADED,
+
+    /// <summary>
+    /// Payment has been downloaded.
+    /// </summary>
+    DOWNLOADED,
+
+    /// <summary>
+    /// Expense has been partially paid.
+    /// </summary>
+    PARTIALLY_PAID,
+
+    /// <summary>
+    /// Expense has been fully paid.
+    /// </summary>
+    PAID,
+
+    /// <summary>
+    /// Payment has partially failed.
+    /// </summary>
+    PARTIALLY_FAILED,
+
+    /// <summary>
+    /// Payment has failed.
+    /// </summary>
+    FAILED
+}

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Expense.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Expense.cs
@@ -1,0 +1,91 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses;
+
+/// <summary>
+/// Full expense entity returned by the single-item Bexio v4.0 <c>/expenses/expenses</c>
+/// endpoints (GET by id, POST create, PUT update, POST actions, PUT bookings/{status}).
+/// See <see cref="ExpenseListItem"/> for the condensed form returned by the list endpoint.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="Id">Unique expense identifier.</param>
+/// <param name="DocumentNo">Unique expense document number. Auto-generated on creation.</param>
+/// <param name="Status">Expense status.</param>
+/// <param name="LastnameCompany">Supplier family name or company name.</param>
+/// <param name="CreatedAt">Creation timestamp.</param>
+/// <param name="SupplierId">Identifier of the supplier contact.</param>
+/// <param name="ContactPartnerId">Identifier of the Bexio contact partner.</param>
+/// <param name="ManualAmount">Whether <c>AmountMan</c> (true) or <c>AmountCalc</c> (false) is the authoritative expense amount.</param>
+/// <param name="ExpenseDate">Expense issue date.</param>
+/// <param name="DueDate">Due date for payment.</param>
+/// <param name="Address">Address attached to the expense.</param>
+/// <param name="LineItems">Line items on the expense.</param>
+/// <param name="Discounts">Discounts applied to the expense.</param>
+/// <param name="ItemNet">Whether line-item amounts are net (<see langword="true"/>) or gross (<see langword="false"/>).</param>
+/// <param name="SplitIntoLineItems">Whether the expense has multiple line items or a single aggregate one.</param>
+/// <param name="CurrencyCode">ISO currency code of the expense.</param>
+/// <param name="BaseCurrencyCode">Base currency code taken from the Bexio account settings.</param>
+/// <param name="Overdue">True when <see cref="DueDate"/> has passed. Not applicable to <c>DRAFT</c> or <c>PAID</c>.</param>
+/// <param name="AttachmentIds">Bexio file identifiers attached to the expense.</param>
+/// <param name="Title">Free-form expense title.</param>
+/// <param name="FirstnameSuffix">Supplier first name or suffix.</param>
+/// <param name="VendorRef">Vendor reference text.</param>
+/// <param name="PendingAmount">Remaining amount to be paid.</param>
+/// <param name="AmountMan">Manual amount. Considered authoritative when <see cref="ManualAmount"/> is <see langword="true"/>.</param>
+/// <param name="AmountCalc">Calculated amount. Considered authoritative when <see cref="ManualAmount"/> is <see langword="false"/>.</param>
+/// <param name="ExchangeRate">Exchange rate applied when <see cref="CurrencyCode"/> differs from <see cref="BaseCurrencyCode"/>.</param>
+/// <param name="BaseCurrencyAmount">Expense amount expressed in the base currency.</param>
+public sealed record Expense(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("document_no")] string DocumentNo,
+    [property: JsonPropertyName("status")] ExpenseStatus Status,
+    [property: JsonPropertyName("lastname_company")] string LastnameCompany,
+    [property: JsonPropertyName("created_at")] string CreatedAt,
+    [property: JsonPropertyName("supplier_id")] int SupplierId,
+    [property: JsonPropertyName("contact_partner_id")] int ContactPartnerId,
+    [property: JsonPropertyName("manual_amount")] bool ManualAmount,
+    [property: JsonPropertyName("expense_date")] DateOnly ExpenseDate,
+    [property: JsonPropertyName("due_date")] DateOnly DueDate,
+    [property: JsonPropertyName("address")] ExpenseAddress Address,
+    [property: JsonPropertyName("line_items")] IReadOnlyList<ExpenseLineItem> LineItems,
+    [property: JsonPropertyName("discounts")] IReadOnlyList<ExpenseDiscount> Discounts,
+    [property: JsonPropertyName("item_net")] bool ItemNet,
+    [property: JsonPropertyName("split_into_line_items")] bool SplitIntoLineItems,
+    [property: JsonPropertyName("currency_code")] string CurrencyCode,
+    [property: JsonPropertyName("base_currency_code")] string BaseCurrencyCode,
+    [property: JsonPropertyName("overdue")] bool Overdue,
+    [property: JsonPropertyName("attachment_ids")] IReadOnlyList<Guid> AttachmentIds,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("firstname_suffix")] string? FirstnameSuffix = null,
+    [property: JsonPropertyName("vendor_ref")] string? VendorRef = null,
+    [property: JsonPropertyName("pending_amount")] decimal? PendingAmount = null,
+    [property: JsonPropertyName("amount_man")] decimal? AmountMan = null,
+    [property: JsonPropertyName("amount_calc")] decimal? AmountCalc = null,
+    [property: JsonPropertyName("exchange_rate")] decimal? ExchangeRate = null,
+    [property: JsonPropertyName("base_currency_amount")] decimal? BaseCurrencyAmount = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseAddress.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseAddress.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses;
+
+/// <summary>
+/// Address block attached to an expense. The same shape is used on the create/update
+/// payloads and on the responses of the Bexio v4.0 <c>/expenses/expenses</c> endpoints.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="LastnameCompany">Family name (for <c>PRIVATE</c>) or company name (for <c>COMPANY</c>). Required.</param>
+/// <param name="Type">Address contact type (<c>PRIVATE</c> or <c>COMPANY</c>).</param>
+/// <param name="Title">Optional academic or honorific title (e.g. <c>Prof.</c>).</param>
+/// <param name="Salutation">Optional salutation (e.g. <c>Mr</c>, <c>Mrs</c>).</param>
+/// <param name="FirstnameSuffix">Given name or contact suffix.</param>
+/// <param name="AddressLine">Street address line.</param>
+/// <param name="Postcode">Postal code.</param>
+/// <param name="City">City name.</param>
+/// <param name="CountryCode">ISO country code.</param>
+/// <param name="MainContactId">Identifier of the main Bexio contact this address belongs to.</param>
+/// <param name="ContactAddressId">Identifier of the Bexio contact address record this entry was copied from.</param>
+public sealed record ExpenseAddress(
+    [property: JsonPropertyName("lastname_company")] string LastnameCompany,
+    [property: JsonPropertyName("type")] ExpenseAddressType Type,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("salutation")] string? Salutation = null,
+    [property: JsonPropertyName("firstname_suffix")] string? FirstnameSuffix = null,
+    [property: JsonPropertyName("address_line")] string? AddressLine = null,
+    [property: JsonPropertyName("postcode")] string? Postcode = null,
+    [property: JsonPropertyName("city")] string? City = null,
+    [property: JsonPropertyName("country_code")] string? CountryCode = null,
+    [property: JsonPropertyName("main_contact_id")] int? MainContactId = null,
+    [property: JsonPropertyName("contact_address_id")] int? ContactAddressId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseDiscount.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseDiscount.cs
@@ -1,0 +1,41 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses;
+
+/// <summary>
+/// A discount entry on an expense. Shared by the create/update payloads and the
+/// responses. On update, callers must echo an existing <c>Id</c> to preserve a
+/// discount or pass <see langword="null"/> to create a new one.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="Position">Zero-based position of the discount within the expense.</param>
+/// <param name="Amount">Discount amount. Max 17 digits, 2 decimals. Must be greater than 0 when booking.</param>
+/// <param name="Id">Discount identifier. Server-generated on create; echoed on update.</param>
+public sealed record ExpenseDiscount(
+    [property: JsonPropertyName("position")] int Position,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("id")] Guid? Id = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseDocumentNumberResponse.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseDocumentNumberResponse.cs
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses;
+
+/// <summary>
+/// Response payload of <c>GET /4.0/expenses/documentnumbers/expenses</c>. The endpoint
+/// validates a proposed document number against all existing non-draft expenses and
+/// returns the next available number when the proposed one is not unique.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="Valid">Whether the proposed document number is unique among non-draft expenses.</param>
+/// <param name="NextAvailableNo">Next unique document number available to use. Set only when <see cref="Valid"/> is <see langword="false"/>.</param>
+public sealed record ExpenseDocumentNumberResponse(
+    [property: JsonPropertyName("valid")] bool Valid,
+    [property: JsonPropertyName("next_available_no")] string? NextAvailableNo
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseLineItem.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseLineItem.cs
@@ -1,0 +1,49 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses;
+
+/// <summary>
+/// A line item on an expense. Shared by the create/update payloads and the responses —
+/// on creation <c>Id</c> and <c>TaxCalc</c> are absent and set by the server; on
+/// update callers must echo the existing <c>Id</c> or omit it to create a new item.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="Position">Zero-based position of the line item within the expense.</param>
+/// <param name="Amount">Line item amount (net or gross per <c>item_net</c>). Max 17 digits, 2 decimals.</param>
+/// <param name="Id">Line item identifier. Server-generated on create; echoed on update to preserve, or <see langword="null"/> to create a new item.</param>
+/// <param name="Title">Optional line item title.</param>
+/// <param name="TaxId">Optional tax identifier applied to this line item.</param>
+/// <param name="TaxCalc">Server-calculated tax amount based on <c>Amount</c> and <c>TaxId</c>. Read-only.</param>
+/// <param name="BookingAccountId">Booking account identifier. Required when the expense transitions to <c>BOOKED</c>.</param>
+public sealed record ExpenseLineItem(
+    [property: JsonPropertyName("position")] int Position,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("id")] Guid? Id = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("tax_id")] int? TaxId = null,
+    [property: JsonPropertyName("tax_calc")] decimal? TaxCalc = null,
+    [property: JsonPropertyName("booking_account_id")] int? BookingAccountId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseListItem.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseListItem.cs
@@ -1,0 +1,47 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses;
+
+/// <summary>
+/// Condensed expense entry returned by the list endpoint
+/// <c>GET /4.0/expenses/expenses</c>. See <see cref="Expense"/> for the full model returned
+/// by the single-item endpoints.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="Id">Unique expense identifier.</param>
+/// <param name="DocumentNo">Unique expense document number.</param>
+/// <param name="Status">Expense status.</param>
+/// <param name="SupplierId">Identifier of the supplier contact.</param>
+/// <param name="ExpenseDate">Expense date.</param>
+public sealed record ExpenseListItem(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("document_no")] string DocumentNo,
+    [property: JsonPropertyName("status")] ExpenseStatus Status,
+    [property: JsonPropertyName("supplier_id")] int SupplierId,
+    [property: JsonPropertyName("expense_date")] DateOnly ExpenseDate
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseListResponse.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpenseListResponse.cs
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses;
+
+/// <summary>
+/// Envelope response returned by <c>GET /4.0/expenses/expenses</c>.
+/// The v4.0 list endpoints wrap results in a <c>{ data, paging }</c> object instead of
+/// returning a raw array (the convention used by v2.0 / v3.0 endpoints).
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="Data">Expenses matching the query.</param>
+/// <param name="Paging">Pagination metadata for the current page.</param>
+public sealed record ExpenseListResponse(
+    [property: JsonPropertyName("data")] IReadOnlyList<ExpenseListItem> Data,
+    [property: JsonPropertyName("paging")] ExpensePaging Paging
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpensePaging.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/ExpensePaging.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses;
+
+/// <summary>
+/// Paging envelope returned by the list endpoint
+/// <c>GET /4.0/expenses/expenses</c>. Bexio v4.0 list endpoints use page-based
+/// pagination (not offset-based).
+/// </summary>
+/// <param name="Page">Current 1-based page number.</param>
+/// <param name="PageSize">Number of items per page (<c>limit</c> query parameter).</param>
+/// <param name="PageCount">Total number of pages.</param>
+/// <param name="ItemCount">Total number of items across all pages.</param>
+public sealed record ExpensePaging(
+    [property: JsonPropertyName("page")] int Page,
+    [property: JsonPropertyName("page_size")] int PageSize,
+    [property: JsonPropertyName("page_count")] int PageCount,
+    [property: JsonPropertyName("item_count")] int ItemCount
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Views/ExpenseActionRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Views/ExpenseActionRequest.cs
@@ -1,0 +1,37 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses.Views;
+
+/// <summary>
+/// Request body for <c>POST /4.0/expenses/expenses/{id}/actions</c>.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="Action">Action to execute.</param>
+public sealed record ExpenseActionRequest(
+    [property: JsonPropertyName("action")] ExpenseAction Action
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Views/ExpenseCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Views/ExpenseCreate.cs
@@ -1,0 +1,69 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses.Views;
+
+/// <summary>
+/// Create view for <c>POST /4.0/expenses/expenses</c>. All required fields per the Bexio
+/// API spec are non-nullable positional parameters; optional fields default to
+/// <see langword="null"/> and are only serialized when supplied.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="SupplierId">Identifier of the supplier contact.</param>
+/// <param name="ContactPartnerId">Identifier of the Bexio contact partner.</param>
+/// <param name="CurrencyCode">ISO currency code of the expense.</param>
+/// <param name="Address">Address block describing the supplier.</param>
+/// <param name="ExpenseDate">Expense issue date.</param>
+/// <param name="DueDate">Due date for payment.</param>
+/// <param name="ManualAmount">Whether <c>AmountMan</c> (true) or <c>AmountCalc</c> (false) is the authoritative expense amount.</param>
+/// <param name="ItemNet">Whether line-item amounts are net (<see langword="true"/>) or gross (<see langword="false"/>).</param>
+/// <param name="LineItems">Expense line items (1-100).</param>
+/// <param name="Discounts">Discounts applied to the expense (0-100).</param>
+/// <param name="AttachmentIds">Bexio file identifiers to attach to the expense.</param>
+/// <param name="VendorRef">Vendor reference text.</param>
+/// <param name="Title">Free-form expense title.</param>
+/// <param name="AmountMan">Manual amount. Required when <see cref="ManualAmount"/> is <see langword="true"/>.</param>
+/// <param name="AmountCalc">Calculated amount. Required when <see cref="ManualAmount"/> is <see langword="false"/>.</param>
+/// <param name="ExchangeRate">Exchange rate. Required when <see cref="CurrencyCode"/> differs from the base currency.</param>
+/// <param name="BaseCurrencyAmount">Expense amount expressed in the base currency. Required with <see cref="ExchangeRate"/>.</param>
+public sealed record ExpenseCreate(
+    [property: JsonPropertyName("supplier_id")] int SupplierId,
+    [property: JsonPropertyName("contact_partner_id")] int ContactPartnerId,
+    [property: JsonPropertyName("currency_code")] string CurrencyCode,
+    [property: JsonPropertyName("address")] ExpenseAddress Address,
+    [property: JsonPropertyName("expense_date")] DateOnly ExpenseDate,
+    [property: JsonPropertyName("due_date")] DateOnly DueDate,
+    [property: JsonPropertyName("manual_amount")] bool ManualAmount,
+    [property: JsonPropertyName("item_net")] bool ItemNet,
+    [property: JsonPropertyName("line_items")] IReadOnlyList<ExpenseLineItem> LineItems,
+    [property: JsonPropertyName("discounts")] IReadOnlyList<ExpenseDiscount> Discounts,
+    [property: JsonPropertyName("attachment_ids")] IReadOnlyList<Guid> AttachmentIds,
+    [property: JsonPropertyName("vendor_ref")] string? VendorRef = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("amount_man")] decimal? AmountMan = null,
+    [property: JsonPropertyName("amount_calc")] decimal? AmountCalc = null,
+    [property: JsonPropertyName("exchange_rate")] decimal? ExchangeRate = null,
+    [property: JsonPropertyName("base_currency_amount")] decimal? BaseCurrencyAmount = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Views/ExpenseUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Expenses/Expenses/Views/ExpenseUpdate.cs
@@ -1,0 +1,73 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Expenses.Expenses.Views;
+
+/// <summary>
+/// Update view for <c>PUT /4.0/expenses/expenses/{id}</c>. When updating an expense in a status
+/// other than <c>DRAFT</c> the Bexio API only persists <c>file_id</c> and <c>payment</c>
+/// — the other fields must still be supplied but are ignored server-side.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+/// <param name="SupplierId">Identifier of the supplier contact.</param>
+/// <param name="ContactPartnerId">Identifier of the Bexio contact partner.</param>
+/// <param name="CurrencyCode">ISO currency code of the expense.</param>
+/// <param name="Address">Address block describing the supplier.</param>
+/// <param name="ExpenseDate">Expense issue date.</param>
+/// <param name="DueDate">Due date for payment.</param>
+/// <param name="ManualAmount">Whether <c>AmountMan</c> (true) or <c>AmountCalc</c> (false) is the authoritative expense amount.</param>
+/// <param name="ItemNet">Whether line-item amounts are net or gross.</param>
+/// <param name="SplitIntoLineItems">Whether the expense has multiple items (true) or a single aggregate one (false).</param>
+/// <param name="LineItems">Expense line items. Echo <c>Id</c> to preserve, omit to create new. When <see cref="SplitIntoLineItems"/> is <see langword="false"/> exactly one item is allowed.</param>
+/// <param name="Discounts">Discounts applied to the expense. Must be empty when <see cref="SplitIntoLineItems"/> is <see langword="false"/>.</param>
+/// <param name="AttachmentIds">Bexio file identifiers attached to the expense.</param>
+/// <param name="DocumentNo">Optional override for the expense document number.</param>
+/// <param name="Title">Free-form expense title.</param>
+/// <param name="VendorRef">Vendor reference text.</param>
+/// <param name="AmountMan">Manual amount. Required when <see cref="ManualAmount"/> is <see langword="true"/>.</param>
+/// <param name="AmountCalc">Calculated amount. Required when <see cref="ManualAmount"/> is <see langword="false"/>.</param>
+/// <param name="ExchangeRate">Exchange rate. Required when <see cref="CurrencyCode"/> differs from the base currency.</param>
+/// <param name="BaseCurrencyAmount">Expense amount expressed in the base currency.</param>
+public sealed record ExpenseUpdate(
+    [property: JsonPropertyName("supplier_id")] int SupplierId,
+    [property: JsonPropertyName("contact_partner_id")] int ContactPartnerId,
+    [property: JsonPropertyName("currency_code")] string CurrencyCode,
+    [property: JsonPropertyName("address")] ExpenseAddress Address,
+    [property: JsonPropertyName("expense_date")] DateOnly ExpenseDate,
+    [property: JsonPropertyName("due_date")] DateOnly DueDate,
+    [property: JsonPropertyName("manual_amount")] bool ManualAmount,
+    [property: JsonPropertyName("item_net")] bool ItemNet,
+    [property: JsonPropertyName("split_into_line_items")] bool SplitIntoLineItems,
+    [property: JsonPropertyName("line_items")] IReadOnlyList<ExpenseLineItem> LineItems,
+    [property: JsonPropertyName("discounts")] IReadOnlyList<ExpenseDiscount> Discounts,
+    [property: JsonPropertyName("attachment_ids")] IReadOnlyList<Guid> AttachmentIds,
+    [property: JsonPropertyName("document_no")] string? DocumentNo = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("vendor_ref")] string? VendorRef = null,
+    [property: JsonPropertyName("amount_man")] decimal? AmountMan = null,
+    [property: JsonPropertyName("amount_calc")] decimal? AmountCalc = null,
+    [property: JsonPropertyName("exchange_rate")] decimal? ExchangeRate = null,
+    [property: JsonPropertyName("base_currency_amount")] decimal? BaseCurrencyAmount = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Payroll/Absences/Absence.cs
+++ b/src/BexioApiNet.Abstractions/Models/Payroll/Absences/Absence.cs
@@ -1,0 +1,49 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Payroll.Absences;
+
+/// <summary>
+/// Payroll absence entity returned by the Bexio v4.0
+/// <c>/payroll/employees/{employeeId}/absences</c> endpoints (GET list, GET by id,
+/// POST create, PUT update). Absences are nested resources scoped to a single employee.
+/// <see href="https://docs.bexio.com/#tag/Absences">Absences</see>
+/// </summary>
+/// <param name="Id">Unique absence identifier.</param>
+/// <param name="EmployeeId">Identifier of the employee the absence belongs to.</param>
+/// <param name="AbsenceType">Absence type (e.g. <c>SICK</c>, <c>VACATION</c>, <c>MATERNITY</c>).</param>
+/// <param name="StartDate">First day of the absence.</param>
+/// <param name="EndDate">Last day of the absence.</param>
+/// <param name="Status">Approval status (e.g. <c>PENDING</c>, <c>APPROVED</c>, <c>REJECTED</c>).</param>
+/// <param name="CreatedAt">Creation timestamp.</param>
+public sealed record Absence(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("employee_id")] Guid? EmployeeId = null,
+    [property: JsonPropertyName("absence_type")] string? AbsenceType = null,
+    [property: JsonPropertyName("start_date")] DateTime? StartDate = null,
+    [property: JsonPropertyName("end_date")] DateTime? EndDate = null,
+    [property: JsonPropertyName("status")] string? Status = null,
+    [property: JsonPropertyName("created_at")] DateTime? CreatedAt = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Payroll/Absences/Views/AbsenceCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Payroll/Absences/Views/AbsenceCreate.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Payroll.Absences.Views;
+
+/// <summary>
+/// Create view for <c>POST /4.0/payroll/employees/{employeeId}/absences</c>. Optional
+/// fields default to <see langword="null"/> and are only serialized when supplied.
+/// <see href="https://docs.bexio.com/#tag/Absences">Absences</see>
+/// </summary>
+/// <param name="AbsenceType">Absence type (e.g. <c>SICK</c>, <c>VACATION</c>, <c>MATERNITY</c>).</param>
+/// <param name="StartDate">First day of the absence.</param>
+/// <param name="EndDate">Last day of the absence.</param>
+/// <param name="Status">Approval status (e.g. <c>PENDING</c>, <c>APPROVED</c>, <c>REJECTED</c>).</param>
+public sealed record AbsenceCreate(
+    [property: JsonPropertyName("absence_type")] string AbsenceType,
+    [property: JsonPropertyName("start_date")] DateTime StartDate,
+    [property: JsonPropertyName("end_date")] DateTime EndDate,
+    [property: JsonPropertyName("status")] string? Status = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Payroll/Absences/Views/AbsenceUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Payroll/Absences/Views/AbsenceUpdate.cs
@@ -1,0 +1,43 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Payroll.Absences.Views;
+
+/// <summary>
+/// Update view for <c>PUT /4.0/payroll/employees/{employeeId}/absences/{id}</c>. All
+/// fields are nullable to support partial-replacement payloads — only the properties
+/// supplied by the caller are serialized and sent to Bexio.
+/// <see href="https://docs.bexio.com/#tag/Absences">Absences</see>
+/// </summary>
+/// <param name="AbsenceType">Absence type (e.g. <c>SICK</c>, <c>VACATION</c>, <c>MATERNITY</c>).</param>
+/// <param name="StartDate">First day of the absence.</param>
+/// <param name="EndDate">Last day of the absence.</param>
+/// <param name="Status">Approval status (e.g. <c>PENDING</c>, <c>APPROVED</c>, <c>REJECTED</c>).</param>
+public sealed record AbsenceUpdate(
+    [property: JsonPropertyName("absence_type")] string? AbsenceType = null,
+    [property: JsonPropertyName("start_date")] DateTime? StartDate = null,
+    [property: JsonPropertyName("end_date")] DateTime? EndDate = null,
+    [property: JsonPropertyName("status")] string? Status = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Payroll/Employees/Employee.cs
+++ b/src/BexioApiNet.Abstractions/Models/Payroll/Employees/Employee.cs
@@ -1,0 +1,46 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Payroll.Employees;
+
+/// <summary>
+/// Payroll employee entity returned by the Bexio v4.0 <c>/payroll/employees</c>
+/// endpoints (GET list, GET by id, POST create, PATCH update).
+/// <see href="https://docs.bexio.com/#tag/Employees">Employees</see>
+/// </summary>
+/// <param name="Id">Unique employee identifier.</param>
+/// <param name="FirstName">Employee first name.</param>
+/// <param name="LastName">Employee last name.</param>
+/// <param name="Email">Employee email address.</param>
+/// <param name="EmploymentStatus">Employment status (e.g. <c>ACTIVE</c>, <c>INACTIVE</c>).</param>
+/// <param name="CreatedAt">Creation timestamp.</param>
+public sealed record Employee(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("first_name")] string? FirstName = null,
+    [property: JsonPropertyName("last_name")] string? LastName = null,
+    [property: JsonPropertyName("email")] string? Email = null,
+    [property: JsonPropertyName("employment_status")] string? EmploymentStatus = null,
+    [property: JsonPropertyName("created_at")] DateTime? CreatedAt = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Payroll/Employees/Views/EmployeeCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Payroll/Employees/Views/EmployeeCreate.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Payroll.Employees.Views;
+
+/// <summary>
+/// Create view for <c>POST /4.0/payroll/employees</c>. Optional fields default to
+/// <see langword="null"/> and are only serialized when supplied.
+/// <see href="https://docs.bexio.com/#tag/Employees">Employees</see>
+/// </summary>
+/// <param name="FirstName">Employee first name.</param>
+/// <param name="LastName">Employee last name.</param>
+/// <param name="Email">Employee email address.</param>
+/// <param name="EmploymentStatus">Employment status (e.g. <c>ACTIVE</c>, <c>INACTIVE</c>).</param>
+public sealed record EmployeeCreate(
+    [property: JsonPropertyName("first_name")] string? FirstName = null,
+    [property: JsonPropertyName("last_name")] string? LastName = null,
+    [property: JsonPropertyName("email")] string? Email = null,
+    [property: JsonPropertyName("employment_status")] string? EmploymentStatus = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Payroll/Employees/Views/EmployeePatch.cs
+++ b/src/BexioApiNet.Abstractions/Models/Payroll/Employees/Views/EmployeePatch.cs
@@ -1,0 +1,43 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Payroll.Employees.Views;
+
+/// <summary>
+/// Patch view for <c>PATCH /4.0/payroll/employees/{id}</c>. All fields are optional
+/// (nullable) — only the properties supplied by the caller are sent to Bexio and
+/// persisted. Unspecified fields retain their current server-side value.
+/// <see href="https://docs.bexio.com/#tag/Employees">Employees</see>
+/// </summary>
+/// <param name="FirstName">Employee first name.</param>
+/// <param name="LastName">Employee last name.</param>
+/// <param name="Email">Employee email address.</param>
+/// <param name="EmploymentStatus">Employment status (e.g. <c>ACTIVE</c>, <c>INACTIVE</c>).</param>
+public sealed record EmployeePatch(
+    [property: JsonPropertyName("first_name")] string? FirstName = null,
+    [property: JsonPropertyName("last_name")] string? LastName = null,
+    [property: JsonPropertyName("email")] string? Email = null,
+    [property: JsonPropertyName("employment_status")] string? EmploymentStatus = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Bill.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Bill.cs
@@ -1,0 +1,99 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// Full bill entity returned by the single-item Bexio v4.0 <c>/purchase/bills</c>
+/// endpoints (GET by id, POST create, PUT update, POST actions, PUT bookings/{status}).
+/// See <see cref="BillListItem"/> for the condensed form returned by the list endpoint.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="Id">Unique bill identifier.</param>
+/// <param name="DocumentNo">Unique bill document number. Auto-generated on creation.</param>
+/// <param name="Status">Bill status.</param>
+/// <param name="LastnameCompany">Supplier family name or company name.</param>
+/// <param name="CreatedAt">Creation timestamp.</param>
+/// <param name="SupplierId">Identifier of the supplier contact.</param>
+/// <param name="ContactPartnerId">Identifier of the Bexio contact partner.</param>
+/// <param name="ManualAmount">Whether <c>AmountMan</c> (true) or <c>AmountCalc</c> (false) is the authoritative bill amount.</param>
+/// <param name="BillDate">Bill issue date.</param>
+/// <param name="DueDate">Due date for payment.</param>
+/// <param name="Address">Address attached to the bill.</param>
+/// <param name="LineItems">Line items on the bill.</param>
+/// <param name="Discounts">Discounts applied to the bill.</param>
+/// <param name="ItemNet">Whether line-item amounts are net (<see langword="true"/>) or gross (<see langword="false"/>).</param>
+/// <param name="SplitIntoLineItems">Whether the bill has multiple line items or a single aggregate one.</param>
+/// <param name="BaseCurrencyCode">Base currency code taken from the Bexio account settings.</param>
+/// <param name="Overdue">True when <see cref="DueDate"/> has passed. Not applicable to <c>DRAFT</c> or <c>PAID</c>.</param>
+/// <param name="AttachmentIds">Bexio file identifiers attached to the bill.</param>
+/// <param name="Title">Free-form bill title.</param>
+/// <param name="FirstnameSuffix">Supplier first name or suffix.</param>
+/// <param name="VendorRef">Vendor reference text.</param>
+/// <param name="PendingAmount">Remaining amount to be paid.</param>
+/// <param name="AmountMan">Manual amount. Considered authoritative when <see cref="ManualAmount"/> is <see langword="true"/>.</param>
+/// <param name="AmountCalc">Calculated amount. Considered authoritative when <see cref="ManualAmount"/> is <see langword="false"/>.</param>
+/// <param name="CurrencyCode">ISO currency code of the bill.</param>
+/// <param name="ExchangeRate">Exchange rate applied when <see cref="CurrencyCode"/> differs from <see cref="BaseCurrencyCode"/>.</param>
+/// <param name="PurchaseOrderId">Optional purchase-order identifier this bill originates from.</param>
+/// <param name="BaseCurrencyAmount">Bill amount expressed in the base currency.</param>
+/// <param name="QrBillInformation">QR bill payload string when the bill was captured from a QR invoice.</param>
+/// <param name="Payment">Optional payment block attached to the bill.</param>
+/// <param name="AverageExchangeRateEnabled">Whether the average exchange rate feature is enabled for this bill.</param>
+public sealed record Bill(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("document_no")] string DocumentNo,
+    [property: JsonPropertyName("status")] BillStatus Status,
+    [property: JsonPropertyName("lastname_company")] string LastnameCompany,
+    [property: JsonPropertyName("created_at")] string CreatedAt,
+    [property: JsonPropertyName("supplier_id")] int SupplierId,
+    [property: JsonPropertyName("contact_partner_id")] int ContactPartnerId,
+    [property: JsonPropertyName("manual_amount")] bool ManualAmount,
+    [property: JsonPropertyName("bill_date")] DateOnly BillDate,
+    [property: JsonPropertyName("due_date")] DateOnly DueDate,
+    [property: JsonPropertyName("address")] BillAddress Address,
+    [property: JsonPropertyName("line_items")] IReadOnlyList<BillLineItem> LineItems,
+    [property: JsonPropertyName("discounts")] IReadOnlyList<BillDiscount> Discounts,
+    [property: JsonPropertyName("item_net")] bool ItemNet,
+    [property: JsonPropertyName("split_into_line_items")] bool SplitIntoLineItems,
+    [property: JsonPropertyName("base_currency_code")] string BaseCurrencyCode,
+    [property: JsonPropertyName("overdue")] bool Overdue,
+    [property: JsonPropertyName("attachment_ids")] IReadOnlyList<Guid> AttachmentIds,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("firstname_suffix")] string? FirstnameSuffix = null,
+    [property: JsonPropertyName("vendor_ref")] string? VendorRef = null,
+    [property: JsonPropertyName("pending_amount")] decimal? PendingAmount = null,
+    [property: JsonPropertyName("amount_man")] decimal? AmountMan = null,
+    [property: JsonPropertyName("amount_calc")] decimal? AmountCalc = null,
+    [property: JsonPropertyName("currency_code")] string? CurrencyCode = null,
+    [property: JsonPropertyName("exchange_rate")] decimal? ExchangeRate = null,
+    [property: JsonPropertyName("purchase_order_id")] int? PurchaseOrderId = null,
+    [property: JsonPropertyName("base_currency_amount")] decimal? BaseCurrencyAmount = null,
+    [property: JsonPropertyName("qr_bill_information")] string? QrBillInformation = null,
+    [property: JsonPropertyName("payment")] BillPayment? Payment = null,
+    [property: JsonPropertyName("average_exchange_rate_enabled")] bool? AverageExchangeRateEnabled = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillAddress.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillAddress.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// Address block attached to a bill. The same shape is used on the create/update
+/// payloads and on the responses of the Bexio v4.0 <c>/purchase/bills</c> endpoints.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="LastnameCompany">Family name (for <c>PRIVATE</c>) or company name (for <c>COMPANY</c>). Required.</param>
+/// <param name="Type">Address contact type (<c>PRIVATE</c> or <c>COMPANY</c>).</param>
+/// <param name="Title">Optional academic or honorific title (e.g. <c>Prof.</c>).</param>
+/// <param name="Salutation">Optional salutation (e.g. <c>Mr</c>, <c>Mrs</c>).</param>
+/// <param name="FirstnameSuffix">Given name or contact suffix.</param>
+/// <param name="AddressLine">Street address line.</param>
+/// <param name="Postcode">Postal code.</param>
+/// <param name="City">City name.</param>
+/// <param name="CountryCode">ISO country code.</param>
+/// <param name="MainContactId">Identifier of the main Bexio contact this address belongs to.</param>
+/// <param name="ContactAddressId">Identifier of the Bexio contact address record this entry was copied from.</param>
+public sealed record BillAddress(
+    [property: JsonPropertyName("lastname_company")] string LastnameCompany,
+    [property: JsonPropertyName("type")] BillAddressType Type,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("salutation")] string? Salutation = null,
+    [property: JsonPropertyName("firstname_suffix")] string? FirstnameSuffix = null,
+    [property: JsonPropertyName("address_line")] string? AddressLine = null,
+    [property: JsonPropertyName("postcode")] string? Postcode = null,
+    [property: JsonPropertyName("city")] string? City = null,
+    [property: JsonPropertyName("country_code")] string? CountryCode = null,
+    [property: JsonPropertyName("main_contact_id")] int? MainContactId = null,
+    [property: JsonPropertyName("contact_address_id")] int? ContactAddressId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillDiscount.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillDiscount.cs
@@ -1,0 +1,41 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// A discount entry on a bill. Shared by the create/update payloads and the
+/// responses. On update, callers must echo an existing <c>Id</c> to preserve a
+/// discount or pass <see langword="null"/> to create a new one.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="Position">Zero-based position of the discount within the bill.</param>
+/// <param name="Amount">Discount amount. Max 17 digits, 2 decimals. Must be greater than 0 when booking.</param>
+/// <param name="Id">Discount identifier. Server-generated on create; echoed on update.</param>
+public sealed record BillDiscount(
+    [property: JsonPropertyName("position")] int Position,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("id")] Guid? Id = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillDocumentNumberResponse.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillDocumentNumberResponse.cs
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// Response payload of <c>GET /4.0/purchase/documentnumbers/bills</c>. The endpoint
+/// validates a proposed document number against all existing non-draft bills and
+/// returns the next available number when the proposed one is not unique.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="Valid">Whether the proposed document number is unique among non-draft bills.</param>
+/// <param name="NextAvailableNo">Next unique document number available to use. Set only when <see cref="Valid"/> is <see langword="false"/>.</param>
+public sealed record BillDocumentNumberResponse(
+    [property: JsonPropertyName("valid")] bool Valid,
+    [property: JsonPropertyName("next_available_no")] string? NextAvailableNo
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillLineItem.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillLineItem.cs
@@ -1,0 +1,49 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// A line item on a bill. Shared by the create/update payloads and the responses —
+/// on creation <c>Id</c> and <c>TaxCalc</c> are absent and set by the server; on
+/// update callers must echo the existing <c>Id</c> or omit it to create a new item.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="Position">Zero-based position of the line item within the bill.</param>
+/// <param name="Amount">Line item amount (net or gross per <c>item_net</c>). Max 17 digits, 2 decimals.</param>
+/// <param name="Id">Line item identifier. Server-generated on create; echoed on update to preserve, or <see langword="null"/> to create a new item.</param>
+/// <param name="Title">Optional line item title.</param>
+/// <param name="TaxId">Optional tax identifier applied to this line item.</param>
+/// <param name="TaxCalc">Server-calculated tax amount based on <c>Amount</c> and <c>TaxId</c>. Read-only.</param>
+/// <param name="BookingAccountId">Booking account identifier. Required when the bill transitions to <c>BOOKED</c>.</param>
+public sealed record BillLineItem(
+    [property: JsonPropertyName("position")] int Position,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("id")] Guid? Id = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("tax_id")] int? TaxId = null,
+    [property: JsonPropertyName("tax_calc")] decimal? TaxCalc = null,
+    [property: JsonPropertyName("booking_account_id")] int? BookingAccountId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillListItem.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillListItem.cs
@@ -1,0 +1,73 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// Condensed bill entry returned by the list endpoint
+/// <c>GET /4.0/purchase/bills</c>. See <see cref="Bill"/> for the full model returned
+/// by the single-item endpoints.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="Id">Unique bill identifier.</param>
+/// <param name="DocumentNo">Unique bill document number.</param>
+/// <param name="Status">Bill status.</param>
+/// <param name="LastnameCompany">Supplier family name or company name.</param>
+/// <param name="Vendor">Joined <c>firstname_suffix</c> and <c>lastname_company</c> based on supplier type.</param>
+/// <param name="CreatedAt">Creation timestamp.</param>
+/// <param name="CurrencyCode">ISO currency code of the bill.</param>
+/// <param name="BillDate">Bill date.</param>
+/// <param name="DueDate">Due date.</param>
+/// <param name="BookingAccountIds">Distinct booking account ids used across the bill's line items.</param>
+/// <param name="Overdue">True when <see cref="DueDate"/> has passed; always <see langword="false"/> for <c>DRAFT</c> and <c>PAID</c>.</param>
+/// <param name="AttachmentIds">Bexio file identifiers attached to the bill.</param>
+/// <param name="Title">Bill title.</param>
+/// <param name="FirstnameSuffix">Supplier first name or suffix.</param>
+/// <param name="VendorRef">Vendor reference text.</param>
+/// <param name="PendingAmount">Remaining amount to be paid.</param>
+/// <param name="Net">Net value of the bill, calculated from line items and discounts.</param>
+/// <param name="Gross">Gross value of the bill, calculated from line items and discounts.</param>
+public sealed record BillListItem(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("document_no")] string DocumentNo,
+    [property: JsonPropertyName("status")] BillStatus Status,
+    [property: JsonPropertyName("lastname_company")] string LastnameCompany,
+    [property: JsonPropertyName("vendor")] string Vendor,
+    [property: JsonPropertyName("created_at")] DateTimeOffset CreatedAt,
+    [property: JsonPropertyName("currency_code")] string CurrencyCode,
+    [property: JsonPropertyName("bill_date")] DateOnly BillDate,
+    [property: JsonPropertyName("due_date")] DateOnly DueDate,
+    [property: JsonPropertyName("booking_account_ids")] IReadOnlyList<int> BookingAccountIds,
+    [property: JsonPropertyName("overdue")] bool Overdue,
+    [property: JsonPropertyName("attachment_ids")] IReadOnlyList<Guid> AttachmentIds,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("firstname_suffix")] string? FirstnameSuffix = null,
+    [property: JsonPropertyName("vendor_ref")] string? VendorRef = null,
+    [property: JsonPropertyName("pending_amount")] decimal? PendingAmount = null,
+    [property: JsonPropertyName("net")] decimal? Net = null,
+    [property: JsonPropertyName("gross")] decimal? Gross = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillListResponse.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillListResponse.cs
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// Envelope response returned by <c>GET /4.0/purchase/bills</c>.
+/// The v4.0 list endpoints wrap results in a <c>{ data, paging }</c> object instead of
+/// returning a raw array (the convention used by v2.0 / v3.0 endpoints).
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="Data">Bills matching the query.</param>
+/// <param name="Paging">Pagination metadata for the current page.</param>
+public sealed record BillListResponse(
+    [property: JsonPropertyName("data")] IReadOnlyList<BillListItem> Data,
+    [property: JsonPropertyName("paging")] BillPaging Paging
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillPaging.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillPaging.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// Paging envelope returned by the list endpoint
+/// <c>GET /4.0/purchase/bills</c>. Bexio v4.0 list endpoints use page-based
+/// pagination (not offset-based).
+/// </summary>
+/// <param name="Page">Current 1-based page number.</param>
+/// <param name="PageSize">Number of items per page (<c>limit</c> query parameter).</param>
+/// <param name="PageCount">Total number of pages.</param>
+/// <param name="ItemCount">Total number of items across all pages.</param>
+public sealed record BillPaging(
+    [property: JsonPropertyName("page")] int Page,
+    [property: JsonPropertyName("page_size")] int PageSize,
+    [property: JsonPropertyName("page_count")] int PageCount,
+    [property: JsonPropertyName("item_count")] int ItemCount
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillPayment.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/BillPayment.cs
@@ -1,0 +1,76 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills;
+
+/// <summary>
+/// Payment block attached to a bill. Same shape on create/update payloads and
+/// in responses.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="Type">Payment type (<c>IBAN</c>, <c>MANUAL</c>, or <c>QR</c>).</param>
+/// <param name="ExecutionDate">Execution date of the payment.</param>
+/// <param name="Amount">Payment amount. Max 17 digits, 2 decimals.</param>
+/// <param name="SalaryPayment">Whether this is a salary payment.</param>
+/// <param name="BankAccountId">Bexio bank account identifier used for the payment.</param>
+/// <param name="Fee">Fee allocation type.</param>
+/// <param name="ExchangeRate">Exchange rate applied. Max 5 digits, 10 decimals.</param>
+/// <param name="AccountNo">Deprecated account number.</param>
+/// <param name="Iban">Receiver IBAN.</param>
+/// <param name="Name">Receiver name.</param>
+/// <param name="Address">Receiver full address line.</param>
+/// <param name="Street">Receiver street.</param>
+/// <param name="HouseNo">Receiver house number.</param>
+/// <param name="Postcode">Receiver postal code.</param>
+/// <param name="City">Receiver city.</param>
+/// <param name="CountryCode">Receiver ISO country code.</param>
+/// <param name="Message">Remittance message sent with the payment.</param>
+/// <param name="BookingText">Internal booking text.</param>
+/// <param name="ReferenceNo">QR reference number.</param>
+/// <param name="Note">Free-form note attached to the payment.</param>
+public sealed record BillPayment(
+    [property: JsonPropertyName("type")] BillPaymentType Type,
+    [property: JsonPropertyName("execution_date")] DateOnly ExecutionDate,
+    [property: JsonPropertyName("amount")] decimal Amount,
+    [property: JsonPropertyName("salary_payment")] bool SalaryPayment,
+    [property: JsonPropertyName("bank_account_id")] int? BankAccountId = null,
+    [property: JsonPropertyName("fee")] BillPaymentFeeType? Fee = null,
+    [property: JsonPropertyName("exchange_rate")] decimal? ExchangeRate = null,
+    [property: JsonPropertyName("account_no")] string? AccountNo = null,
+    [property: JsonPropertyName("iban")] string? Iban = null,
+    [property: JsonPropertyName("name")] string? Name = null,
+    [property: JsonPropertyName("address")] string? Address = null,
+    [property: JsonPropertyName("street")] string? Street = null,
+    [property: JsonPropertyName("house_no")] string? HouseNo = null,
+    [property: JsonPropertyName("postcode")] string? Postcode = null,
+    [property: JsonPropertyName("city")] string? City = null,
+    [property: JsonPropertyName("country_code")] string? CountryCode = null,
+    [property: JsonPropertyName("message")] string? Message = null,
+    [property: JsonPropertyName("booking_text")] string? BookingText = null,
+    [property: JsonPropertyName("reference_no")] string? ReferenceNo = null,
+    [property: JsonPropertyName("note")] string? Note = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillAction.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillAction.cs
@@ -1,0 +1,40 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+/// <summary>
+/// Actions accepted by <c>POST /4.0/purchase/bills/{id}/actions</c>.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum BillAction
+{
+    /// <summary>
+    /// Duplicate the bill and return the newly created duplicate.
+    /// </summary>
+    DUPLICATE
+}

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillAddressType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillAddressType.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+/// <summary>
+/// Bill address contact type.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum BillAddressType
+{
+    /// <summary>
+    /// Private (natural person) contact type.
+    /// </summary>
+    PRIVATE,
+
+    /// <summary>
+    /// Company (legal entity) contact type.
+    /// </summary>
+    COMPANY
+}

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillBookingStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillBookingStatus.cs
@@ -1,0 +1,47 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+/// <summary>
+/// Target status for the <c>PUT /4.0/purchase/bills/{id}/bookings/{status}</c> endpoint.
+/// Only <c>DRAFT</c> and <c>BOOKED</c> are accepted as booking transition targets.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum BillBookingStatus
+{
+    /// <summary>
+    /// Transition the bill back to <c>DRAFT</c> status. Only allowed from <c>BOOKED</c>.
+    /// </summary>
+    DRAFT,
+
+    /// <summary>
+    /// Transition the bill to <c>BOOKED</c> status. Only allowed from <c>DRAFT</c> and
+    /// triggers the full set of booking validations in the Bexio API.
+    /// </summary>
+    BOOKED
+}

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillPaymentFeeType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillPaymentFeeType.cs
@@ -1,0 +1,55 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+/// <summary>
+/// Bill payment fee allocation (<c>payment.fee</c>).
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum BillPaymentFeeType
+{
+    /// <summary>
+    /// Fees are paid by the sender.
+    /// </summary>
+    BY_SENDER,
+
+    /// <summary>
+    /// Fees are paid by the receiver.
+    /// </summary>
+    BY_RECEIVER,
+
+    /// <summary>
+    /// Fees are split between sender and receiver.
+    /// </summary>
+    BREAKDOWN,
+
+    /// <summary>
+    /// No fees apply.
+    /// </summary>
+    NO_FEE
+}

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillPaymentType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillPaymentType.cs
@@ -1,0 +1,50 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+/// <summary>
+/// Bill payment type as used by the <c>payment</c> block of a bill.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum BillPaymentType
+{
+    /// <summary>
+    /// IBAN bank transfer payment.
+    /// </summary>
+    IBAN,
+
+    /// <summary>
+    /// Manually recorded payment.
+    /// </summary>
+    MANUAL,
+
+    /// <summary>
+    /// QR-bill payment. Only allowed for <c>CHF</c> or <c>EUR</c> bills.
+    /// </summary>
+    QR
+}

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillStatus.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Enums/BillStatus.cs
@@ -1,0 +1,95 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+/// <summary>
+/// Bill status as returned by the Bexio v4.0 <c>/purchase/bills</c> endpoints.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum BillStatus
+{
+    /// <summary>
+    /// Bill is a draft and has not yet been booked.
+    /// </summary>
+    DRAFT,
+
+    /// <summary>
+    /// Bill has been booked.
+    /// </summary>
+    BOOKED,
+
+    /// <summary>
+    /// Payment has been partially created for this bill.
+    /// </summary>
+    PARTIALLY_CREATED,
+
+    /// <summary>
+    /// Payment has been fully created for this bill.
+    /// </summary>
+    CREATED,
+
+    /// <summary>
+    /// Payment has been partially sent.
+    /// </summary>
+    PARTIALLY_SENT,
+
+    /// <summary>
+    /// Payment has been sent.
+    /// </summary>
+    SENT,
+
+    /// <summary>
+    /// Payment has been partially downloaded.
+    /// </summary>
+    PARTIALLY_DOWNLOADED,
+
+    /// <summary>
+    /// Payment has been downloaded.
+    /// </summary>
+    DOWNLOADED,
+
+    /// <summary>
+    /// Bill has been partially paid.
+    /// </summary>
+    PARTIALLY_PAID,
+
+    /// <summary>
+    /// Bill has been fully paid.
+    /// </summary>
+    PAID,
+
+    /// <summary>
+    /// Payment has partially failed.
+    /// </summary>
+    PARTIALLY_FAILED,
+
+    /// <summary>
+    /// Payment has failed.
+    /// </summary>
+    FAILED
+}

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Views/BillActionRequest.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Views/BillActionRequest.cs
@@ -1,0 +1,37 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Views;
+
+/// <summary>
+/// Request body for <c>POST /4.0/purchase/bills/{id}/actions</c>.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="Action">Action to execute.</param>
+public sealed record BillActionRequest(
+    [property: JsonPropertyName("action")] BillAction Action
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Views/BillCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Views/BillCreate.cs
@@ -1,0 +1,75 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Views;
+
+/// <summary>
+/// Create view for <c>POST /4.0/purchase/bills</c>. All required fields per the Bexio
+/// API spec are non-nullable positional parameters; optional fields default to
+/// <see langword="null"/> and are only serialized when supplied.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="SupplierId">Identifier of the supplier contact.</param>
+/// <param name="ContactPartnerId">Identifier of the Bexio contact partner.</param>
+/// <param name="CurrencyCode">ISO currency code of the bill.</param>
+/// <param name="Address">Address block describing the supplier.</param>
+/// <param name="BillDate">Bill issue date.</param>
+/// <param name="DueDate">Due date for payment.</param>
+/// <param name="ManualAmount">Whether <c>AmountMan</c> (true) or <c>AmountCalc</c> (false) is the authoritative bill amount.</param>
+/// <param name="ItemNet">Whether line-item amounts are net (<see langword="true"/>) or gross (<see langword="false"/>).</param>
+/// <param name="LineItems">Bill line items (1-100).</param>
+/// <param name="Discounts">Discounts applied to the bill (0-100).</param>
+/// <param name="AttachmentIds">Bexio file identifiers to attach to the bill.</param>
+/// <param name="VendorRef">Vendor reference text.</param>
+/// <param name="Title">Free-form bill title.</param>
+/// <param name="AmountMan">Manual amount. Required when <see cref="ManualAmount"/> is <see langword="true"/>.</param>
+/// <param name="AmountCalc">Calculated amount. Required when <see cref="ManualAmount"/> is <see langword="false"/>.</param>
+/// <param name="ExchangeRate">Exchange rate. Required when <see cref="CurrencyCode"/> differs from the base currency.</param>
+/// <param name="BaseCurrencyAmount">Bill amount expressed in the base currency. Required with <see cref="ExchangeRate"/>.</param>
+/// <param name="PurchaseOrderId">Optional purchase-order identifier this bill originates from.</param>
+/// <param name="QrBillInformation">QR bill payload string when the bill was captured from a QR invoice.</param>
+/// <param name="Payment">Optional payment block attached to the bill.</param>
+public sealed record BillCreate(
+    [property: JsonPropertyName("supplier_id")] int SupplierId,
+    [property: JsonPropertyName("contact_partner_id")] int ContactPartnerId,
+    [property: JsonPropertyName("currency_code")] string CurrencyCode,
+    [property: JsonPropertyName("address")] BillAddress Address,
+    [property: JsonPropertyName("bill_date")] DateOnly BillDate,
+    [property: JsonPropertyName("due_date")] DateOnly DueDate,
+    [property: JsonPropertyName("manual_amount")] bool ManualAmount,
+    [property: JsonPropertyName("item_net")] bool ItemNet,
+    [property: JsonPropertyName("line_items")] IReadOnlyList<BillLineItem> LineItems,
+    [property: JsonPropertyName("discounts")] IReadOnlyList<BillDiscount> Discounts,
+    [property: JsonPropertyName("attachment_ids")] IReadOnlyList<Guid> AttachmentIds,
+    [property: JsonPropertyName("vendor_ref")] string? VendorRef = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("amount_man")] decimal? AmountMan = null,
+    [property: JsonPropertyName("amount_calc")] decimal? AmountCalc = null,
+    [property: JsonPropertyName("exchange_rate")] decimal? ExchangeRate = null,
+    [property: JsonPropertyName("base_currency_amount")] decimal? BaseCurrencyAmount = null,
+    [property: JsonPropertyName("purchase_order_id")] int? PurchaseOrderId = null,
+    [property: JsonPropertyName("qr_bill_information")] string? QrBillInformation = null,
+    [property: JsonPropertyName("payment")] BillPayment? Payment = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Views/BillUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/Bills/Views/BillUpdate.cs
@@ -1,0 +1,75 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.Bills.Views;
+
+/// <summary>
+/// Update view for <c>PUT /4.0/purchase/bills/{id}</c>. When updating a bill in a status
+/// other than <c>DRAFT</c> the Bexio API only persists <c>file_id</c> and <c>payment</c>
+/// — the other fields must still be supplied but are ignored server-side.
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+/// <param name="SupplierId">Identifier of the supplier contact.</param>
+/// <param name="ContactPartnerId">Identifier of the Bexio contact partner.</param>
+/// <param name="CurrencyCode">ISO currency code of the bill.</param>
+/// <param name="Address">Address block describing the supplier.</param>
+/// <param name="BillDate">Bill issue date.</param>
+/// <param name="DueDate">Due date for payment.</param>
+/// <param name="ManualAmount">Whether <c>AmountMan</c> (true) or <c>AmountCalc</c> (false) is the authoritative bill amount.</param>
+/// <param name="ItemNet">Whether line-item amounts are net or gross.</param>
+/// <param name="SplitIntoLineItems">Whether the bill has multiple items (true) or a single aggregate one (false).</param>
+/// <param name="LineItems">Bill line items. Echo <c>Id</c> to preserve, omit to create new. When <see cref="SplitIntoLineItems"/> is <see langword="false"/> exactly one item is allowed.</param>
+/// <param name="Discounts">Discounts applied to the bill. Must be empty when <see cref="SplitIntoLineItems"/> is <see langword="false"/>.</param>
+/// <param name="AttachmentIds">Bexio file identifiers attached to the bill.</param>
+/// <param name="DocumentNo">Optional override for the bill document number.</param>
+/// <param name="Title">Free-form bill title.</param>
+/// <param name="VendorRef">Vendor reference text.</param>
+/// <param name="AmountMan">Manual amount. Required when <see cref="ManualAmount"/> is <see langword="true"/>.</param>
+/// <param name="AmountCalc">Calculated amount. Required when <see cref="ManualAmount"/> is <see langword="false"/>.</param>
+/// <param name="ExchangeRate">Exchange rate. Required when <see cref="CurrencyCode"/> differs from the base currency.</param>
+/// <param name="BaseCurrencyAmount">Bill amount expressed in the base currency.</param>
+/// <param name="Payment">Optional payment block attached to the bill.</param>
+public sealed record BillUpdate(
+    [property: JsonPropertyName("supplier_id")] int SupplierId,
+    [property: JsonPropertyName("contact_partner_id")] int ContactPartnerId,
+    [property: JsonPropertyName("currency_code")] string CurrencyCode,
+    [property: JsonPropertyName("address")] BillAddress Address,
+    [property: JsonPropertyName("bill_date")] DateOnly BillDate,
+    [property: JsonPropertyName("due_date")] DateOnly DueDate,
+    [property: JsonPropertyName("manual_amount")] bool ManualAmount,
+    [property: JsonPropertyName("item_net")] bool ItemNet,
+    [property: JsonPropertyName("split_into_line_items")] bool SplitIntoLineItems,
+    [property: JsonPropertyName("line_items")] IReadOnlyList<BillLineItem> LineItems,
+    [property: JsonPropertyName("discounts")] IReadOnlyList<BillDiscount> Discounts,
+    [property: JsonPropertyName("attachment_ids")] IReadOnlyList<Guid> AttachmentIds,
+    [property: JsonPropertyName("document_no")] string? DocumentNo = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("vendor_ref")] string? VendorRef = null,
+    [property: JsonPropertyName("amount_man")] decimal? AmountMan = null,
+    [property: JsonPropertyName("amount_calc")] decimal? AmountCalc = null,
+    [property: JsonPropertyName("exchange_rate")] decimal? ExchangeRate = null,
+    [property: JsonPropertyName("base_currency_amount")] decimal? BaseCurrencyAmount = null,
+    [property: JsonPropertyName("payment")] BillPayment? Payment = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/PurchaseOrders/PurchaseOrder.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/PurchaseOrders/PurchaseOrder.cs
@@ -1,0 +1,62 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders;
+
+/// <summary>
+/// Purchase order entity returned by the Bexio v3.0 <c>/purchase/orders</c> endpoints
+/// (GET list/by id, POST create, POST <c>/{id}</c> update). Bexio v3.0 follows the
+/// same POST-to-id update convention as v2.0 sales documents — see
+/// <see cref="BexioApiNet.Abstractions.Models.Sales.Quotes.Quote"/>.
+/// <see href="https://docs.bexio.com/#tag/Purchase-Orders">Purchase Orders</see>
+/// </summary>
+/// <param name="Id">Unique purchase order identifier (read-only).</param>
+/// <param name="DocumentNo">Purchase order document number. Auto-generated on creation when omitted.</param>
+/// <param name="ContactId">Identifier of the supplier contact the order is addressed to.</param>
+/// <param name="CurrencyId">Identifier of the currency in which the order is denominated.</param>
+/// <param name="UserId">Identifier of the user that owns the purchase order.</param>
+/// <param name="Title">Free-form purchase order title.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within the supplier company).</param>
+/// <param name="TotalNet">Net total of the order (read-only).</param>
+/// <param name="TotalGross">Gross total of the order (read-only).</param>
+/// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidUntil">Order validity end in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+/// <param name="UpdatedAt">Timestamp of the last update in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format (read-only).</param>
+public sealed record PurchaseOrder(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("document_no")] string DocumentNo,
+    [property: JsonPropertyName("contact_id")] int ContactId,
+    [property: JsonPropertyName("currency_id")] int CurrencyId,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("total_net")] decimal? TotalNet = null,
+    [property: JsonPropertyName("total_gross")] decimal? TotalGross = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("is_valid_until")] string? IsValidUntil = null,
+    [property: JsonPropertyName("api_reference")] string? ApiReference = null,
+    [property: JsonPropertyName("updated_at")] string? UpdatedAt = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/PurchaseOrders/Views/PurchaseOrderCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/PurchaseOrders/Views/PurchaseOrderCreate.cs
@@ -1,0 +1,53 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders.Views;
+
+/// <summary>
+/// Create view for <c>POST /3.0/purchase/orders</c>. Read-only fields (id, totals,
+/// updated_at) are intentionally omitted. <c>document_no</c> is optional — Bexio
+/// auto-generates it when omitted.
+/// <see href="https://docs.bexio.com/#tag/Purchase-Orders">Purchase Orders</see>
+/// </summary>
+/// <param name="ContactId">Identifier of the supplier contact the order is addressed to.</param>
+/// <param name="CurrencyId">Identifier of the currency in which the order is denominated.</param>
+/// <param name="UserId">Identifier of the user that owns the purchase order.</param>
+/// <param name="DocumentNo">Optional document number. Auto-generated when omitted.</param>
+/// <param name="Title">Free-form purchase order title.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within the supplier company).</param>
+/// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidUntil">Order validity end in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+public sealed record PurchaseOrderCreate(
+    [property: JsonPropertyName("contact_id")] int ContactId,
+    [property: JsonPropertyName("currency_id")] int CurrencyId,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("document_no")] string? DocumentNo = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("is_valid_until")] string? IsValidUntil = null,
+    [property: JsonPropertyName("api_reference")] string? ApiReference = null
+);

--- a/src/BexioApiNet.Abstractions/Models/Purchases/PurchaseOrders/Views/PurchaseOrderUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Purchases/PurchaseOrders/Views/PurchaseOrderUpdate.cs
@@ -1,0 +1,54 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders.Views;
+
+/// <summary>
+/// Update view for <c>POST /3.0/purchase/orders/{id}</c>. Bexio v3.0 follows the same
+/// POST-to-id update convention as v2.0 — full replacement edits are issued via
+/// <c>POST</c> on the resource, not <c>PUT</c>. Read-only fields (id, totals,
+/// updated_at) are intentionally omitted.
+/// <see href="https://docs.bexio.com/#tag/Purchase-Orders">Purchase Orders</see>
+/// </summary>
+/// <param name="ContactId">Identifier of the supplier contact the order is addressed to.</param>
+/// <param name="CurrencyId">Identifier of the currency in which the order is denominated.</param>
+/// <param name="UserId">Identifier of the user that owns the purchase order.</param>
+/// <param name="DocumentNo">Optional override for the purchase order document number.</param>
+/// <param name="Title">Free-form purchase order title.</param>
+/// <param name="ContactSubId">Optional additional contact reference (e.g. addressee within the supplier company).</param>
+/// <param name="IsValidFrom">Order validity start in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="IsValidUntil">Order validity end in Bexio's <c>yyyy-MM-dd</c> format.</param>
+/// <param name="ApiReference">Caller-supplied reference accessible only via the API.</param>
+public sealed record PurchaseOrderUpdate(
+    [property: JsonPropertyName("contact_id")] int ContactId,
+    [property: JsonPropertyName("currency_id")] int CurrencyId,
+    [property: JsonPropertyName("user_id")] int UserId,
+    [property: JsonPropertyName("document_no")] string? DocumentNo = null,
+    [property: JsonPropertyName("title")] string? Title = null,
+    [property: JsonPropertyName("contact_sub_id")] int? ContactSubId = null,
+    [property: JsonPropertyName("is_valid_from")] string? IsValidFrom = null,
+    [property: JsonPropertyName("is_valid_until")] string? IsValidUntil = null,
+    [property: JsonPropertyName("api_reference")] string? ApiReference = null
+);

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -155,6 +155,7 @@ public static class BexioServiceCollection
         services.AddScoped<IMilestoneService, MilestoneService>();
         services.AddScoped<IPackageService, PackageService>();
         services.AddScoped<IBillService, BillService>();
+        services.AddScoped<IPurchaseOrderService, PurchaseOrderService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
 using BexioApiNet.Interfaces.Connectors.Sales;
@@ -45,6 +46,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
 using BexioApiNet.Services.Connectors.Sales;
@@ -159,6 +161,7 @@ public static class BexioServiceCollection
         services.AddScoped<IBillService, BillService>();
         services.AddScoped<IPurchaseOrderService, PurchaseOrderService>();
         services.AddScoped<IExpenseService, ExpenseService>();
+        services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -42,6 +43,7 @@ using BexioApiNet.Services.Connectors.Accounting;
 using BexioApiNet.Services.Connectors.Banking;
 using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
+using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -156,6 +158,7 @@ public static class BexioServiceCollection
         services.AddScoped<IPackageService, PackageService>();
         services.AddScoped<IBillService, BillService>();
         services.AddScoped<IPurchaseOrderService, PurchaseOrderService>();
+        services.AddScoped<IExpenseService, ExpenseService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -162,6 +162,7 @@ public static class BexioServiceCollection
         services.AddScoped<IPurchaseOrderService, PurchaseOrderService>();
         services.AddScoped<IExpenseService, ExpenseService>();
         services.AddScoped<IEmployeeService, EmployeeService>();
+        services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -163,6 +163,7 @@ public static class BexioServiceCollection
         services.AddScoped<IExpenseService, ExpenseService>();
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
+        services.AddScoped<IPaystubService, PaystubService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Projects;
+using BexioApiNet.Interfaces.Connectors.Purchases;
 using BexioApiNet.Interfaces.Connectors.Sales;
 using BexioApiNet.Interfaces.Connectors.Sales.Positions;
 using BexioApiNet.Interfaces.Connectors.Tasks;
@@ -43,6 +44,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Items;
 using BexioApiNet.Services.Connectors.Projects;
+using BexioApiNet.Services.Connectors.Purchases;
 using BexioApiNet.Services.Connectors.Sales;
 using BexioApiNet.Services.Connectors.Sales.Positions;
 using BexioApiNet.Services.Connectors.Tasks;
@@ -152,6 +154,7 @@ public static class BexioServiceCollection
         services.AddScoped<IProjectTypeService, ProjectTypeService>();
         services.AddScoped<IMilestoneService, MilestoneService>();
         services.AddScoped<IPackageService, PackageService>();
+        services.AddScoped<IBillService, BillService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet/Interfaces/Connectors/Expenses/IExpenseService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Expenses/IExpenseService.cs
@@ -1,0 +1,117 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Expenses;
+
+/// <summary>
+/// Service for managing expenses in the Bexio expenses namespace (v4.0).
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+public interface IExpenseService
+{
+    /// <summary>
+    /// List expenses.
+    /// <see href="https://docs.bexio.com/#tag/Expenses">List Expenses</see>
+    /// </summary>
+    /// <param name="queryParameterExpense">Optional query parameters for pagination, sorting and filtering.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the paged <see cref="ExpenseListResponse"/> envelope.</returns>
+    public Task<ApiResult<ExpenseListResponse>> Get([Optional] QueryParameterExpense? queryParameterExpense, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single expense by id.
+    /// <see href="https://docs.bexio.com/#tag/Expenses">Get Expense</see>
+    /// </summary>
+    /// <param name="id">Expense identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the full <see cref="Expense"/>.</returns>
+    public Task<ApiResult<Expense>> GetById(Guid id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Validate a proposed expense document number. Returns the next available number when
+    /// the proposed one is not unique among non-draft expenses.
+    /// <see href="https://docs.bexio.com/#tag/Expenses">Validate Document Number</see>
+    /// </summary>
+    /// <param name="documentNo">Proposed document number to validate (max 255 characters).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the <see cref="ExpenseDocumentNumberResponse"/>.</returns>
+    public Task<ApiResult<ExpenseDocumentNumberResponse>> GetDocNumbers(string documentNo, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new expense.
+    /// <see href="https://docs.bexio.com/#tag/Expenses">Create Expense</see>
+    /// </summary>
+    /// <param name="expense">Create view containing the expense details.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the newly created <see cref="Expense"/>.</returns>
+    public Task<ApiResult<Expense>> Create(ExpenseCreate expense, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Execute an expense action (e.g. <see cref="ExpenseAction.DUPLICATE"/>).
+    /// <see href="https://docs.bexio.com/#tag/Expenses">Execute Expense Action</see>
+    /// </summary>
+    /// <param name="id">Expense identifier the action is executed for.</param>
+    /// <param name="action">Action payload identifying the operation to perform.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the resulting <see cref="Expense"/> (for <c>DUPLICATE</c> this is the new duplicate).</returns>
+    public Task<ApiResult<Expense>> Actions(Guid id, ExpenseActionRequest action, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update an existing expense. Bexio v4.0 uses PUT for full-replacement updates. When the
+    /// expense is not in <c>DRAFT</c> only <c>file_id</c> and <c>payment</c> are actually persisted.
+    /// <see href="https://docs.bexio.com/#tag/Expenses">Update Expense</see>
+    /// </summary>
+    /// <param name="id">Expense identifier to update.</param>
+    /// <param name="expense">Update view containing the full expense state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated <see cref="Expense"/>.</returns>
+    public Task<ApiResult<Expense>> Update(Guid id, ExpenseUpdate expense, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Transition an expense's booking status between <c>DRAFT</c> and <c>BOOKED</c>.
+    /// <see href="https://docs.bexio.com/#tag/Expenses">Update Expense Status</see>
+    /// </summary>
+    /// <param name="id">Expense identifier.</param>
+    /// <param name="status">Target booking status (<see cref="ExpenseBookingStatus.DRAFT"/> or <see cref="ExpenseBookingStatus.BOOKED"/>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated <see cref="Expense"/>.</returns>
+    public Task<ApiResult<Expense>> UpdateBookings(Guid id, ExpenseBookingStatus status, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete an expense. Only allowed for expenses in status <c>DRAFT</c>.
+    /// <see href="https://docs.bexio.com/#tag/Expenses">Delete Expense</see>
+    /// </summary>
+    /// <param name="id">Expense identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> indicating success or failure.</returns>
+    public Task<ApiResult<object>> Delete(Guid id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Payroll/IAbsenceService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Payroll/IAbsenceService.cs
@@ -1,0 +1,93 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Payroll.Absences;
+using BexioApiNet.Abstractions.Models.Payroll.Absences.Views;
+
+namespace BexioApiNet.Interfaces.Connectors.Payroll;
+
+/// <summary>
+/// Service for managing payroll absences in the Bexio payroll namespace (v4.0).
+/// Absences are a nested resource under employees — every method takes the parent
+/// employee identifier as its first parameter and is routed to
+/// <c>/4.0/payroll/employees/{employeeId}/absences</c>. Updates use <c>PUT</c>
+/// (full replacement) per the v4.0 convention shared with bills and expenses.
+/// <see href="https://docs.bexio.com/#tag/Absences">Absences</see>
+/// </summary>
+public interface IAbsenceService
+{
+    /// <summary>
+    /// List all absences for a given payroll employee.
+    /// <see href="https://docs.bexio.com/#tag/Absences">List Absences</see>
+    /// </summary>
+    /// <param name="employeeId">Identifier of the parent employee.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of <see cref="Absence"/>.</returns>
+    public Task<ApiResult<List<Absence>>> Get(Guid employeeId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single absence by id for a given payroll employee.
+    /// <see href="https://docs.bexio.com/#tag/Absences">Get Absence</see>
+    /// </summary>
+    /// <param name="employeeId">Identifier of the parent employee.</param>
+    /// <param name="id">Absence identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the <see cref="Absence"/>.</returns>
+    public Task<ApiResult<Absence>> GetById(Guid employeeId, Guid id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new absence for a given payroll employee.
+    /// <see href="https://docs.bexio.com/#tag/Absences">Create Absence</see>
+    /// </summary>
+    /// <param name="employeeId">Identifier of the parent employee.</param>
+    /// <param name="absence">Create view containing the absence details.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the newly created <see cref="Absence"/>.</returns>
+    public Task<ApiResult<Absence>> Create(Guid employeeId, AbsenceCreate absence, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update an existing absence for a given payroll employee. Bexio v4.0 uses
+    /// <c>PUT</c> for full-replacement updates.
+    /// <see href="https://docs.bexio.com/#tag/Absences">Update Absence</see>
+    /// </summary>
+    /// <param name="employeeId">Identifier of the parent employee.</param>
+    /// <param name="id">Absence identifier to update.</param>
+    /// <param name="absence">Update view containing the full absence state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated <see cref="Absence"/>.</returns>
+    public Task<ApiResult<Absence>> Update(Guid employeeId, Guid id, AbsenceUpdate absence, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete an absence for a given payroll employee.
+    /// <see href="https://docs.bexio.com/#tag/Absences">Delete Absence</see>
+    /// </summary>
+    /// <param name="employeeId">Identifier of the parent employee.</param>
+    /// <param name="id">Absence identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> indicating success or failure.</returns>
+    public Task<ApiResult<object>> Delete(Guid employeeId, Guid id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Payroll/IEmployeeService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Payroll/IEmployeeService.cs
@@ -1,0 +1,78 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Payroll.Employees;
+using BexioApiNet.Abstractions.Models.Payroll.Employees.Views;
+
+namespace BexioApiNet.Interfaces.Connectors.Payroll;
+
+/// <summary>
+/// Service for managing payroll employees in the Bexio payroll namespace (v4.0).
+/// Unlike expenses and bills (which use <c>PUT</c> for updates), employees are updated
+/// with <c>PATCH</c> for partial updates — unspecified fields keep their current value.
+/// <see href="https://docs.bexio.com/#tag/Employees">Employees</see>
+/// </summary>
+public interface IEmployeeService
+{
+    /// <summary>
+    /// List all payroll employees.
+    /// <see href="https://docs.bexio.com/#tag/Employees">List Employees</see>
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of <see cref="Employee"/>.</returns>
+    public Task<ApiResult<List<Employee>>> Get([Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single payroll employee by id.
+    /// <see href="https://docs.bexio.com/#tag/Employees">Get Employee</see>
+    /// </summary>
+    /// <param name="id">Employee identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the <see cref="Employee"/>.</returns>
+    public Task<ApiResult<Employee>> GetById(Guid id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new payroll employee.
+    /// <see href="https://docs.bexio.com/#tag/Employees">Create Employee</see>
+    /// </summary>
+    /// <param name="employee">Create view containing the employee details.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the newly created <see cref="Employee"/>.</returns>
+    public Task<ApiResult<Employee>> Create(EmployeeCreate employee, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Partially update an existing payroll employee. Only the fields supplied on the
+    /// <see cref="EmployeePatch"/> view are sent to Bexio and persisted — unspecified
+    /// fields retain their current server-side value (<c>PATCH</c>, not <c>PUT</c>).
+    /// <see href="https://docs.bexio.com/#tag/Employees">Patch Employee</see>
+    /// </summary>
+    /// <param name="id">Employee identifier to update.</param>
+    /// <param name="employee">Patch view containing the fields to update.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated <see cref="Employee"/>.</returns>
+    public Task<ApiResult<Employee>> Patch(Guid id, EmployeePatch employee, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Payroll/IPaystubService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Payroll/IPaystubService.cs
@@ -1,0 +1,53 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+
+namespace BexioApiNet.Interfaces.Connectors.Payroll;
+
+/// <summary>
+///     Service for downloading payroll paystubs in the Bexio payroll namespace (v4.0).
+///     Paystubs are a nested binary resource under employees — the single available
+///     operation returns the raw PDF bytes for a given employee, year and month at
+///     <c>/4.0/payroll/employees/{employeeId}/paystub-pdf/{year}/{month}</c>. No JSON
+///     model is involved; the response is surfaced as <c>byte[]</c> on the
+///     <see cref="ApiResult{T}" /> wrapper.
+///     <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
+/// </summary>
+public interface IPaystubService
+{
+    /// <summary>
+    ///     Downloads the paystub PDF for an employee for a given month as raw bytes.
+    ///     <see href="https://docs.bexio.com/#tag/Paystubs">Get Paystub PDF</see>
+    /// </summary>
+    /// <param name="employeeId">Identifier of the payroll employee.</param>
+    /// <param name="year">Four-digit year of the requested paystub.</param>
+    /// <param name="month">Month (1-12) of the requested paystub.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> whose <c>Data</c> contains the PDF bytes on success.</returns>
+    public Task<ApiResult<byte[]>> GetPdf(int employeeId, int year, int month,
+        [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Purchases/IBillService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Purchases/IBillService.cs
@@ -1,0 +1,117 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Purchases.Bills;
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Purchases;
+
+/// <summary>
+/// Service for managing bills in the Bexio purchase namespace (v4.0).
+/// <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+/// </summary>
+public interface IBillService
+{
+    /// <summary>
+    /// List bills.
+    /// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiBillsList_GET">List Bills</see>
+    /// </summary>
+    /// <param name="queryParameterBill">Optional query parameters for pagination, sorting and filtering.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the paged <see cref="BillListResponse"/> envelope.</returns>
+    public Task<ApiResult<BillListResponse>> Get([Optional] QueryParameterBill? queryParameterBill, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single bill by id.
+    /// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiBills_GET">Get Bill</see>
+    /// </summary>
+    /// <param name="id">Bill identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the full <see cref="Bill"/>.</returns>
+    public Task<ApiResult<Bill>> GetById(Guid id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Validate a proposed bill document number. Returns the next available number when
+    /// the proposed one is not unique among non-draft bills.
+    /// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiPurchaseDocumentNumbers_GET">Validate Document Number</see>
+    /// </summary>
+    /// <param name="documentNo">Proposed document number to validate (max 255 characters).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the <see cref="BillDocumentNumberResponse"/>.</returns>
+    public Task<ApiResult<BillDocumentNumberResponse>> GetDocNumbers(string documentNo, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new bill.
+    /// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiBills_POST">Create Bill</see>
+    /// </summary>
+    /// <param name="bill">Create view containing the bill details.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the newly created <see cref="Bill"/>.</returns>
+    public Task<ApiResult<Bill>> Create(BillCreate bill, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Execute a bill action (e.g. <see cref="BillAction.DUPLICATE"/>).
+    /// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiBillActions_POST">Execute Bill Action</see>
+    /// </summary>
+    /// <param name="id">Bill identifier the action is executed for.</param>
+    /// <param name="action">Action payload identifying the operation to perform.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the resulting <see cref="Bill"/> (for <c>DUPLICATE</c> this is the new duplicate).</returns>
+    public Task<ApiResult<Bill>> Actions(Guid id, BillActionRequest action, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update an existing bill. Bexio v4.0 uses PUT for full-replacement updates. When the
+    /// bill is not in <c>DRAFT</c> only <c>file_id</c> and <c>payment</c> are actually persisted.
+    /// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiBills_PUT">Update Bill</see>
+    /// </summary>
+    /// <param name="id">Bill identifier to update.</param>
+    /// <param name="bill">Update view containing the full bill state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated <see cref="Bill"/>.</returns>
+    public Task<ApiResult<Bill>> Update(Guid id, BillUpdate bill, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Transition a bill's booking status between <c>DRAFT</c> and <c>BOOKED</c>.
+    /// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiBillBookings_PUT">Update Bill Status</see>
+    /// </summary>
+    /// <param name="id">Bill identifier.</param>
+    /// <param name="status">Target booking status (<see cref="BillBookingStatus.DRAFT"/> or <see cref="BillBookingStatus.BOOKED"/>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated <see cref="Bill"/>.</returns>
+    public Task<ApiResult<Bill>> UpdateBookings(Guid id, BillBookingStatus status, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a bill. Only allowed for bills in status <c>DRAFT</c>.
+    /// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiBills_DELETE">Delete Bill</see>
+    /// </summary>
+    /// <param name="id">Bill identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> indicating success or failure.</returns>
+    public Task<ApiResult<object>> Delete(Guid id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Purchases/IPurchaseOrderService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Purchases/IPurchaseOrderService.cs
@@ -1,0 +1,86 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders;
+using BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.Purchases;
+
+/// <summary>
+/// Service for managing purchase orders in the Bexio purchase namespace (v3.0).
+/// <see href="https://docs.bexio.com/#tag/Purchase-Orders">Purchase Orders</see>
+/// </summary>
+public interface IPurchaseOrderService
+{
+    /// <summary>
+    /// List purchase orders.
+    /// <see href="https://docs.bexio.com/#tag/Purchase-Orders">List Purchase Orders</see>
+    /// </summary>
+    /// <param name="queryParameter">Optional query parameters (limit/offset/order_by).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of purchase orders.</returns>
+    public Task<ApiResult<List<PurchaseOrder>?>> Get([Optional] QueryParameter? queryParameter, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get a single purchase order by id.
+    /// <see href="https://docs.bexio.com/#tag/Purchase-Orders">Get Purchase Order</see>
+    /// </summary>
+    /// <param name="id">Purchase order identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the full <see cref="PurchaseOrder"/>.</returns>
+    public Task<ApiResult<PurchaseOrder>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new purchase order.
+    /// <see href="https://docs.bexio.com/#tag/Purchase-Orders">Create Purchase Order</see>
+    /// </summary>
+    /// <param name="purchaseOrder">Create view containing the purchase order details.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the newly created <see cref="PurchaseOrder"/>.</returns>
+    public Task<ApiResult<PurchaseOrder>> Create(PurchaseOrderCreate purchaseOrder, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Update an existing purchase order. Bexio v3.0 uses <c>POST /3.0/purchase/orders/{id}</c>
+    /// (not <c>PUT</c>) for full-replacement updates — the same convention as v2.0 sales documents.
+    /// <see href="https://docs.bexio.com/#tag/Purchase-Orders">Update Purchase Order</see>
+    /// </summary>
+    /// <param name="id">Purchase order identifier to update.</param>
+    /// <param name="purchaseOrder">Update view containing the full purchase order state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the updated <see cref="PurchaseOrder"/>.</returns>
+    public Task<ApiResult<PurchaseOrder>> Update(int id, PurchaseOrderUpdate purchaseOrder, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a purchase order.
+    /// <see href="https://docs.bexio.com/#tag/Purchase-Orders">Delete Purchase Order</see>
+    /// </summary>
+    /// <param name="id">Purchase order identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> indicating success or failure.</returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Projects;
+using BexioApiNet.Interfaces.Connectors.Purchases;
 using BexioApiNet.Interfaces.Connectors.Sales;
 using BexioApiNet.Interfaces.Connectors.Sales.Positions;
 using BexioApiNet.Interfaces.Connectors.Timesheets;
@@ -279,4 +280,9 @@ public interface IBexioApiClient : IDisposable
     /// <see href="https://docs.bexio.com/#tag/Projects">Projects</see>
     /// </summary>
     public IPackageService Packages { get; set; }
+
+    /// <summary>
+    ///     Bexio purchase bills connector. <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
+    /// </summary>
+    public IBillService PurchaseBills { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -27,6 +27,7 @@ using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -290,4 +291,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio purchase orders connector. <see href="https://docs.bexio.com/#tag/Purchase-Orders">Purchase Orders</see>
     /// </summary>
     public IPurchaseOrderService PurchaseOrders { get; set; }
+
+    /// <summary>
+    ///     Bexio expenses connector. <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+    /// </summary>
+    public IExpenseService Expenses { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -307,4 +307,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll absences connector. <see href="https://docs.bexio.com/#tag/Absences">Absences</see>
     /// </summary>
     public IAbsenceService PayrollAbsences { get; set; }
+
+    /// <summary>
+    ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
+    /// </summary>
+    public IPaystubService PayrollPaystubs { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -285,4 +285,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio purchase bills connector. <see href="https://docs.bexio.com/#tag/Bills">Bills</see>
     /// </summary>
     public IBillService PurchaseBills { get; set; }
+
+    /// <summary>
+    ///     Bexio purchase orders connector. <see href="https://docs.bexio.com/#tag/Purchase-Orders">Purchase Orders</see>
+    /// </summary>
+    public IPurchaseOrderService PurchaseOrders { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -302,4 +302,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll employees connector. <see href="https://docs.bexio.com/#tag/Employees">Employees</see>
     /// </summary>
     public IEmployeeService PayrollEmployees { get; set; }
+
+    /// <summary>
+    ///     Bexio payroll absences connector. <see href="https://docs.bexio.com/#tag/Absences">Absences</see>
+    /// </summary>
+    public IAbsenceService PayrollAbsences { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
 using BexioApiNet.Interfaces.Connectors.Sales;
@@ -296,4 +297,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio expenses connector. <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
     /// </summary>
     public IExpenseService Expenses { get; set; }
+
+    /// <summary>
+    ///     Bexio payroll employees connector. <see href="https://docs.bexio.com/#tag/Employees">Employees</see>
+    /// </summary>
+    public IEmployeeService PayrollEmployees { get; set; }
 }

--- a/src/BexioApiNet/Models/QueryParameterBill.cs
+++ b/src/BexioApiNet/Models/QueryParameterBill.cs
@@ -1,0 +1,119 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Query parameters for <c>GET /4.0/purchase/bills</c>. All parameters are optional;
+/// only supplied values are appended to the final URI.
+/// <see href="https://docs.bexio.com/#tag/Bills/operation/ApiBillsList_GET">List Bills</see>
+/// </summary>
+public sealed record QueryParameterBill
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryParameterBill"/> record.
+    /// </summary>
+    /// <param name="limit">Page size (1-500). Bexio default is 100.</param>
+    /// <param name="page">1-based page number. Bexio default is 1.</param>
+    /// <param name="order">Sort direction. Must be <c>asc</c> or <c>desc</c>. Bexio default is <c>asc</c>.</param>
+    /// <param name="sort">Field name to sort by (e.g. <c>document_no</c>).</param>
+    /// <param name="searchTerm">Free-text search term (3-255 characters).</param>
+    /// <param name="status">Status filter — one of <c>DRAFTS</c>, <c>TODO</c>, <c>PAID</c>, <c>OVERDUE</c>.</param>
+    /// <param name="billDateStart">Lower bound (inclusive) for <c>bill_date</c>.</param>
+    /// <param name="billDateEnd">Upper bound (inclusive) for <c>bill_date</c>.</param>
+    /// <param name="dueDateStart">Lower bound (inclusive) for <c>due_date</c>.</param>
+    /// <param name="dueDateEnd">Upper bound (inclusive) for <c>due_date</c>.</param>
+    /// <param name="vendorRef">Substring filter on <c>vendor_ref</c>.</param>
+    /// <param name="title">Substring filter on <c>title</c>.</param>
+    /// <param name="currencyCode">Substring filter on <c>currency_code</c>.</param>
+    /// <param name="pendingAmountMin">Lower bound (inclusive) for <c>pending_amount</c>.</param>
+    /// <param name="pendingAmountMax">Upper bound (inclusive) for <c>pending_amount</c>.</param>
+    /// <param name="vendor">Substring filter across <c>lastname_company</c> and <c>firstname_suffix</c>.</param>
+    /// <param name="grossMin">Lower bound (inclusive) for <c>gross</c>.</param>
+    /// <param name="grossMax">Upper bound (inclusive) for <c>gross</c>.</param>
+    /// <param name="netMin">Lower bound (inclusive) for <c>net</c>.</param>
+    /// <param name="netMax">Upper bound (inclusive) for <c>net</c>.</param>
+    /// <param name="documentNo">Substring filter on <c>document_no</c>.</param>
+    /// <param name="supplierId">Exact match on <c>supplier_id</c>.</param>
+    /// <param name="averageExchangeRateEnabled">Filter for bills where the average exchange rate feature is enabled.</param>
+    public QueryParameterBill(
+        int? limit = null,
+        int? page = null,
+        string? order = null,
+        string? sort = null,
+        string? searchTerm = null,
+        string? status = null,
+        DateOnly? billDateStart = null,
+        DateOnly? billDateEnd = null,
+        DateOnly? dueDateStart = null,
+        DateOnly? dueDateEnd = null,
+        string? vendorRef = null,
+        string? title = null,
+        string? currencyCode = null,
+        double? pendingAmountMin = null,
+        double? pendingAmountMax = null,
+        string? vendor = null,
+        double? grossMin = null,
+        double? grossMax = null,
+        double? netMin = null,
+        double? netMax = null,
+        string? documentNo = null,
+        int? supplierId = null,
+        bool? averageExchangeRateEnabled = null)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l) parameters["limit"] = l;
+        if (page is { } p) parameters["page"] = p;
+        if (!string.IsNullOrWhiteSpace(order)) parameters["order"] = order;
+        if (!string.IsNullOrWhiteSpace(sort)) parameters["sort"] = sort;
+        if (!string.IsNullOrWhiteSpace(searchTerm)) parameters["search_term"] = searchTerm;
+        if (!string.IsNullOrWhiteSpace(status)) parameters["status"] = status;
+        if (billDateStart is { } bds) parameters["bill_date_start"] = bds.ToString("yyyy-MM-dd");
+        if (billDateEnd is { } bde) parameters["bill_date_end"] = bde.ToString("yyyy-MM-dd");
+        if (dueDateStart is { } dds) parameters["due_date_start"] = dds.ToString("yyyy-MM-dd");
+        if (dueDateEnd is { } dde) parameters["due_date_end"] = dde.ToString("yyyy-MM-dd");
+        if (!string.IsNullOrWhiteSpace(vendorRef)) parameters["vendor_ref"] = vendorRef;
+        if (!string.IsNullOrWhiteSpace(title)) parameters["title"] = title;
+        if (!string.IsNullOrWhiteSpace(currencyCode)) parameters["currency_code"] = currencyCode;
+        if (pendingAmountMin is { } pmin) parameters["pending_amount_min"] = pmin;
+        if (pendingAmountMax is { } pmax) parameters["pending_amount_max"] = pmax;
+        if (!string.IsNullOrWhiteSpace(vendor)) parameters["vendor"] = vendor;
+        if (grossMin is { } gmin) parameters["gross_min"] = gmin;
+        if (grossMax is { } gmax) parameters["gross_max"] = gmax;
+        if (netMin is { } nmin) parameters["net_min"] = nmin;
+        if (netMax is { } nmax) parameters["net_max"] = nmax;
+        if (!string.IsNullOrWhiteSpace(documentNo)) parameters["document_no"] = documentNo;
+        if (supplierId is { } sid) parameters["supplier_id"] = sid;
+        if (averageExchangeRateEnabled is { } aer) parameters["average_exchange_rate_enabled"] = aer;
+
+        QueryParameter = new(parameters);
+    }
+
+    /// <summary>
+    /// Serializable query parameter dictionary forwarded to <c>ConnectionHandler</c>.
+    /// </summary>
+    public QueryParameter QueryParameter { get; }
+}

--- a/src/BexioApiNet/Models/QueryParameterExpense.cs
+++ b/src/BexioApiNet/Models/QueryParameterExpense.cs
@@ -1,0 +1,116 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Query parameters for <c>GET /4.0/expenses/expenses</c>. All parameters are optional;
+/// only supplied values are appended to the final URI.
+/// <see href="https://docs.bexio.com/#tag/Expenses">Expenses</see>
+/// </summary>
+public sealed record QueryParameterExpense
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryParameterExpense"/> record.
+    /// </summary>
+    /// <param name="limit">Page size (1-500). Bexio default is 100.</param>
+    /// <param name="page">1-based page number. Bexio default is 1.</param>
+    /// <param name="order">Sort direction. Must be <c>asc</c> or <c>desc</c>. Bexio default is <c>asc</c>.</param>
+    /// <param name="sort">Field name to sort by (e.g. <c>document_no</c>).</param>
+    /// <param name="searchTerm">Free-text search term (3-255 characters).</param>
+    /// <param name="status">Status filter — one of <c>DRAFTS</c>, <c>TODO</c>, <c>PAID</c>, <c>OVERDUE</c>.</param>
+    /// <param name="expenseDateStart">Lower bound (inclusive) for <c>expense_date</c>.</param>
+    /// <param name="expenseDateEnd">Upper bound (inclusive) for <c>expense_date</c>.</param>
+    /// <param name="dueDateStart">Lower bound (inclusive) for <c>due_date</c>.</param>
+    /// <param name="dueDateEnd">Upper bound (inclusive) for <c>due_date</c>.</param>
+    /// <param name="vendorRef">Substring filter on <c>vendor_ref</c>.</param>
+    /// <param name="title">Substring filter on <c>title</c>.</param>
+    /// <param name="currencyCode">Substring filter on <c>currency_code</c>.</param>
+    /// <param name="pendingAmountMin">Lower bound (inclusive) for <c>pending_amount</c>.</param>
+    /// <param name="pendingAmountMax">Upper bound (inclusive) for <c>pending_amount</c>.</param>
+    /// <param name="vendor">Substring filter across <c>lastname_company</c> and <c>firstname_suffix</c>.</param>
+    /// <param name="grossMin">Lower bound (inclusive) for <c>gross</c>.</param>
+    /// <param name="grossMax">Upper bound (inclusive) for <c>gross</c>.</param>
+    /// <param name="netMin">Lower bound (inclusive) for <c>net</c>.</param>
+    /// <param name="netMax">Upper bound (inclusive) for <c>net</c>.</param>
+    /// <param name="documentNo">Substring filter on <c>document_no</c>.</param>
+    /// <param name="supplierId">Exact match on <c>supplier_id</c>.</param>
+    public QueryParameterExpense(
+        int? limit = null,
+        int? page = null,
+        string? order = null,
+        string? sort = null,
+        string? searchTerm = null,
+        string? status = null,
+        DateOnly? expenseDateStart = null,
+        DateOnly? expenseDateEnd = null,
+        DateOnly? dueDateStart = null,
+        DateOnly? dueDateEnd = null,
+        string? vendorRef = null,
+        string? title = null,
+        string? currencyCode = null,
+        double? pendingAmountMin = null,
+        double? pendingAmountMax = null,
+        string? vendor = null,
+        double? grossMin = null,
+        double? grossMax = null,
+        double? netMin = null,
+        double? netMax = null,
+        string? documentNo = null,
+        int? supplierId = null)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l) parameters["limit"] = l;
+        if (page is { } p) parameters["page"] = p;
+        if (!string.IsNullOrWhiteSpace(order)) parameters["order"] = order;
+        if (!string.IsNullOrWhiteSpace(sort)) parameters["sort"] = sort;
+        if (!string.IsNullOrWhiteSpace(searchTerm)) parameters["search_term"] = searchTerm;
+        if (!string.IsNullOrWhiteSpace(status)) parameters["status"] = status;
+        if (expenseDateStart is { } eds) parameters["expense_date_start"] = eds.ToString("yyyy-MM-dd");
+        if (expenseDateEnd is { } ede) parameters["expense_date_end"] = ede.ToString("yyyy-MM-dd");
+        if (dueDateStart is { } dds) parameters["due_date_start"] = dds.ToString("yyyy-MM-dd");
+        if (dueDateEnd is { } dde) parameters["due_date_end"] = dde.ToString("yyyy-MM-dd");
+        if (!string.IsNullOrWhiteSpace(vendorRef)) parameters["vendor_ref"] = vendorRef;
+        if (!string.IsNullOrWhiteSpace(title)) parameters["title"] = title;
+        if (!string.IsNullOrWhiteSpace(currencyCode)) parameters["currency_code"] = currencyCode;
+        if (pendingAmountMin is { } pmin) parameters["pending_amount_min"] = pmin;
+        if (pendingAmountMax is { } pmax) parameters["pending_amount_max"] = pmax;
+        if (!string.IsNullOrWhiteSpace(vendor)) parameters["vendor"] = vendor;
+        if (grossMin is { } gmin) parameters["gross_min"] = gmin;
+        if (grossMax is { } gmax) parameters["gross_max"] = gmax;
+        if (netMin is { } nmin) parameters["net_min"] = nmin;
+        if (netMax is { } nmax) parameters["net_max"] = nmax;
+        if (!string.IsNullOrWhiteSpace(documentNo)) parameters["document_no"] = documentNo;
+        if (supplierId is { } sid) parameters["supplier_id"] = sid;
+
+        QueryParameter = new(parameters);
+    }
+
+    /// <summary>
+    /// Serializable query parameter dictionary forwarded to <c>ConnectionHandler</c>.
+    /// </summary>
+    public QueryParameter QueryParameter { get; }
+}

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
 using BexioApiNet.Interfaces.Connectors.Sales;
@@ -191,6 +192,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IExpenseService Expenses { get; set; }
 
+    /// <inheritdoc />
+    public IEmployeeService PayrollEmployees { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -243,7 +247,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IPackageService packages,
         IBillService purchaseBills,
         IPurchaseOrderService purchaseOrders,
-        IExpenseService expenses)
+        IExpenseService expenses,
+        IEmployeeService payrollEmployees)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -294,6 +299,7 @@ public sealed class BexioApiClient : IBexioApiClient
         PurchaseBills = purchaseBills;
         PurchaseOrders = purchaseOrders;
         Expenses = expenses;
+        PayrollEmployees = payrollEmployees;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -198,6 +198,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IAbsenceService PayrollAbsences { get; set; }
 
+    /// <inheritdoc />
+    public IPaystubService PayrollPaystubs { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -252,7 +255,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IPurchaseOrderService purchaseOrders,
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
-        IAbsenceService payrollAbsences)
+        IAbsenceService payrollAbsences,
+        IPaystubService payrollPaystubs)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -305,6 +309,7 @@ public sealed class BexioApiClient : IBexioApiClient
         Expenses = expenses;
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
+        PayrollPaystubs = payrollPaystubs;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -195,6 +195,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IEmployeeService PayrollEmployees { get; set; }
 
+    /// <inheritdoc />
+    public IAbsenceService PayrollAbsences { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -248,7 +251,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IBillService purchaseBills,
         IPurchaseOrderService purchaseOrders,
         IExpenseService expenses,
-        IEmployeeService payrollEmployees)
+        IEmployeeService payrollEmployees,
+        IAbsenceService payrollAbsences)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -300,6 +304,7 @@ public sealed class BexioApiClient : IBexioApiClient
         PurchaseOrders = purchaseOrders;
         Expenses = expenses;
         PayrollEmployees = payrollEmployees;
+        PayrollAbsences = payrollAbsences;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -184,6 +184,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IBillService PurchaseBills { get; set; }
 
+    /// <inheritdoc />
+    public IPurchaseOrderService PurchaseOrders { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -234,7 +237,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IProjectTypeService projectTypes,
         IMilestoneService milestones,
         IPackageService packages,
-        IBillService purchaseBills)
+        IBillService purchaseBills,
+        IPurchaseOrderService purchaseOrders)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -283,6 +287,7 @@ public sealed class BexioApiClient : IBexioApiClient
         Milestones = milestones;
         Packages = packages;
         PurchaseBills = purchaseBills;
+        PurchaseOrders = purchaseOrders;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Projects;
+using BexioApiNet.Interfaces.Connectors.Purchases;
 using BexioApiNet.Interfaces.Connectors.Sales;
 using BexioApiNet.Interfaces.Connectors.Sales.Positions;
 using BexioApiNet.Interfaces.Connectors.Timesheets;
@@ -180,6 +181,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPackageService Packages { get; set; }
 
+    /// <inheritdoc />
+    public IBillService PurchaseBills { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -229,7 +233,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IProjectStateService projectStates,
         IProjectTypeService projectTypes,
         IMilestoneService milestones,
-        IPackageService packages)
+        IPackageService packages,
+        IBillService purchaseBills)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -277,6 +282,7 @@ public sealed class BexioApiClient : IBexioApiClient
         ProjectTypes = projectTypes;
         Milestones = milestones;
         Packages = packages;
+        PurchaseBills = purchaseBills;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -28,6 +28,7 @@ using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -187,6 +188,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPurchaseOrderService PurchaseOrders { get; set; }
 
+    /// <inheritdoc />
+    public IExpenseService Expenses { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -238,7 +242,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IMilestoneService milestones,
         IPackageService packages,
         IBillService purchaseBills,
-        IPurchaseOrderService purchaseOrders)
+        IPurchaseOrderService purchaseOrders,
+        IExpenseService expenses)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -288,6 +293,7 @@ public sealed class BexioApiClient : IBexioApiClient
         Packages = packages;
         PurchaseBills = purchaseBills;
         PurchaseOrders = purchaseOrders;
+        Expenses = expenses;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/Connectors/Expenses/ExpenseConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Expenses/ExpenseConfiguration.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Expenses;
+
+/// <summary>
+/// Expense endpoint configuration. Bexio <c>4.0/expenses/expenses</c>.
+/// </summary>
+public static class ExpenseConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "4.0";
+
+    /// <summary>
+    /// The request path for expense resources.
+    /// </summary>
+    public const string EndpointRoot = "expenses/expenses";
+
+    /// <summary>
+    /// The request path for the document-number validation endpoint. This is a sibling
+    /// route of <see cref="EndpointRoot"/> — <c>/4.0/expenses/documentnumbers/expenses</c>.
+    /// </summary>
+    public const string DocNumberEndpointRoot = "expenses/documentnumbers/expenses";
+}

--- a/src/BexioApiNet/Services/Connectors/Expenses/ExpenseService.cs
+++ b/src/BexioApiNet/Services/Connectors/Expenses/ExpenseService.cs
@@ -1,0 +1,113 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Expenses;
+
+/// <inheritdoc cref="IExpenseService" />
+public sealed class ExpenseService : ConnectorService, IExpenseService
+{
+    /// <summary>
+    /// The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = ExpenseConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path for expense resources.
+    /// </summary>
+    private const string EndpointRoot = ExpenseConfiguration.EndpointRoot;
+
+    /// <summary>
+    /// The api request path for the document-number validation endpoint.
+    /// </summary>
+    private const string DocNumberEndpointRoot = ExpenseConfiguration.DocNumberEndpointRoot;
+
+    /// <inheritdoc />
+    public ExpenseService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ExpenseListResponse>> Get([Optional] QueryParameterExpense? queryParameterExpense, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<ExpenseListResponse>($"{ApiVersion}/{EndpointRoot}", queryParameterExpense?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Expense>> GetById(Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Expense>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<ExpenseDocumentNumberResponse>> GetDocNumbers(string documentNo, [Optional] CancellationToken cancellationToken)
+    {
+        var queryParameter = new QueryParameter(new Dictionary<string, object>
+        {
+            ["document_no"] = documentNo
+        });
+
+        return await ConnectionHandler.GetAsync<ExpenseDocumentNumberResponse>($"{ApiVersion}/{DocNumberEndpointRoot}", queryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Expense>> Create(ExpenseCreate expense, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Expense, ExpenseCreate>(expense, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Expense>> Actions(Guid id, ExpenseActionRequest action, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Expense, ExpenseActionRequest>(action, $"{ApiVersion}/{EndpointRoot}/{id}/actions", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Expense>> Update(Guid id, ExpenseUpdate expense, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Expense, ExpenseUpdate>(expense, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Expense>> UpdateBookings(Guid id, ExpenseBookingStatus status, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Expense, object?>(null, $"{ApiVersion}/{EndpointRoot}/{id}/bookings/{status}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Payroll/AbsenceConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Payroll/AbsenceConfiguration.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Payroll;
+
+/// <summary>
+/// Absence endpoint configuration. Bexio <c>4.0/payroll/employees/{employeeId}/absences</c>.
+/// Absences are nested under employees, so the <see cref="EndpointRoot"/> covers only the
+/// employee path segment — callers append <c>/{employeeId}/absences</c> at the call site.
+/// </summary>
+public static class AbsenceConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "4.0";
+
+    /// <summary>
+    /// The request path prefix for the parent payroll employee resource.
+    /// </summary>
+    public const string EndpointRoot = "payroll/employees";
+}

--- a/src/BexioApiNet/Services/Connectors/Payroll/AbsenceService.cs
+++ b/src/BexioApiNet/Services/Connectors/Payroll/AbsenceService.cs
@@ -1,0 +1,83 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Payroll.Absences;
+using BexioApiNet.Abstractions.Models.Payroll.Absences.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Payroll;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Payroll;
+
+/// <inheritdoc cref="IAbsenceService" />
+public sealed class AbsenceService : ConnectorService, IAbsenceService
+{
+    /// <summary>
+    /// The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = AbsenceConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path prefix for the parent payroll employee resource.
+    /// </summary>
+    private const string EndpointRoot = AbsenceConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public AbsenceService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Absence>>> Get(Guid employeeId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<Absence>>($"{ApiVersion}/{EndpointRoot}/{employeeId}/absences", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Absence>> GetById(Guid employeeId, Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Absence>($"{ApiVersion}/{EndpointRoot}/{employeeId}/absences/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Absence>> Create(Guid employeeId, AbsenceCreate absence, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Absence, AbsenceCreate>(absence, $"{ApiVersion}/{EndpointRoot}/{employeeId}/absences", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Absence>> Update(Guid employeeId, Guid id, AbsenceUpdate absence, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Absence, AbsenceUpdate>(absence, $"{ApiVersion}/{EndpointRoot}/{employeeId}/absences/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(Guid employeeId, Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{employeeId}/absences/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Payroll/EmployeeConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Payroll/EmployeeConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Payroll;
+
+/// <summary>
+/// Employee endpoint configuration. Bexio <c>4.0/payroll/employees</c>.
+/// </summary>
+public static class EmployeeConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "4.0";
+
+    /// <summary>
+    /// The request path for payroll employee resources.
+    /// </summary>
+    public const string EndpointRoot = "payroll/employees";
+}

--- a/src/BexioApiNet/Services/Connectors/Payroll/EmployeeService.cs
+++ b/src/BexioApiNet/Services/Connectors/Payroll/EmployeeService.cs
@@ -1,0 +1,77 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Payroll.Employees;
+using BexioApiNet.Abstractions.Models.Payroll.Employees.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Payroll;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Payroll;
+
+/// <inheritdoc cref="IEmployeeService" />
+public sealed class EmployeeService : ConnectorService, IEmployeeService
+{
+    /// <summary>
+    /// The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = EmployeeConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path for payroll employee resources.
+    /// </summary>
+    private const string EndpointRoot = EmployeeConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public EmployeeService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Employee>>> Get([Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<Employee>>($"{ApiVersion}/{EndpointRoot}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Employee>> GetById(Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Employee>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Employee>> Create(EmployeeCreate employee, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Employee, EmployeeCreate>(employee, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Employee>> Patch(Guid id, EmployeePatch employee, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PatchAsync<Employee, EmployeePatch>(employee, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Payroll/PaystubConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Payroll/PaystubConfiguration.cs
@@ -1,0 +1,46 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Payroll;
+
+/// <summary>
+///     Paystub endpoint configuration. Bexio
+///     <c>4.0/payroll/employees/{employeeId}/paystub-pdf/{year}/{month}</c>.
+///     Paystubs are a nested binary download under employees, so the
+///     <see cref="EndpointRoot" /> covers only the employee path segment — callers
+///     append <c>/{employeeId}/paystub-pdf/{year}/{month}</c> at the call site.
+/// </summary>
+public static class PaystubConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "4.0";
+
+    /// <summary>
+    ///     The request path prefix for the parent payroll employee resource.
+    /// </summary>
+    public const string EndpointRoot = "payroll/employees";
+}

--- a/src/BexioApiNet/Services/Connectors/Payroll/PaystubService.cs
+++ b/src/BexioApiNet/Services/Connectors/Payroll/PaystubService.cs
@@ -1,0 +1,60 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Payroll;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Payroll;
+
+/// <inheritdoc cref="IPaystubService" />
+public sealed class PaystubService : ConnectorService, IPaystubService
+{
+    /// <summary>
+    ///     The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = PaystubConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path prefix for the parent payroll employee resource.
+    /// </summary>
+    private const string EndpointRoot = PaystubConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public PaystubService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<byte[]>> GetPdf(int employeeId, int year, int month,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetBinaryAsync(
+            $"{ApiVersion}/{EndpointRoot}/{employeeId}/paystub-pdf/{year}/{month}",
+            cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Purchases/BillConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Purchases/BillConfiguration.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Purchases;
+
+/// <summary>
+/// Bill endpoint configuration. Bexio <c>4.0/purchase/bills</c>.
+/// </summary>
+public static class BillConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "4.0";
+
+    /// <summary>
+    /// The request path for bill resources.
+    /// </summary>
+    public const string EndpointRoot = "purchase/bills";
+
+    /// <summary>
+    /// The request path for the document-number validation endpoint. This is a sibling
+    /// route of <see cref="EndpointRoot"/> — <c>/4.0/purchase/documentnumbers/bills</c>.
+    /// </summary>
+    public const string DocNumberEndpointRoot = "purchase/documentnumbers/bills";
+}

--- a/src/BexioApiNet/Services/Connectors/Purchases/BillService.cs
+++ b/src/BexioApiNet/Services/Connectors/Purchases/BillService.cs
@@ -1,0 +1,113 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Purchases.Bills;
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Purchases;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Purchases;
+
+/// <inheritdoc cref="IBillService" />
+public sealed class BillService : ConnectorService, IBillService
+{
+    /// <summary>
+    /// The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = BillConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path for bill resources.
+    /// </summary>
+    private const string EndpointRoot = BillConfiguration.EndpointRoot;
+
+    /// <summary>
+    /// The api request path for the document-number validation endpoint.
+    /// </summary>
+    private const string DocNumberEndpointRoot = BillConfiguration.DocNumberEndpointRoot;
+
+    /// <inheritdoc />
+    public BillService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<BillListResponse>> Get([Optional] QueryParameterBill? queryParameterBill, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<BillListResponse>($"{ApiVersion}/{EndpointRoot}", queryParameterBill?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Bill>> GetById(Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Bill>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<BillDocumentNumberResponse>> GetDocNumbers(string documentNo, [Optional] CancellationToken cancellationToken)
+    {
+        var queryParameter = new QueryParameter(new Dictionary<string, object>
+        {
+            ["document_no"] = documentNo
+        });
+
+        return await ConnectionHandler.GetAsync<BillDocumentNumberResponse>($"{ApiVersion}/{DocNumberEndpointRoot}", queryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Bill>> Create(BillCreate bill, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Bill, BillCreate>(bill, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Bill>> Actions(Guid id, BillActionRequest action, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Bill, BillActionRequest>(action, $"{ApiVersion}/{EndpointRoot}/{id}/actions", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Bill>> Update(Guid id, BillUpdate bill, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Bill, BillUpdate>(bill, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Bill>> UpdateBookings(Guid id, BillBookingStatus status, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Bill, object?>(null, $"{ApiVersion}/{EndpointRoot}/{id}/bookings/{status}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(Guid id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Purchases/PurchaseOrderConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Purchases/PurchaseOrderConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Purchases;
+
+/// <summary>
+/// Purchase order endpoint configuration. Bexio <c>3.0/purchase/orders</c>.
+/// </summary>
+public static class PurchaseOrderConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    /// The request path for purchase order resources.
+    /// </summary>
+    public const string EndpointRoot = "purchase/orders";
+}

--- a/src/BexioApiNet/Services/Connectors/Purchases/PurchaseOrderService.cs
+++ b/src/BexioApiNet/Services/Connectors/Purchases/PurchaseOrderService.cs
@@ -1,0 +1,84 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders;
+using BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Purchases;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Purchases;
+
+/// <inheritdoc cref="IPurchaseOrderService" />
+public sealed class PurchaseOrderService : ConnectorService, IPurchaseOrderService
+{
+    /// <summary>
+    /// The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = PurchaseOrderConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path for purchase order resources.
+    /// </summary>
+    private const string EndpointRoot = PurchaseOrderConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public PurchaseOrderService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<PurchaseOrder>?>> Get([Optional] QueryParameter? queryParameter, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<PurchaseOrder>?>($"{ApiVersion}/{EndpointRoot}", queryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<PurchaseOrder>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<PurchaseOrder>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<PurchaseOrder>> Create(PurchaseOrderCreate purchaseOrder, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<PurchaseOrder, PurchaseOrderCreate>(purchaseOrder, $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<PurchaseOrder>> Update(int id, PurchaseOrderUpdate purchaseOrder, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<PurchaseOrder, PurchaseOrderUpdate>(purchaseOrder, $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
 using BexioApiNet.Services.Connectors.Sales;
@@ -129,7 +130,8 @@ public abstract class BexioE2eTestBase
             new PackageService(connectionHandler),
             new BillService(connectionHandler),
             new PurchaseOrderService(connectionHandler),
-            new ExpenseService(connectionHandler));
+            new ExpenseService(connectionHandler),
+            new EmployeeService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -28,6 +28,7 @@ using BexioApiNet.Services.Connectors.Accounting;
 using BexioApiNet.Services.Connectors.Banking;
 using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
+using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -127,7 +128,8 @@ public abstract class BexioE2eTestBase
             new MilestoneService(connectionHandler),
             new PackageService(connectionHandler),
             new BillService(connectionHandler),
-            new PurchaseOrderService(connectionHandler));
+            new PurchaseOrderService(connectionHandler),
+            new ExpenseService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -132,7 +132,8 @@ public abstract class BexioE2eTestBase
             new PurchaseOrderService(connectionHandler),
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
-            new AbsenceService(connectionHandler));
+            new AbsenceService(connectionHandler),
+            new PaystubService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -131,7 +131,8 @@ public abstract class BexioE2eTestBase
             new BillService(connectionHandler),
             new PurchaseOrderService(connectionHandler),
             new ExpenseService(connectionHandler),
-            new EmployeeService(connectionHandler));
+            new EmployeeService(connectionHandler),
+            new AbsenceService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -126,7 +126,8 @@ public abstract class BexioE2eTestBase
             new ProjectTypeService(connectionHandler),
             new MilestoneService(connectionHandler),
             new PackageService(connectionHandler),
-            new BillService(connectionHandler));
+            new BillService(connectionHandler),
+            new PurchaseOrderService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Items;
 using BexioApiNet.Services.Connectors.Projects;
+using BexioApiNet.Services.Connectors.Purchases;
 using BexioApiNet.Services.Connectors.Sales;
 using BexioApiNet.Services.Connectors.Sales.Positions;
 using BexioApiNet.Services.Connectors.Timesheets;
@@ -124,7 +125,8 @@ public abstract class BexioE2eTestBase
             new ProjectStateService(connectionHandler),
             new ProjectTypeService(connectionHandler),
             new MilestoneService(connectionHandler),
-            new PackageService(connectionHandler));
+            new PackageService(connectionHandler),
+            new BillService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/Tests/Expenses/Expenses/ExpenseServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Expenses/Expenses/ExpenseServiceE2eTests.cs
@@ -1,0 +1,114 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Expenses.Expenses;
+
+/// <summary>
+/// Live E2E tests for the <see cref="BexioApiNet.Services.Connectors.Expenses.ExpenseService"/>.
+/// Read-only calls only: listing expenses, retrieving an expense by id, and validating a
+/// document number. Tests are auto-skipped when credentials are missing per
+/// <see cref="BexioE2eTestBase"/>.
+/// </summary>
+[Category("E2E")]
+public sealed class ExpenseServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists expenses and asserts the response envelope deserializes correctly —
+    /// <c>data</c> and <c>paging</c> must both be populated.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsListResponse()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.Expenses.Get();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Data, Is.Not.Null);
+            Assert.That(result.Data.Paging, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches the first expense returned by the list endpoint (when any exist) and
+    /// asserts the full expense payload deserializes correctly through
+    /// <see cref="BexioApiNet.Services.Connectors.Expenses.ExpenseService.GetById"/>.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsExpenseOrIgnoresWhenNoneExist()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var listResult = await BexioApiClient!.Expenses.Get(new QueryParameterExpense(limit: 1));
+
+        Assert.That(listResult.IsSuccess, Is.True);
+
+        if (listResult.Data?.Data.Count is not > 0)
+        {
+            Assert.Ignore("no expenses available in the target Bexio account");
+            return;
+        }
+
+        var firstId = listResult.Data.Data[0].Id;
+
+        var result = await BexioApiClient.Expenses.GetById(firstId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(firstId));
+        });
+    }
+
+    /// <summary>
+    /// Validates a proposed document number. For an arbitrary candidate the endpoint
+    /// should respond with a successful result — <c>valid</c> may be <c>true</c> or
+    /// <c>false</c> depending on the account state, so the test only asserts that the
+    /// call succeeds and the response deserializes.
+    /// </summary>
+    [Test]
+    public async Task GetDocNumbers_ReturnsValidationResponse()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.Expenses.GetDocNumbers("BEXIOAPINET-E2E-PROBE");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Payroll/Absences/AbsenceServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Payroll/Absences/AbsenceServiceE2eTests.cs
@@ -1,0 +1,57 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Payroll.Absences;
+
+/// <summary>
+/// Live E2E tests for the <see cref="BexioApiNet.Services.Connectors.Payroll.AbsenceService"/>.
+/// Read-only calls only: listing absences for a placeholder employee. Tests are
+/// auto-skipped when credentials are missing per <see cref="BexioE2eTestBase"/>.
+/// </summary>
+[Category("E2E")]
+public sealed class AbsenceServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists payroll absences for a placeholder employee id and asserts the response
+    /// deserializes correctly — the call must succeed and <c>Data</c> must be populated
+    /// (possibly empty). The id is a dummy because this stub is auto-skipped without
+    /// credentials.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsListResult()
+    {
+        var employeeId = Guid.Empty;
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.PayrollAbsences.Get(employeeId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Payroll/Employees/EmployeeServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Payroll/Employees/EmployeeServiceE2eTests.cs
@@ -1,0 +1,54 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Payroll.Employees;
+
+/// <summary>
+/// Live E2E tests for the <see cref="BexioApiNet.Services.Connectors.Payroll.EmployeeService"/>.
+/// Read-only calls only: listing active payroll employees. Tests are auto-skipped when
+/// credentials are missing per <see cref="BexioE2eTestBase"/>.
+/// </summary>
+[Category("E2E")]
+public sealed class EmployeeServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists payroll employees and asserts the response deserializes correctly — the call
+    /// must succeed and <c>Data</c> must be populated (possibly empty).
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsListResult()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.PayrollEmployees.Get();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Payroll/Paystubs/PaystubServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Payroll/Paystubs/PaystubServiceE2eTests.cs
@@ -1,0 +1,56 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Payroll.Paystubs;
+
+/// <summary>
+///     Live E2E tests for the <see cref="BexioApiNet.Services.Connectors.Payroll.PaystubService" />.
+///     Read-only calls only: downloading a paystub PDF for a placeholder employee and period.
+///     Tests are auto-skipped when credentials are missing per <see cref="BexioE2eTestBase" />.
+/// </summary>
+[Category("E2E")]
+public sealed class PaystubServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    ///     Downloads a paystub PDF for a placeholder employee and period and asserts the
+    ///     response returns binary data — the call must succeed and <c>Data</c> must be
+    ///     populated. The id and period are placeholders because this stub is auto-skipped
+    ///     without credentials.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_ReturnsBinaryResult()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.PayrollPaystubs.GetPdf(1, 2026, 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Purchases/Bills/BillServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Purchases/Bills/BillServiceE2eTests.cs
@@ -1,0 +1,114 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Models;
+
+namespace BexioApiNet.E2eTests.Tests.Purchases.Bills;
+
+/// <summary>
+/// Live E2E tests for the <see cref="BexioApiNet.Services.Connectors.Purchases.BillService"/>.
+/// Read-only calls only: listing bills, retrieving a bill by id, and validating a
+/// document number. Tests are auto-skipped when credentials are missing per
+/// <see cref="BexioE2eTestBase"/>.
+/// </summary>
+[Category("E2E")]
+public sealed class BillServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists bills and asserts the response envelope deserializes correctly —
+    /// <c>data</c> and <c>paging</c> must both be populated.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsListResponse()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.PurchaseBills.Get();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Data, Is.Not.Null);
+            Assert.That(result.Data.Paging, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches the first bill returned by the list endpoint (when any exist) and
+    /// asserts the full bill payload deserializes correctly through
+    /// <see cref="BexioApiNet.Services.Connectors.Purchases.BillService.GetById"/>.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsBillOrIgnoresWhenNoneExist()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var listResult = await BexioApiClient!.PurchaseBills.Get(new QueryParameterBill(limit: 1));
+
+        Assert.That(listResult.IsSuccess, Is.True);
+
+        if (listResult.Data?.Data.Count is not > 0)
+        {
+            Assert.Ignore("no bills available in the target Bexio account");
+            return;
+        }
+
+        var firstId = listResult.Data.Data[0].Id;
+
+        var result = await BexioApiClient.PurchaseBills.GetById(firstId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(firstId));
+        });
+    }
+
+    /// <summary>
+    /// Validates a proposed document number. For an arbitrary candidate the endpoint
+    /// should respond with a successful result — <c>valid</c> may be <c>true</c> or
+    /// <c>false</c> depending on the account state, so the test only asserts that the
+    /// call succeeds and the response deserializes.
+    /// </summary>
+    [Test]
+    public async Task GetDocNumbers_ReturnsValidationResponse()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.PurchaseBills.GetDocNumbers("BEXIOAPINET-E2E-PROBE");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+}

--- a/tests/BexioApiNet.E2eTests/Tests/Purchases/PurchaseOrders/PurchaseOrderServiceE2eTests.cs
+++ b/tests/BexioApiNet.E2eTests/Tests/Purchases/PurchaseOrders/PurchaseOrderServiceE2eTests.cs
@@ -1,0 +1,87 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.E2eTests.Tests.Purchases.PurchaseOrders;
+
+/// <summary>
+/// Live E2E tests for the <see cref="BexioApiNet.Services.Connectors.Purchases.PurchaseOrderService"/>.
+/// Read-only calls only: listing purchase orders and retrieving a purchase order by id.
+/// Tests are auto-skipped when credentials are missing per <see cref="BexioE2eTestBase"/>.
+/// </summary>
+[Category("E2E")]
+public sealed class PurchaseOrderServiceE2eTests : BexioE2eTestBase
+{
+    /// <summary>
+    /// Lists purchase orders and asserts the list response deserializes correctly.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsListResponse()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var result = await BexioApiClient!.PurchaseOrders.Get();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+        });
+    }
+
+    /// <summary>
+    /// Fetches the first purchase order returned by the list endpoint (when any exist) and
+    /// asserts the full payload deserializes correctly through
+    /// <see cref="BexioApiNet.Services.Connectors.Purchases.PurchaseOrderService.GetById"/>.
+    /// </summary>
+    [Test]
+    public async Task GetById_ReturnsPurchaseOrderOrIgnoresWhenNoneExist()
+    {
+        Assert.That(BexioApiClient, Is.Not.Null);
+
+        var listResult = await BexioApiClient!.PurchaseOrders.Get();
+
+        Assert.That(listResult.IsSuccess, Is.True);
+
+        if (listResult.Data is not { Count: > 0 })
+        {
+            Assert.Ignore("no purchase orders available in the target Bexio account");
+            return;
+        }
+
+        var firstId = listResult.Data[0].Id;
+
+        var result = await BexioApiClient.PurchaseOrders.GetById(firstId);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.ApiError, Is.Null);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(firstId));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Expenses/ExpenseServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Expenses/ExpenseServiceIntegrationTests.cs
@@ -1,0 +1,296 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Expenses.Expenses;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Views;
+using BexioApiNet.Services.Connectors.Expenses;
+
+namespace BexioApiNet.IntegrationTests.Expenses;
+
+/// <summary>
+/// Integration tests for <see cref="ExpenseService"/> against WireMock stubs. Verifies the
+/// path composed from <see cref="ExpenseConfiguration"/> (<c>4.0/expenses/expenses</c> and
+/// <c>4.0/expenses/documentnumbers/expenses</c>) reaches the handler correctly and that the
+/// expected HTTP verbs are used for each operation — including <c>PUT</c> for Update and
+/// UpdateBookings, which differs from the v2.0 Invoice convention.
+/// </summary>
+[Category("Integration")]
+public sealed class ExpenseServiceIntegrationTests : IntegrationTestBase
+{
+    private const string ExpensesPath = "/4.0/expenses/expenses";
+    private const string DocNumbersPath = "/4.0/expenses/documentnumbers/expenses";
+
+    private static readonly Guid TestExpenseId = Guid.Parse("64bf865d-988a-496d-a24f-bab2d52e4b4a");
+
+    private const string ExpenseResponse = """
+                                           {
+                                               "id": "64bf865d-988a-496d-a24f-bab2d52e4b4a",
+                                               "document_no": "LR-12345",
+                                               "title": "Expense 42",
+                                               "status": "DRAFT",
+                                               "lastname_company": "Organisation",
+                                               "created_at": "2026-02-12T09:53:49",
+                                               "supplier_id": 1323,
+                                               "contact_partner_id": 647,
+                                               "expense_date": "2026-02-12",
+                                               "due_date": "2026-03-14",
+                                               "manual_amount": true,
+                                               "currency_code": "CHF",
+                                               "base_currency_code": "CHF",
+                                               "item_net": false,
+                                               "split_into_line_items": true,
+                                               "overdue": false,
+                                               "address": {
+                                                   "lastname_company": "Acme",
+                                                   "type": "COMPANY"
+                                               },
+                                               "line_items": [
+                                                   {
+                                                       "id": "2d267f64-6b94-4109-818e-c54515837004",
+                                                       "position": 0,
+                                                       "amount": 56.8
+                                                   }
+                                               ],
+                                               "discounts": [],
+                                               "attachment_ids": []
+                                           }
+                                           """;
+
+    private const string ExpenseListBody = """
+                                           {
+                                               "data": [],
+                                               "paging": {
+                                                   "page": 1,
+                                                   "page_size": 100,
+                                                   "page_count": 0,
+                                                   "item_count": 0
+                                               }
+                                           }
+                                           """;
+
+    private const string DocumentNumberBody = """
+                                              {
+                                                  "valid": false,
+                                                  "next_available_no": "AB-1235"
+                                              }
+                                              """;
+
+    /// <summary>
+    /// <c>ExpenseService.Get</c> issues a <c>GET</c> against <c>/4.0/expenses/expenses</c>
+    /// and deserializes the paged envelope response on success.
+    /// </summary>
+    [Test]
+    public async Task ExpenseService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(ExpensesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ExpenseListBody));
+
+        var service = new ExpenseService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Data, Is.Empty);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ExpensesPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>ExpenseService.GetById</c> issues a <c>GET</c> request with the expense id
+    /// in the URL path and surfaces the returned expense on success.
+    /// </summary>
+    [Test]
+    public async Task ExpenseService_GetById_SendsGetRequestWithIdInPath()
+    {
+        var expectedPath = $"{ExpensesPath}/{TestExpenseId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ExpenseResponse));
+
+        var service = new ExpenseService(ConnectionHandler);
+
+        var result = await service.GetById(TestExpenseId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(TestExpenseId));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>ExpenseService.GetDocNumbers</c> routes to
+    /// <c>/4.0/expenses/documentnumbers/expenses</c> and passes the proposed number via
+    /// the <c>document_no</c> query parameter.
+    /// </summary>
+    [Test]
+    public async Task ExpenseService_GetDocNumbers_SendsGetRequestToDocNumberEndpoint()
+    {
+        Server
+            .Given(Request.Create().WithPath(DocNumbersPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(DocumentNumberBody));
+
+        var service = new ExpenseService(ConnectionHandler);
+
+        var result = await service.GetDocNumbers("AB-1234", TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Valid, Is.False);
+            Assert.That(result.Data.NextAvailableNo, Is.EqualTo("AB-1235"));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(DocNumbersPath));
+            Assert.That(request.Url, Does.Contain("document_no=AB-1234"));
+        });
+    }
+
+    /// <summary>
+    /// <c>ExpenseService.Create</c> sends a <c>POST</c> request whose body contains
+    /// the serialized <see cref="ExpenseCreate"/> payload.
+    /// </summary>
+    [Test]
+    public async Task ExpenseService_Create_SendsPostRequestWithPayload()
+    {
+        Server
+            .Given(Request.Create().WithPath(ExpensesPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(ExpenseResponse));
+
+        var service = new ExpenseService(ConnectionHandler);
+
+        var payload = new ExpenseCreate(
+            SupplierId: 1323,
+            ContactPartnerId: 647,
+            CurrencyCode: "CHF",
+            Address: new ExpenseAddress("Acme", ExpenseAddressType.COMPANY),
+            ExpenseDate: new DateOnly(2026, 2, 12),
+            DueDate: new DateOnly(2026, 3, 14),
+            ManualAmount: false,
+            ItemNet: true,
+            LineItems: [new ExpenseLineItem(Position: 0, Amount: 56.8m)],
+            Discounts: [],
+            AttachmentIds: []);
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(ExpensesPath));
+            Assert.That(request.Body, Does.Contain("\"currency_code\":\"CHF\""));
+            Assert.That(request.Body, Does.Contain("\"supplier_id\":1323"));
+        });
+    }
+
+    /// <summary>
+    /// <c>ExpenseService.Update</c> sends a <c>PUT</c> request against
+    /// <c>/4.0/expenses/expenses/{id}</c> — v4.0 uses <c>PUT</c> for updates, not <c>POST</c>.
+    /// </summary>
+    [Test]
+    public async Task ExpenseService_Update_SendsPutRequestWithIdInPath()
+    {
+        var expectedPath = $"{ExpensesPath}/{TestExpenseId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(ExpenseResponse));
+
+        var service = new ExpenseService(ConnectionHandler);
+
+        var payload = new ExpenseUpdate(
+            SupplierId: 1323,
+            ContactPartnerId: 647,
+            CurrencyCode: "CHF",
+            Address: new ExpenseAddress("Acme", ExpenseAddressType.COMPANY),
+            ExpenseDate: new DateOnly(2026, 2, 12),
+            DueDate: new DateOnly(2026, 3, 14),
+            ManualAmount: false,
+            ItemNet: true,
+            SplitIntoLineItems: true,
+            LineItems: [new ExpenseLineItem(Position: 0, Amount: 56.8m)],
+            Discounts: [],
+            AttachmentIds: []);
+
+        var result = await service.Update(TestExpenseId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("PUT"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>ExpenseService.Delete</c> issues a <c>DELETE</c> request that includes the
+    /// expense id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task ExpenseService_Delete_SendsDeleteRequestWithIdInPath()
+    {
+        var expectedPath = $"{ExpensesPath}/{TestExpenseId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var service = new ExpenseService(ConnectionHandler);
+
+        var result = await service.Delete(TestExpenseId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Payroll/AbsenceServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Payroll/AbsenceServiceIntegrationTests.cs
@@ -1,0 +1,217 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Payroll.Absences.Views;
+using BexioApiNet.Services.Connectors.Payroll;
+
+namespace BexioApiNet.IntegrationTests.Payroll;
+
+/// <summary>
+/// Integration tests for <see cref="AbsenceService"/> against WireMock stubs. Verifies the
+/// nested path composed from <see cref="AbsenceConfiguration"/>
+/// (<c>4.0/payroll/employees/{employeeId}/absences</c>) reaches the handler correctly,
+/// and that the expected HTTP verbs are used for each operation — including <c>PUT</c>
+/// for Update per the v4.0 convention.
+/// </summary>
+[Category("Integration")]
+public sealed class AbsenceServiceIntegrationTests : IntegrationTestBase
+{
+    private static readonly Guid TestEmployeeId = Guid.Parse("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+    private static readonly Guid TestAbsenceId = Guid.Parse("a1b2c3d4-58cc-4372-a567-0e02b2c3d479");
+
+    private static readonly string AbsencesPath = $"/4.0/payroll/employees/{TestEmployeeId}/absences";
+    private static readonly string AbsencePathWithId = $"{AbsencesPath}/{TestAbsenceId}";
+
+    private const string AbsenceResponse = """
+                                           {
+                                               "id": "a1b2c3d4-58cc-4372-a567-0e02b2c3d479",
+                                               "employee_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                                               "absence_type": "SICK",
+                                               "start_date": "2026-01-10T00:00:00",
+                                               "end_date": "2026-01-12T00:00:00",
+                                               "status": "APPROVED",
+                                               "created_at": "2026-01-01T00:00:00"
+                                           }
+                                           """;
+
+    private const string AbsenceListBody = """
+                                           [
+                                               {
+                                                   "id": "a1b2c3d4-58cc-4372-a567-0e02b2c3d479",
+                                                   "employee_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                                                   "absence_type": "SICK",
+                                                   "start_date": "2026-01-10T00:00:00",
+                                                   "end_date": "2026-01-12T00:00:00",
+                                                   "status": "APPROVED",
+                                                   "created_at": "2026-01-01T00:00:00"
+                                               }
+                                           ]
+                                           """;
+
+    /// <summary>
+    /// <c>AbsenceService.Get</c> issues a <c>GET</c> against
+    /// <c>/4.0/payroll/employees/{employeeId}/absences</c> and deserializes the list
+    /// response on success.
+    /// </summary>
+    [Test]
+    public async Task AbsenceService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(AbsencesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(AbsenceListBody));
+
+        var service = new AbsenceService(ConnectionHandler);
+
+        var result = await service.Get(TestEmployeeId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!, Has.Count.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(AbsencesPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>AbsenceService.GetById</c> issues a <c>GET</c> request with both the employee
+    /// id and the absence id in the URL path and surfaces the returned absence on success.
+    /// </summary>
+    [Test]
+    public async Task AbsenceService_GetById_SendsGetRequestWithIdsInPath()
+    {
+        Server
+            .Given(Request.Create().WithPath(AbsencePathWithId).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(AbsenceResponse));
+
+        var service = new AbsenceService(ConnectionHandler);
+
+        var result = await service.GetById(TestEmployeeId, TestAbsenceId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(TestAbsenceId));
+            Assert.That(result.Data.EmployeeId, Is.EqualTo(TestEmployeeId));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(AbsencePathWithId));
+        });
+    }
+
+    /// <summary>
+    /// <c>AbsenceService.Create</c> sends a <c>POST</c> request whose body contains
+    /// the serialized <see cref="AbsenceCreate"/> payload.
+    /// </summary>
+    [Test]
+    public async Task AbsenceService_Create_SendsPostRequestWithPayload()
+    {
+        Server
+            .Given(Request.Create().WithPath(AbsencesPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(AbsenceResponse));
+
+        var service = new AbsenceService(ConnectionHandler);
+
+        var payload = new AbsenceCreate(
+            AbsenceType: "SICK",
+            StartDate: new DateTime(2026, 1, 10),
+            EndDate: new DateTime(2026, 1, 12),
+            Status: "APPROVED");
+
+        var result = await service.Create(TestEmployeeId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(AbsencesPath));
+            Assert.That(request.Body, Does.Contain("\"absence_type\":\"SICK\""));
+            Assert.That(request.Body, Does.Contain("\"status\":\"APPROVED\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>AbsenceService.Update</c> sends a <c>PUT</c> request against
+    /// <c>/4.0/payroll/employees/{employeeId}/absences/{id}</c> — v4.0 uses <c>PUT</c>
+    /// for updates.
+    /// </summary>
+    [Test]
+    public async Task AbsenceService_Update_SendsPutRequestWithIdsInPath()
+    {
+        Server
+            .Given(Request.Create().WithPath(AbsencePathWithId).UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(AbsenceResponse));
+
+        var service = new AbsenceService(ConnectionHandler);
+
+        var payload = new AbsenceUpdate(Status: "APPROVED");
+
+        var result = await service.Update(TestEmployeeId, TestAbsenceId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("PUT"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(AbsencePathWithId));
+            Assert.That(request.Body, Does.Contain("\"status\":\"APPROVED\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>AbsenceService.Delete</c> issues a <c>DELETE</c> request that includes both
+    /// the employee id and the absence id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task AbsenceService_Delete_SendsDeleteRequestWithIdsInPath()
+    {
+        Server
+            .Given(Request.Create().WithPath(AbsencePathWithId).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var service = new AbsenceService(ConnectionHandler);
+
+        var result = await service.Delete(TestEmployeeId, TestAbsenceId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(AbsencePathWithId));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Payroll/EmployeeServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Payroll/EmployeeServiceIntegrationTests.cs
@@ -1,0 +1,190 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Payroll.Employees.Views;
+using BexioApiNet.Services.Connectors.Payroll;
+
+namespace BexioApiNet.IntegrationTests.Payroll;
+
+/// <summary>
+/// Integration tests for <see cref="EmployeeService"/> against WireMock stubs. Verifies the
+/// path composed from <see cref="EmployeeConfiguration"/> (<c>4.0/payroll/employees</c>) reaches
+/// the handler correctly, and that the expected HTTP verbs are used for each operation —
+/// including <c>PATCH</c> (not <c>PUT</c>) for partial updates, which differs from the
+/// v4.0 Bill / Expense convention.
+/// </summary>
+[Category("Integration")]
+public sealed class EmployeeServiceIntegrationTests : IntegrationTestBase
+{
+    private const string EmployeesPath = "/4.0/payroll/employees";
+
+    private static readonly Guid TestEmployeeId = Guid.Parse("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+
+    private const string EmployeeResponse = """
+                                            {
+                                                "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                                                "first_name": "John",
+                                                "last_name": "Doe",
+                                                "email": "john.doe@example.com",
+                                                "employment_status": "ACTIVE",
+                                                "created_at": "2026-01-01T00:00:00"
+                                            }
+                                            """;
+
+    private const string EmployeeListBody = """
+                                            [
+                                                {
+                                                    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                                                    "first_name": "John",
+                                                    "last_name": "Doe",
+                                                    "email": "john.doe@example.com",
+                                                    "employment_status": "ACTIVE",
+                                                    "created_at": "2026-01-01T00:00:00"
+                                                }
+                                            ]
+                                            """;
+
+    /// <summary>
+    /// <c>EmployeeService.Get</c> issues a <c>GET</c> against <c>/4.0/payroll/employees</c>
+    /// and deserializes the list response on success.
+    /// </summary>
+    [Test]
+    public async Task EmployeeService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(EmployeesPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(EmployeeListBody));
+
+        var service = new EmployeeService(ConnectionHandler);
+
+        var result = await service.Get(TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!, Has.Count.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(EmployeesPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>EmployeeService.GetById</c> issues a <c>GET</c> request with the employee id
+    /// in the URL path and surfaces the returned employee on success.
+    /// </summary>
+    [Test]
+    public async Task EmployeeService_GetById_SendsGetRequestWithIdInPath()
+    {
+        var expectedPath = $"{EmployeesPath}/{TestEmployeeId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(EmployeeResponse));
+
+        var service = new EmployeeService(ConnectionHandler);
+
+        var result = await service.GetById(TestEmployeeId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(TestEmployeeId));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>EmployeeService.Create</c> sends a <c>POST</c> request whose body contains
+    /// the serialized <see cref="EmployeeCreate"/> payload.
+    /// </summary>
+    [Test]
+    public async Task EmployeeService_Create_SendsPostRequestWithPayload()
+    {
+        Server
+            .Given(Request.Create().WithPath(EmployeesPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(EmployeeResponse));
+
+        var service = new EmployeeService(ConnectionHandler);
+
+        var payload = new EmployeeCreate(
+            FirstName: "John",
+            LastName: "Doe",
+            Email: "john.doe@example.com",
+            EmploymentStatus: "ACTIVE");
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(EmployeesPath));
+            Assert.That(request.Body, Does.Contain("\"first_name\":\"John\""));
+            Assert.That(request.Body, Does.Contain("\"employment_status\":\"ACTIVE\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>EmployeeService.Patch</c> sends a <c>PATCH</c> request against
+    /// <c>/4.0/payroll/employees/{id}</c> — employees use <c>PATCH</c> for partial updates,
+    /// not <c>PUT</c>.
+    /// </summary>
+    [Test]
+    public async Task EmployeeService_Patch_SendsPatchRequestWithIdInPath()
+    {
+        var expectedPath = $"{EmployeesPath}/{TestEmployeeId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPatch())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(EmployeeResponse));
+
+        var service = new EmployeeService(ConnectionHandler);
+
+        var payload = new EmployeePatch(FirstName: "Jane");
+
+        var result = await service.Patch(TestEmployeeId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("PATCH"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"first_name\":\"Jane\""));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Payroll/PaystubServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Payroll/PaystubServiceIntegrationTests.cs
@@ -1,0 +1,75 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Services.Connectors.Payroll;
+
+namespace BexioApiNet.IntegrationTests.Payroll;
+
+/// <summary>
+///     Integration tests for <see cref="PaystubService" /> against WireMock stubs. Verifies the
+///     nested path composed from <see cref="PaystubConfiguration" />
+///     (<c>4.0/payroll/employees/{employeeId}/paystub-pdf/{year}/{month}</c>) reaches the
+///     handler correctly, the PDF bytes are returned verbatim on success and a <c>GET</c>
+///     verb is used.
+/// </summary>
+[Category("Integration")]
+public sealed class PaystubServiceIntegrationTests : IntegrationTestBase
+{
+    /// <summary>
+    ///     <c>PaystubService.GetPdf</c> issues a <c>GET</c> against
+    ///     <c>/4.0/payroll/employees/{employeeId}/paystub-pdf/{year}/{month}</c> and
+    ///     surfaces the raw PDF bytes on success.
+    /// </summary>
+    [Test]
+    public async Task PaystubService_GetPdf_SendsGetRequest_AndReturnsBytes()
+    {
+        const int employeeId = 1;
+        const int year = 2026;
+        const int month = 1;
+        var expectedPath = $"/4.0/payroll/employees/{employeeId}/paystub-pdf/{year}/{month}";
+        var pdfBytes = "%PDF-1.4 fake"u8.ToArray();
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/pdf")
+                .WithBody(pdfBytes));
+
+        var service = new PaystubService(ConnectionHandler);
+
+        var result = await service.GetPdf(employeeId, year, month, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.EqualTo(pdfBytes));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Purchases/BillServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Purchases/BillServiceIntegrationTests.cs
@@ -1,0 +1,295 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Purchases.Bills;
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Views;
+using BexioApiNet.Services.Connectors.Purchases;
+
+namespace BexioApiNet.IntegrationTests.Purchases;
+
+/// <summary>
+/// Integration tests for <see cref="BillService"/> against WireMock stubs. Verifies the
+/// path composed from <see cref="BillConfiguration"/> (<c>4.0/purchase/bills</c> and
+/// <c>4.0/purchase/documentnumbers/bills</c>) reaches the handler correctly and that the
+/// expected HTTP verbs are used for each operation — including <c>PUT</c> for Update and
+/// UpdateBookings, which differs from the v2.0 Invoice convention.
+/// </summary>
+public sealed class BillServiceIntegrationTests : IntegrationTestBase
+{
+    private const string BillsPath = "/4.0/purchase/bills";
+    private const string DocNumbersPath = "/4.0/purchase/documentnumbers/bills";
+
+    private static readonly Guid TestBillId = Guid.Parse("64bf865d-988a-496d-a24f-bab2d52e4b4a");
+
+    private const string BillResponse = """
+                                        {
+                                            "id": "64bf865d-988a-496d-a24f-bab2d52e4b4a",
+                                            "document_no": "LR-12345",
+                                            "title": "Bill 42",
+                                            "status": "DRAFT",
+                                            "lastname_company": "Organisation",
+                                            "created_at": "2026-02-12T09:53:49",
+                                            "supplier_id": 1323,
+                                            "contact_partner_id": 647,
+                                            "bill_date": "2026-02-12",
+                                            "due_date": "2026-03-14",
+                                            "manual_amount": true,
+                                            "currency_code": "CHF",
+                                            "base_currency_code": "CHF",
+                                            "item_net": false,
+                                            "split_into_line_items": true,
+                                            "overdue": false,
+                                            "address": {
+                                                "lastname_company": "Acme",
+                                                "type": "COMPANY"
+                                            },
+                                            "line_items": [
+                                                {
+                                                    "id": "2d267f64-6b94-4109-818e-c54515837004",
+                                                    "position": 0,
+                                                    "amount": 56.8
+                                                }
+                                            ],
+                                            "discounts": [],
+                                            "attachment_ids": []
+                                        }
+                                        """;
+
+    private const string BillListBody = """
+                                        {
+                                            "data": [],
+                                            "paging": {
+                                                "page": 1,
+                                                "page_size": 100,
+                                                "page_count": 0,
+                                                "item_count": 0
+                                            }
+                                        }
+                                        """;
+
+    private const string DocumentNumberBody = """
+                                              {
+                                                  "valid": false,
+                                                  "next_available_no": "AB-1235"
+                                              }
+                                              """;
+
+    /// <summary>
+    /// <c>BillService.Get</c> issues a <c>GET</c> against <c>/4.0/purchase/bills</c>
+    /// and deserializes the paged envelope response on success.
+    /// </summary>
+    [Test]
+    public async Task BillService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(BillsPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(BillListBody));
+
+        var service = new BillService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Data, Is.Empty);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(BillsPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>BillService.GetById</c> issues a <c>GET</c> request with the bill id
+    /// in the URL path and surfaces the returned bill on success.
+    /// </summary>
+    [Test]
+    public async Task BillService_GetById_SendsGetRequestWithIdInPath()
+    {
+        var expectedPath = $"{BillsPath}/{TestBillId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(BillResponse));
+
+        var service = new BillService(ConnectionHandler);
+
+        var result = await service.GetById(TestBillId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(TestBillId));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>BillService.GetDocNumbers</c> routes to
+    /// <c>/4.0/purchase/documentnumbers/bills</c> and passes the proposed number via
+    /// the <c>document_no</c> query parameter.
+    /// </summary>
+    [Test]
+    public async Task BillService_GetDocNumbers_SendsGetRequestToDocNumberEndpoint()
+    {
+        Server
+            .Given(Request.Create().WithPath(DocNumbersPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(DocumentNumberBody));
+
+        var service = new BillService(ConnectionHandler);
+
+        var result = await service.GetDocNumbers("AB-1234", TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Valid, Is.False);
+            Assert.That(result.Data.NextAvailableNo, Is.EqualTo("AB-1235"));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(DocNumbersPath));
+            Assert.That(request.Url, Does.Contain("document_no=AB-1234"));
+        });
+    }
+
+    /// <summary>
+    /// <c>BillService.Create</c> sends a <c>POST</c> request whose body contains
+    /// the serialized <see cref="BillCreate"/> payload.
+    /// </summary>
+    [Test]
+    public async Task BillService_Create_SendsPostRequestWithPayload()
+    {
+        Server
+            .Given(Request.Create().WithPath(BillsPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(BillResponse));
+
+        var service = new BillService(ConnectionHandler);
+
+        var payload = new BillCreate(
+            SupplierId: 1323,
+            ContactPartnerId: 647,
+            CurrencyCode: "CHF",
+            Address: new BillAddress("Acme", BillAddressType.COMPANY),
+            BillDate: new DateOnly(2026, 2, 12),
+            DueDate: new DateOnly(2026, 3, 14),
+            ManualAmount: false,
+            ItemNet: true,
+            LineItems: [new BillLineItem(Position: 0, Amount: 56.8m)],
+            Discounts: [],
+            AttachmentIds: []);
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(BillsPath));
+            Assert.That(request.Body, Does.Contain("\"currency_code\":\"CHF\""));
+            Assert.That(request.Body, Does.Contain("\"supplier_id\":1323"));
+        });
+    }
+
+    /// <summary>
+    /// <c>BillService.Update</c> sends a <c>PUT</c> request against
+    /// <c>/4.0/purchase/bills/{id}</c> — v4.0 uses <c>PUT</c> for updates, not <c>POST</c>.
+    /// </summary>
+    [Test]
+    public async Task BillService_Update_SendsPutRequestWithIdInPath()
+    {
+        var expectedPath = $"{BillsPath}/{TestBillId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(BillResponse));
+
+        var service = new BillService(ConnectionHandler);
+
+        var payload = new BillUpdate(
+            SupplierId: 1323,
+            ContactPartnerId: 647,
+            CurrencyCode: "CHF",
+            Address: new BillAddress("Acme", BillAddressType.COMPANY),
+            BillDate: new DateOnly(2026, 2, 12),
+            DueDate: new DateOnly(2026, 3, 14),
+            ManualAmount: false,
+            ItemNet: true,
+            SplitIntoLineItems: true,
+            LineItems: [new BillLineItem(Position: 0, Amount: 56.8m)],
+            Discounts: [],
+            AttachmentIds: []);
+
+        var result = await service.Update(TestBillId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("PUT"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>BillService.Delete</c> issues a <c>DELETE</c> request that includes the
+    /// bill id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task BillService_Delete_SendsDeleteRequestWithIdInPath()
+    {
+        var expectedPath = $"{BillsPath}/{TestBillId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var service = new BillService(ConnectionHandler);
+
+        var result = await service.Delete(TestBillId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/Purchases/PurchaseOrderServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/Purchases/PurchaseOrderServiceIntegrationTests.cs
@@ -1,0 +1,214 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders.Views;
+using BexioApiNet.Services.Connectors.Purchases;
+
+namespace BexioApiNet.IntegrationTests.Purchases;
+
+/// <summary>
+/// Integration tests for <see cref="PurchaseOrderService"/> against WireMock stubs. Verifies the
+/// path composed from <see cref="PurchaseOrderConfiguration"/> (<c>3.0/purchase/orders</c>)
+/// reaches the handler correctly and that the expected HTTP verbs are used for each operation —
+/// including <c>POST</c> (not <c>PUT</c>) for Update, which matches the v2.0 sales-document
+/// convention rather than the v4.0 Bills convention.
+/// </summary>
+public sealed class PurchaseOrderServiceIntegrationTests : IntegrationTestBase
+{
+    private const string PurchaseOrdersPath = "/3.0/purchase/orders";
+
+    private const int TestPurchaseOrderId = 42;
+
+    private const string PurchaseOrderResponse = """
+                                                 {
+                                                     "id": 42,
+                                                     "document_no": "PO-1001",
+                                                     "title": "Office supplies",
+                                                     "contact_id": 1323,
+                                                     "currency_id": 1,
+                                                     "user_id": 1,
+                                                     "total_net": 540.00,
+                                                     "total_gross": 581.40,
+                                                     "is_valid_from": "2026-04-01",
+                                                     "is_valid_until": "2026-05-01"
+                                                 }
+                                                 """;
+
+    private const string PurchaseOrderListBody = "[]";
+
+    /// <summary>
+    /// <c>PurchaseOrderService.Get</c> issues a <c>GET</c> against <c>/3.0/purchase/orders</c>
+    /// and deserializes the list response on success.
+    /// </summary>
+    [Test]
+    public async Task PurchaseOrderService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(PurchaseOrdersPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(PurchaseOrderListBody));
+
+        var service = new PurchaseOrderService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!, Is.Empty);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(PurchaseOrdersPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>PurchaseOrderService.GetById</c> issues a <c>GET</c> request with the purchase order id
+    /// in the URL path and surfaces the returned purchase order on success.
+    /// </summary>
+    [Test]
+    public async Task PurchaseOrderService_GetById_SendsGetRequestWithIdInPath()
+    {
+        var expectedPath = $"{PurchaseOrdersPath}/{TestPurchaseOrderId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(PurchaseOrderResponse));
+
+        var service = new PurchaseOrderService(ConnectionHandler);
+
+        var result = await service.GetById(TestPurchaseOrderId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(TestPurchaseOrderId));
+            Assert.That(result.Data.DocumentNo, Is.EqualTo("PO-1001"));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>PurchaseOrderService.Create</c> sends a <c>POST</c> request whose body contains
+    /// the serialized <see cref="PurchaseOrderCreate"/> payload.
+    /// </summary>
+    [Test]
+    public async Task PurchaseOrderService_Create_SendsPostRequestWithPayload()
+    {
+        Server
+            .Given(Request.Create().WithPath(PurchaseOrdersPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(PurchaseOrderResponse));
+
+        var service = new PurchaseOrderService(ConnectionHandler);
+
+        var payload = new PurchaseOrderCreate(
+            ContactId: 1323,
+            CurrencyId: 1,
+            UserId: 1,
+            Title: "Office supplies");
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(PurchaseOrdersPath));
+            Assert.That(request.Body, Does.Contain("\"contact_id\":1323"));
+            Assert.That(request.Body, Does.Contain("\"currency_id\":1"));
+            Assert.That(request.Body, Does.Contain("\"title\":\"Office supplies\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>PurchaseOrderService.Update</c> sends a <c>POST</c> request against
+    /// <c>/3.0/purchase/orders/{id}</c> — Bexio v3.0 uses <c>POST</c> for updates,
+    /// not <c>PUT</c>.
+    /// </summary>
+    [Test]
+    public async Task PurchaseOrderService_Update_SendsPostRequestWithIdInPath()
+    {
+        var expectedPath = $"{PurchaseOrdersPath}/{TestPurchaseOrderId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(PurchaseOrderResponse));
+
+        var service = new PurchaseOrderService(ConnectionHandler);
+
+        var payload = new PurchaseOrderUpdate(
+            ContactId: 1323,
+            CurrencyId: 1,
+            UserId: 1,
+            Title: "Office supplies (updated)");
+
+        var result = await service.Update(TestPurchaseOrderId, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>PurchaseOrderService.Delete</c> issues a <c>DELETE</c> request that includes the
+    /// purchase order id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task PurchaseOrderService_Delete_SendsDeleteRequestWithIdInPath()
+    {
+        var expectedPath = $"{PurchaseOrdersPath}/{TestPurchaseOrderId}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var service = new PurchaseOrderService(ConnectionHandler);
+
+        var result = await service.Delete(TestPurchaseOrderId, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -109,7 +109,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IPurchaseOrderService>(),
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
-            Substitute.For<IAbsenceService>());
+            Substitute.For<IAbsenceService>(),
+            Substitute.For<IPaystubService>());
 
         Assert.Multiple(() =>
         {
@@ -163,6 +164,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.Expenses, Is.Not.Null);
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
+            Assert.That(client.PayrollPaystubs, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -108,7 +108,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IBillService>(),
             Substitute.For<IPurchaseOrderService>(),
             Substitute.For<IExpenseService>(),
-            Substitute.For<IEmployeeService>());
+            Substitute.For<IEmployeeService>(),
+            Substitute.For<IAbsenceService>());
 
         Assert.Multiple(() =>
         {
@@ -161,6 +162,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PurchaseOrders, Is.Not.Null);
             Assert.That(client.Expenses, Is.Not.Null);
             Assert.That(client.PayrollEmployees, Is.Not.Null);
+            Assert.That(client.PayrollAbsences, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Projects;
+using BexioApiNet.Interfaces.Connectors.Purchases;
 using BexioApiNet.Interfaces.Connectors.Sales;
 using BexioApiNet.Interfaces.Connectors.Sales.Positions;
 using BexioApiNet.Interfaces.Connectors.Timesheets;
@@ -101,7 +102,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IProjectStateService>(),
             Substitute.For<IProjectTypeService>(),
             Substitute.For<IMilestoneService>(),
-            Substitute.For<IPackageService>());
+            Substitute.For<IPackageService>(),
+            Substitute.For<IBillService>());
 
         Assert.Multiple(() =>
         {
@@ -150,6 +152,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.ProjectTypes, Is.Not.Null);
             Assert.That(client.Milestones, Is.Not.Null);
             Assert.That(client.Packages, Is.Not.Null);
+            Assert.That(client.PurchaseBills, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -27,6 +27,7 @@ using BexioApiNet.Interfaces.Connectors.Accounting;
 using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
+using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -104,7 +105,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IMilestoneService>(),
             Substitute.For<IPackageService>(),
             Substitute.For<IBillService>(),
-            Substitute.For<IPurchaseOrderService>());
+            Substitute.For<IPurchaseOrderService>(),
+            Substitute.For<IExpenseService>());
 
         Assert.Multiple(() =>
         {
@@ -155,6 +157,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.Packages, Is.Not.Null);
             Assert.That(client.PurchaseBills, Is.Not.Null);
             Assert.That(client.PurchaseOrders, Is.Not.Null);
+            Assert.That(client.Expenses, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -103,7 +103,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IProjectTypeService>(),
             Substitute.For<IMilestoneService>(),
             Substitute.For<IPackageService>(),
-            Substitute.For<IBillService>());
+            Substitute.For<IBillService>(),
+            Substitute.For<IPurchaseOrderService>());
 
         Assert.Multiple(() =>
         {
@@ -153,6 +154,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.Milestones, Is.Not.Null);
             Assert.That(client.Packages, Is.Not.Null);
             Assert.That(client.PurchaseBills, Is.Not.Null);
+            Assert.That(client.PurchaseOrders, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
 using BexioApiNet.Interfaces.Connectors.Sales;
@@ -106,7 +107,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IPackageService>(),
             Substitute.For<IBillService>(),
             Substitute.For<IPurchaseOrderService>(),
-            Substitute.For<IExpenseService>());
+            Substitute.For<IExpenseService>(),
+            Substitute.For<IEmployeeService>());
 
         Assert.Multiple(() =>
         {
@@ -158,6 +160,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PurchaseBills, Is.Not.Null);
             Assert.That(client.PurchaseOrders, Is.Not.Null);
             Assert.That(client.Expenses, Is.Not.Null);
+            Assert.That(client.PayrollEmployees, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/Expenses/ExpenseServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Expenses/ExpenseServiceTests.cs
@@ -1,0 +1,365 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Enums;
+using BexioApiNet.Abstractions.Models.Expenses.Expenses.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Expenses;
+
+namespace BexioApiNet.UnitTests.Expenses;
+
+/// <summary>
+/// Offline unit tests for <see cref="ExpenseService"/>. Each test asserts that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected
+/// verb, path, payload and query parameters, and returns the handler's <see cref="ApiResult{T}"/>
+/// unchanged. No network, no filesystem.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public sealed class ExpenseServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "4.0/expenses/expenses";
+    private const string ExpectedDocNumberEndpoint = "4.0/expenses/documentnumbers/expenses";
+
+    private ExpenseService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="ExpenseService"/> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new ExpenseService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// Get with no query parameter forwards a <see langword="null"/> <see cref="QueryParameter"/>
+    /// to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> at the expenses collection path.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<ExpenseListResponse>
+        {
+            IsSuccess = true,
+            Data = new ExpenseListResponse([], new ExpensePaging(1, 100, 1, 0))
+        };
+        ConnectionHandler
+            .GetAsync<ExpenseListResponse>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<ExpenseListResponse>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get forwards the supplied <see cref="QueryParameterExpense.QueryParameter"/>
+    /// to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_ForwardsQueryParameter()
+    {
+        var queryParameter = new QueryParameterExpense(limit: 50, status: "TODO");
+        ConnectionHandler
+            .GetAsync<ExpenseListResponse>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<ExpenseListResponse>
+            {
+                IsSuccess = true,
+                Data = new ExpenseListResponse([], new ExpensePaging(1, 50, 0, 0))
+            });
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<ExpenseListResponse>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<ExpenseListResponse>
+        {
+            IsSuccess = true,
+            Data = new ExpenseListResponse([], new ExpensePaging(1, 100, 1, 0))
+        };
+        ConnectionHandler
+            .GetAsync<ExpenseListResponse>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with the
+    /// expense id appended to the endpoint root and a <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Expense>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Expense> { IsSuccess = true });
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).GetAsync<Expense>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// GetDocNumbers routes to the document-number validation endpoint at
+    /// <c>/4.0/expenses/documentnumbers/expenses</c> and forwards the caller's
+    /// <c>document_no</c> as a query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetDocNumbers_CallsGetAsync_WithDocNumberPath()
+    {
+        const string documentNo = "AB-1234";
+        QueryParameter? capturedQueryParameter = null;
+        ConnectionHandler
+            .GetAsync<ExpenseDocumentNumberResponse>(
+                Arg.Any<string>(),
+                Arg.Do<QueryParameter?>(q => capturedQueryParameter = q),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<ExpenseDocumentNumberResponse>
+            {
+                IsSuccess = true,
+                Data = new ExpenseDocumentNumberResponse(true, null)
+            });
+
+        await _sut.GetDocNumbers(documentNo);
+
+        await ConnectionHandler.Received(1).GetAsync<ExpenseDocumentNumberResponse>(
+            ExpectedDocNumberEndpoint,
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+        Assert.That(capturedQueryParameter, Is.Not.Null);
+        Assert.That(capturedQueryParameter!.Parameters["document_no"], Is.EqualTo(documentNo));
+    }
+
+    /// <summary>
+    /// Create forwards the <see cref="ExpenseCreate"/> payload and the endpoint path
+    /// to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        ConnectionHandler
+            .PostAsync<Expense, ExpenseCreate>(Arg.Any<ExpenseCreate>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Expense> { IsSuccess = true });
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<Expense, ExpenseCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Actions posts the <see cref="ExpenseActionRequest"/> to
+    /// <c>/4.0/expenses/expenses/{id}/actions</c> via <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Actions_CallsPostAsync_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        var action = new ExpenseActionRequest(ExpenseAction.DUPLICATE);
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Expense, ExpenseActionRequest>(
+                Arg.Any<ExpenseActionRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Expense> { IsSuccess = true });
+
+        await _sut.Actions(id, action);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/actions"));
+        await ConnectionHandler.Received(1).PostAsync<Expense, ExpenseActionRequest>(
+            action,
+            $"{ExpectedEndpoint}/{id}/actions",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Update calls <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}"/> (PUT, not POST)
+    /// with the expense id appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsync_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        var payload = BuildUpdatePayload();
+        string? capturedPath = null;
+        ConnectionHandler
+            .PutAsync<Expense, ExpenseUpdate>(
+                Arg.Any<ExpenseUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Expense> { IsSuccess = true });
+
+        await _sut.Update(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).PutAsync<Expense, ExpenseUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// UpdateBookings calls <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}"/> with
+    /// the target status in the path. The request body is <see langword="null"/> because the
+    /// Bexio endpoint takes the target status from the URL only.
+    /// </summary>
+    [Test]
+    public async Task UpdateBookings_CallsPutAsync_WithBookingsPath()
+    {
+        var id = Guid.NewGuid();
+        const ExpenseBookingStatus status = ExpenseBookingStatus.BOOKED;
+        string? capturedPath = null;
+        ConnectionHandler
+            .PutAsync<Expense, object?>(
+                Arg.Any<object?>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Expense> { IsSuccess = true });
+
+        await _sut.UpdateBookings(id, status);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/bookings/{status}"));
+        await ConnectionHandler.Received(1).PutAsync<Expense, object?>(
+            null,
+            $"{ExpectedEndpoint}/{id}/bookings/{status}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete calls <see cref="IBexioConnectionHandler.Delete"/> with the expense id
+    /// appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(Arg.Do<string>(path => capturedPath = path), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<object> { IsSuccess = true });
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Create_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<Expense> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Expense, ExpenseCreate>(Arg.Any<ExpenseCreate>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Delete returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Delete_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(Guid.NewGuid());
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    private static ExpenseCreate BuildCreatePayload() =>
+        new(
+            SupplierId: 1,
+            ContactPartnerId: 2,
+            CurrencyCode: "CHF",
+            Address: new ExpenseAddress("Acme Ltd.", ExpenseAddressType.COMPANY),
+            ExpenseDate: new DateOnly(2026, 4, 1),
+            DueDate: new DateOnly(2026, 5, 1),
+            ManualAmount: false,
+            ItemNet: true,
+            LineItems: [new ExpenseLineItem(Position: 0, Amount: 100m)],
+            Discounts: [],
+            AttachmentIds: []);
+
+    private static ExpenseUpdate BuildUpdatePayload() =>
+        new(
+            SupplierId: 1,
+            ContactPartnerId: 2,
+            CurrencyCode: "CHF",
+            Address: new ExpenseAddress("Acme Ltd.", ExpenseAddressType.COMPANY),
+            ExpenseDate: new DateOnly(2026, 4, 1),
+            DueDate: new DateOnly(2026, 5, 1),
+            ManualAmount: false,
+            ItemNet: true,
+            SplitIntoLineItems: false,
+            LineItems: [new ExpenseLineItem(Position: 0, Amount: 100m)],
+            Discounts: [],
+            AttachmentIds: []);
+}

--- a/tests/BexioApiNet.UnitTests/Payroll/AbsenceServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Payroll/AbsenceServiceTests.cs
@@ -1,0 +1,202 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Payroll.Absences;
+using BexioApiNet.Abstractions.Models.Payroll.Absences.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Payroll;
+
+namespace BexioApiNet.UnitTests.Payroll;
+
+/// <summary>
+/// Offline unit tests for <see cref="AbsenceService"/>. Each test asserts that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected verb, path
+/// and payload, and returns the handler's <see cref="ApiResult{T}"/> unchanged. Verifies
+/// that absences are routed under the nested
+/// <c>4.0/payroll/employees/{employeeId}/absences</c> path and that <c>Update</c> uses
+/// <c>PUT</c> per the Bexio v4.0 convention. No network, no filesystem.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public sealed class AbsenceServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "4.0/payroll/employees";
+
+    private static readonly Guid EmployeeId = Guid.NewGuid();
+
+    private AbsenceService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="AbsenceService"/> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new AbsenceService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// Get forwards a <see langword="null"/> <see cref="QueryParameter"/> to
+    /// <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> at the nested absences
+    /// collection path under the supplied employee id.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsync_WithEmployeeIdInPath()
+    {
+        var response = new ApiResult<List<Absence>>
+        {
+            IsSuccess = true,
+            Data = []
+        };
+        ConnectionHandler
+            .GetAsync<List<Absence>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get(EmployeeId);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Absence>>(
+            $"{ExpectedEndpoint}/{EmployeeId}/absences",
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with both
+    /// the employee id and the absence id appended to the endpoint path and a
+    /// <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithEmployeeAndAbsenceIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Absence>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Absence> { IsSuccess = true });
+
+        await _sut.GetById(EmployeeId, id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{EmployeeId}/absences/{id}"));
+        await ConnectionHandler.Received(1).GetAsync<Absence>(
+            $"{ExpectedEndpoint}/{EmployeeId}/absences/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create forwards the <see cref="AbsenceCreate"/> payload and the nested endpoint
+    /// path to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync_WithEmployeeIdInPath()
+    {
+        var payload = new AbsenceCreate(
+            AbsenceType: "SICK",
+            StartDate: new DateTime(2026, 1, 10),
+            EndDate: new DateTime(2026, 1, 12));
+        var response = new ApiResult<Absence> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Absence, AbsenceCreate>(Arg.Any<AbsenceCreate>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(EmployeeId, payload);
+
+        await ConnectionHandler.Received(1).PostAsync<Absence, AbsenceCreate>(
+            payload,
+            $"{ExpectedEndpoint}/{EmployeeId}/absences",
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Update calls <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}"/>
+    /// (PUT, not PATCH) with both the employee id and the absence id appended to
+    /// the nested endpoint path.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsync_WithEmployeeAndAbsenceIdInPath()
+    {
+        var id = Guid.NewGuid();
+        var payload = new AbsenceUpdate(Status: "APPROVED");
+        string? capturedPath = null;
+        ConnectionHandler
+            .PutAsync<Absence, AbsenceUpdate>(
+                Arg.Any<AbsenceUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Absence> { IsSuccess = true });
+
+        await _sut.Update(EmployeeId, id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{EmployeeId}/absences/{id}"));
+        await ConnectionHandler.Received(1).PutAsync<Absence, AbsenceUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{EmployeeId}/absences/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete calls <see cref="IBexioConnectionHandler.Delete"/> with both the employee
+    /// id and the absence id appended to the nested endpoint path.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithEmployeeAndAbsenceIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(Arg.Do<string>(path => capturedPath = path), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<object> { IsSuccess = true });
+
+        await _sut.Delete(EmployeeId, id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{EmployeeId}/absences/{id}"));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{EmployeeId}/absences/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Delete_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(EmployeeId, Guid.NewGuid());
+
+        Assert.That(result, Is.SameAs(response));
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Payroll/EmployeeServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Payroll/EmployeeServiceTests.cs
@@ -1,0 +1,156 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Payroll.Employees;
+using BexioApiNet.Abstractions.Models.Payroll.Employees.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Payroll;
+
+namespace BexioApiNet.UnitTests.Payroll;
+
+/// <summary>
+/// Offline unit tests for <see cref="EmployeeService"/>. Each test asserts that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected verb, path
+/// and payload, and returns the handler's <see cref="ApiResult{T}"/> unchanged. Verifies
+/// that <see cref="EmployeeService.Patch"/> routes to <c>PATCH</c> (not <c>PUT</c>) as per
+/// the Bexio v4.0 <c>payroll/employees</c> semantics. No network, no filesystem.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public sealed class EmployeeServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "4.0/payroll/employees";
+
+    private EmployeeService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="EmployeeService"/> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new EmployeeService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// Get forwards a <see langword="null"/> <see cref="QueryParameter"/> to
+    /// <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> at the employees collection path.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsync_WithoutQueryParameter()
+    {
+        var response = new ApiResult<List<Employee>>
+        {
+            IsSuccess = true,
+            Data = []
+        };
+        ConnectionHandler
+            .GetAsync<List<Employee>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<Employee>>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with the
+    /// employee id appended to the endpoint root and a <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Employee>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Employee> { IsSuccess = true });
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).GetAsync<Employee>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create forwards the <see cref="EmployeeCreate"/> payload and the endpoint path
+    /// to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = new EmployeeCreate(FirstName: "John", LastName: "Doe", Email: "john@example.com");
+        var response = new ApiResult<Employee> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Employee, EmployeeCreate>(Arg.Any<EmployeeCreate>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<Employee, EmployeeCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Patch calls <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}"/> (PATCH, not PUT)
+    /// with the employee id appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Patch_CallsPatchAsync_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        var payload = new EmployeePatch(FirstName: "Jane");
+        string? capturedPath = null;
+        ConnectionHandler
+            .PatchAsync<Employee, EmployeePatch>(
+                Arg.Any<EmployeePatch>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Employee> { IsSuccess = true });
+
+        await _sut.Patch(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).PatchAsync<Employee, EmployeePatch>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Payroll/PaystubServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Payroll/PaystubServiceTests.cs
@@ -1,0 +1,97 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Services.Connectors.Payroll;
+
+namespace BexioApiNet.UnitTests.Payroll;
+
+/// <summary>
+///     Offline unit tests for <see cref="PaystubService" />. Each test asserts that the service
+///     forwards its call to <see cref="IBexioConnectionHandler.GetBinaryAsync" /> with the
+///     expected nested path and returns the handler's <see cref="ApiResult{T}" /> unchanged.
+///     Paystubs are a binary PDF download nested under the parent
+///     <c>4.0/payroll/employees/{employeeId}/paystub-pdf/{year}/{month}</c> route. No network,
+///     no filesystem.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public sealed class PaystubServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="PaystubService" /> bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new PaystubService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "4.0/payroll/employees";
+
+    private PaystubService _sut = null!;
+
+    /// <summary>
+    ///     GetPdf forwards the call to <see cref="IBexioConnectionHandler.GetBinaryAsync" />
+    ///     with the employee id, year and month embedded in the path and returns the
+    ///     handler's result unchanged.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_CallsGetBinaryAsync_WithExpectedPath()
+    {
+        const int employeeId = 42;
+        const int year = 2026;
+        const int month = 1;
+        var expected = new ApiResult<byte[]> { IsSuccess = true, Data = [1, 2, 3] };
+        ConnectionHandler
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var result = await _sut.GetPdf(employeeId, year, month);
+
+        await ConnectionHandler.Received(1).GetBinaryAsync(
+            $"{ExpectedEndpoint}/{employeeId}/paystub-pdf/{year}/{month}",
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(expected));
+    }
+
+    /// <summary>
+    ///     GetPdf forwards the supplied <see cref="CancellationToken" /> through to the
+    ///     connection handler so callers can cancel the download in-flight.
+    /// </summary>
+    [Test]
+    public async Task GetPdf_ForwardsCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetBinaryAsync(Arg.Any<string>(), cts.Token)
+            .Returns(new ApiResult<byte[]> { IsSuccess = true });
+
+        await _sut.GetPdf(1, 2026, 1, cts.Token);
+
+        await ConnectionHandler.Received(1).GetBinaryAsync(Arg.Any<string>(), cts.Token);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Purchases/BillServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Purchases/BillServiceTests.cs
@@ -1,0 +1,364 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Purchases.Bills;
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Enums;
+using BexioApiNet.Abstractions.Models.Purchases.Bills.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Purchases;
+
+namespace BexioApiNet.UnitTests.Purchases;
+
+/// <summary>
+/// Offline unit tests for <see cref="BillService"/>. Each test asserts that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected
+/// verb, path, payload and query parameters, and returns the handler's <see cref="ApiResult{T}"/>
+/// unchanged. No network, no filesystem.
+/// </summary>
+[TestFixture]
+public sealed class BillServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "4.0/purchase/bills";
+    private const string ExpectedDocNumberEndpoint = "4.0/purchase/documentnumbers/bills";
+
+    private BillService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="BillService"/> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new BillService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// Get with no query parameter forwards a <see langword="null"/> <see cref="QueryParameter"/>
+    /// to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> at the bills collection path.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<BillListResponse>
+        {
+            IsSuccess = true,
+            Data = new BillListResponse([], new BillPaging(1, 100, 1, 0))
+        };
+        ConnectionHandler
+            .GetAsync<BillListResponse>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<BillListResponse>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get forwards the supplied <see cref="QueryParameterBill.QueryParameter"/>
+    /// to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_ForwardsQueryParameter()
+    {
+        var queryParameter = new QueryParameterBill(limit: 50, status: "TODO");
+        ConnectionHandler
+            .GetAsync<BillListResponse>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<BillListResponse>
+            {
+                IsSuccess = true,
+                Data = new BillListResponse([], new BillPaging(1, 50, 0, 0))
+            });
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<BillListResponse>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<BillListResponse>
+        {
+            IsSuccess = true,
+            Data = new BillListResponse([], new BillPaging(1, 100, 1, 0))
+        };
+        ConnectionHandler
+            .GetAsync<BillListResponse>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with the
+    /// bill id appended to the endpoint root and a <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Bill>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Bill> { IsSuccess = true });
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).GetAsync<Bill>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// GetDocNumbers routes to the document-number validation endpoint at
+    /// <c>/4.0/purchase/documentnumbers/bills</c> and forwards the caller's
+    /// <c>document_no</c> as a query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetDocNumbers_CallsGetAsync_WithDocNumberPath()
+    {
+        const string documentNo = "AB-1234";
+        QueryParameter? capturedQueryParameter = null;
+        ConnectionHandler
+            .GetAsync<BillDocumentNumberResponse>(
+                Arg.Any<string>(),
+                Arg.Do<QueryParameter?>(q => capturedQueryParameter = q),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<BillDocumentNumberResponse>
+            {
+                IsSuccess = true,
+                Data = new BillDocumentNumberResponse(true, null)
+            });
+
+        await _sut.GetDocNumbers(documentNo);
+
+        await ConnectionHandler.Received(1).GetAsync<BillDocumentNumberResponse>(
+            ExpectedDocNumberEndpoint,
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+        Assert.That(capturedQueryParameter, Is.Not.Null);
+        Assert.That(capturedQueryParameter!.Parameters["document_no"], Is.EqualTo(documentNo));
+    }
+
+    /// <summary>
+    /// Create forwards the <see cref="BillCreate"/> payload and the endpoint path
+    /// to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        ConnectionHandler
+            .PostAsync<Bill, BillCreate>(Arg.Any<BillCreate>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Bill> { IsSuccess = true });
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<Bill, BillCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Actions posts the <see cref="BillActionRequest"/> to
+    /// <c>/4.0/purchase/bills/{id}/actions</c> via <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Actions_CallsPostAsync_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        var action = new BillActionRequest(BillAction.DUPLICATE);
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Bill, BillActionRequest>(
+                Arg.Any<BillActionRequest>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Bill> { IsSuccess = true });
+
+        await _sut.Actions(id, action);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/actions"));
+        await ConnectionHandler.Received(1).PostAsync<Bill, BillActionRequest>(
+            action,
+            $"{ExpectedEndpoint}/{id}/actions",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Update calls <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}"/> (PUT, not POST)
+    /// with the bill id appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsync_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        var payload = BuildUpdatePayload();
+        string? capturedPath = null;
+        ConnectionHandler
+            .PutAsync<Bill, BillUpdate>(
+                Arg.Any<BillUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Bill> { IsSuccess = true });
+
+        await _sut.Update(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).PutAsync<Bill, BillUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// UpdateBookings calls <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}"/> with
+    /// the target status in the path. The request body is <see langword="null"/> because the
+    /// Bexio endpoint takes the target status from the URL only.
+    /// </summary>
+    [Test]
+    public async Task UpdateBookings_CallsPutAsync_WithBookingsPath()
+    {
+        var id = Guid.NewGuid();
+        const BillBookingStatus status = BillBookingStatus.BOOKED;
+        string? capturedPath = null;
+        ConnectionHandler
+            .PutAsync<Bill, object?>(
+                Arg.Any<object?>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<Bill> { IsSuccess = true });
+
+        await _sut.UpdateBookings(id, status);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}/bookings/{status}"));
+        await ConnectionHandler.Received(1).PutAsync<Bill, object?>(
+            null,
+            $"{ExpectedEndpoint}/{id}/bookings/{status}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete calls <see cref="IBexioConnectionHandler.Delete"/> with the bill id
+    /// appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
+    {
+        var id = Guid.NewGuid();
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(Arg.Do<string>(path => capturedPath = path), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<object> { IsSuccess = true });
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Create_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<Bill> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Bill, BillCreate>(Arg.Any<BillCreate>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Delete returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Delete_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(Guid.NewGuid());
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    private static BillCreate BuildCreatePayload() =>
+        new(
+            SupplierId: 1,
+            ContactPartnerId: 2,
+            CurrencyCode: "CHF",
+            Address: new BillAddress("Acme Ltd.", BillAddressType.COMPANY),
+            BillDate: new DateOnly(2026, 4, 1),
+            DueDate: new DateOnly(2026, 5, 1),
+            ManualAmount: false,
+            ItemNet: true,
+            LineItems: [new BillLineItem(Position: 0, Amount: 100m)],
+            Discounts: [],
+            AttachmentIds: []);
+
+    private static BillUpdate BuildUpdatePayload() =>
+        new(
+            SupplierId: 1,
+            ContactPartnerId: 2,
+            CurrencyCode: "CHF",
+            Address: new BillAddress("Acme Ltd.", BillAddressType.COMPANY),
+            BillDate: new DateOnly(2026, 4, 1),
+            DueDate: new DateOnly(2026, 5, 1),
+            ManualAmount: false,
+            ItemNet: true,
+            SplitIntoLineItems: false,
+            LineItems: [new BillLineItem(Position: 0, Amount: 100m)],
+            Discounts: [],
+            AttachmentIds: []);
+}

--- a/tests/BexioApiNet.UnitTests/Purchases/PurchaseOrderServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Purchases/PurchaseOrderServiceTests.cs
@@ -1,0 +1,253 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders;
+using BexioApiNet.Abstractions.Models.Purchases.PurchaseOrders.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Purchases;
+
+namespace BexioApiNet.UnitTests.Purchases;
+
+/// <summary>
+/// Offline unit tests for <see cref="PurchaseOrderService"/>. Each test asserts that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected verb, path and
+/// payload, and returns the handler's <see cref="ApiResult{T}"/> unchanged. Note in particular
+/// that <c>Update</c> uses <c>POST</c> (not <c>PUT</c>) — Bexio v3.0 follows the same
+/// POST-to-id update convention as v2.0.
+/// </summary>
+[TestFixture]
+public sealed class PurchaseOrderServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "3.0/purchase/orders";
+
+    private PurchaseOrderService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="PurchaseOrderService"/> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new PurchaseOrderService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// Get with no query parameter forwards a <see langword="null"/> <see cref="QueryParameter"/>
+    /// to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> at the purchase orders collection path.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<PurchaseOrder>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<PurchaseOrder>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<PurchaseOrder>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get forwards the supplied <see cref="QueryParameter"/> to the connection handler so the
+    /// caller's filters (limit/offset/order_by) reach the API.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_ForwardsQueryParameter()
+    {
+        var queryParameter = new QueryParameter(new Dictionary<string, object> { ["limit"] = 50 });
+        ConnectionHandler
+            .GetAsync<List<PurchaseOrder>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<List<PurchaseOrder>?> { IsSuccess = true, Data = [] });
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<PurchaseOrder>?>(
+            ExpectedEndpoint,
+            queryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<List<PurchaseOrder>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<PurchaseOrder>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with the
+    /// purchase order id appended to the endpoint root and a <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithIdInPath()
+    {
+        const int id = 42;
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<PurchaseOrder>(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<PurchaseOrder> { IsSuccess = true });
+
+        await _sut.GetById(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).GetAsync<PurchaseOrder>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create forwards the <see cref="PurchaseOrderCreate"/> payload and the endpoint path
+    /// to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsync()
+    {
+        var payload = BuildCreatePayload();
+        ConnectionHandler
+            .PostAsync<PurchaseOrder, PurchaseOrderCreate>(Arg.Any<PurchaseOrderCreate>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<PurchaseOrder> { IsSuccess = true });
+
+        await _sut.Create(payload);
+
+        await ConnectionHandler.Received(1).PostAsync<PurchaseOrder, PurchaseOrderCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Update calls <see cref="IBexioConnectionHandler.PostAsync{TResult,TUpdate}"/> (POST, not PUT)
+    /// at <c>/3.0/purchase/orders/{id}</c> — Bexio v3.0 routes update via POST on the resource,
+    /// matching the v2.0 sales-document convention.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPostAsync_WithIdInPath()
+    {
+        const int id = 42;
+        var payload = BuildUpdatePayload();
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<PurchaseOrder, PurchaseOrderUpdate>(
+                Arg.Any<PurchaseOrderUpdate>(),
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<PurchaseOrder> { IsSuccess = true });
+
+        await _sut.Update(id, payload);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).PostAsync<PurchaseOrder, PurchaseOrderUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete calls <see cref="IBexioConnectionHandler.Delete"/> with the purchase order id
+    /// appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDelete_WithIdInPath()
+    {
+        const int id = 42;
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(Arg.Do<string>(path => capturedPath = path), Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<object> { IsSuccess = true });
+
+        await _sut.Delete(id);
+
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Create_ReturnsApiResultFromConnectionHandler()
+    {
+        var payload = BuildCreatePayload();
+        var response = new ApiResult<PurchaseOrder> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<PurchaseOrder, PurchaseOrderCreate>(Arg.Any<PurchaseOrderCreate>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    /// Delete returns the <see cref="ApiResult{T}"/> from the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Delete_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(42);
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    private static PurchaseOrderCreate BuildCreatePayload() =>
+        new(
+            ContactId: 1323,
+            CurrencyId: 1,
+            UserId: 1,
+            Title: "Order");
+
+    private static PurchaseOrderUpdate BuildUpdatePayload() =>
+        new(
+            ContactId: 1323,
+            CurrencyId: 1,
+            UserId: 1,
+            Title: "Order");
+}


### PR DESCRIPTION
## Summary

Wave 5 of the BexioApiNet epic (#28): adds 6 new connector services covering the Purchase, Expenses, and Payroll domains — 31 new endpoint methods in total.

API coverage increases from **192/309 (62.1%)** → **223/309 (72.2%)**.

### Services Implemented

| # | Service | Domain | API | Methods | Sub-issue |
|---|---------|--------|-----|---------|-----------|
| 1 | `BillService` | Purchases | v4.0 | Get, GetById, Create, Update, Delete, GetDocNumber + Book/Cancel/Send actions | #86 |
| 2 | `PurchaseOrderService` | Purchases | v3.0 | Get, GetById, Create, Update | #87 |
| 3 | `ExpenseService` | Expenses | v4.0 | Get, GetById, Create, Update, Delete, GetDocNumber + Book action | #88 |
| 4 | `EmployeeService` | Payroll | v4.0 | Get, GetById, Create, Patch (PATCH verb) | #89 |
| 5 | `AbsenceService` | Payroll | v4.0 | Get, GetById, Create, Update, Delete (nested: `/employees/{id}/absences`) | #90 |
| 6 | `PaystubService` | Payroll | v4.0 | GetPdf — binary PDF download (`byte[]`) | #91 |

### Pattern Notes
- `EmployeeService` uses `PatchAsync` (PATCH) for partial updates — not PUT
- `AbsenceService` is a nested resource: all methods accept `employeeId` (Guid) as the first parameter
- `PaystubService` uses `GetBinaryAsync` — no JSON model needed, returns `ApiResult<byte[]>`
- `PurchaseOrderService` follows v3.0 conventions (`PostAsync` for updates)

### Changes to Shared Files
- `IBexioApiClient` — 6 new properties added
- `BexioApiClient` — 6 new constructor parameters + assignments
- `BexioServiceCollection` — 6 new `AddScoped` registrations
- `BexioApiClientWireUpTests` — wire-up assertions for all 6 new services

### Test Coverage
- **Unit tests:** all methods covered (NSubstitute, `ServiceTestBase`)
- **Integration tests:** WireMock stubs for all verbs including DELETE and binary PDF
- **E2E stubs:** all services have `BexioE2eTestBase`-backed stubs (auto-skipped without credentials)
- Full test suite: **clean build, zero warnings** under `dotnet build /warnaserror`

### Documentation
- `doc/analysis/api-completeness-audit.md` — updated 31 endpoints from TODO→DONE
- `doc/ai-readiness.md` — updated coverage summary and Wave 5 completion entry

## Closes

Closes #86
Closes #87
Closes #88
Closes #89
Closes #90
Closes #91
Closes #28

## Known Pre-Existing Issues (not introduced by this PR)

- `NU1902` NuGet vulnerability warnings in the IntegrationTests project (`OpenTelemetry.Api 1.14.0`, `OpenTelemetry.Exporter.OpenTelemetryProtocol 1.14.0`) — exist on `main` prior to this branch, unrelated to Wave 5. Recommend a separate dependency-bump PR.
- Minor NuGet updates available: `Microsoft.Extensions.DependencyInjection` 10.0.6→10.0.7, `WireMock.Net` 2.2.0→2.3.0 — deferred per scope discipline.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)