### PR TITLE
feat(wave-6): Files & Master Data — 53 endpoints across 14 services

### DIFF
--- a/src/BexioApiNet.Abstractions/Enums/MasterData/KbDocumentType.cs
+++ b/src/BexioApiNet.Abstractions/Enums/MasterData/KbDocumentType.cs
@@ -1,0 +1,67 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Enums.MasterData;
+
+/// <summary>
+/// Bexio document-type discriminator used as the <c>{kb_document_type}</c> URL segment in
+/// document-scoped endpoints such as Comments (<c>/2.0/{kb_document_type}/{document_id}/comment</c>).
+/// Use <see cref="KbDocumentTypeExtensions.ToBexioString"/> to convert to the snake_case
+/// path segment expected by the Bexio API.
+/// <see href="https://docs.bexio.com/#tag/Comments">Comments</see>
+/// </summary>
+public enum KbDocumentType
+{
+    /// <summary>Quote (offer) document type. Maps to the <c>kb_offer</c> path segment.</summary>
+    Offer,
+
+    /// <summary>Order document type. Maps to the <c>kb_order</c> path segment.</summary>
+    Order,
+
+    /// <summary>Invoice document type. Maps to the <c>kb_invoice</c> path segment.</summary>
+    Invoice
+}
+
+/// <summary>
+/// Extension methods for <see cref="KbDocumentType"/> that translate the typed enum to the
+/// snake_case string Bexio expects in the URL.
+/// </summary>
+public static class KbDocumentTypeExtensions
+{
+    /// <summary>
+    /// Returns the Bexio API path segment for the given <see cref="KbDocumentType"/>
+    /// (e.g. <c>kb_invoice</c>).
+    /// </summary>
+    /// <param name="kbDocumentType">The document-type discriminator.</param>
+    /// <returns>The snake_case path segment used in the URL.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is not a defined enum member.</exception>
+    public static string ToBexioString(this KbDocumentType kbDocumentType) => kbDocumentType switch
+    {
+        KbDocumentType.Offer => "kb_offer",
+        KbDocumentType.Order => "kb_order",
+        KbDocumentType.Invoice => "kb_invoice",
+        _ => throw new ArgumentOutOfRangeException(nameof(kbDocumentType), kbDocumentType, "Unknown kb_document_type value.")
+    };
+}

--- a/src/BexioApiNet.Abstractions/Models/Files/DocumentSettings/DocumentSetting.cs
+++ b/src/BexioApiNet.Abstractions/Models/Files/DocumentSettings/DocumentSetting.cs
@@ -1,0 +1,81 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Files.DocumentSettings;
+
+/// <summary>
+/// Document setting (a.k.a. <c>KbItemSetting</c>) returned by the Bexio v2.0
+/// <c>/kb_item_setting</c> endpoint. Describes the default configuration applied to a
+/// given document class (offer, order, invoice, delivery, credit voucher, ...).
+/// <see href="https://docs.bexio.com/#tag/Document-Settings/operation/v2ListDocumentSettings">v2 List Document Settings</see>
+/// </summary>
+/// <param name="Id">Unique document-setting identifier.</param>
+/// <param name="Text">Display name of the document setting (e.g. <c>Quote</c>).</param>
+/// <param name="KbItemClass">Target document class (e.g. <c>KbOffer</c>, <c>KbInvoice</c>).</param>
+/// <param name="EnumerationFormat">Format string used to build the document number (e.g. <c>AN-%nummer%</c>).</param>
+/// <param name="UseAutomaticEnumeration">When true, document numbers are auto-generated.</param>
+/// <param name="UseYearlyEnumeration">When true, the document counter resets at the start of every year.</param>
+/// <param name="NextNr">The next number that will be assigned to a new document.</param>
+/// <param name="NrMinLength">Minimum length of the numeric part of the document number (zero-padded).</param>
+/// <param name="DefaultTimePeriodInDays">Default validity / due period applied to new documents, in days.</param>
+/// <param name="DefaultLogopaperId">Default logopaper template id applied to new documents.</param>
+/// <param name="DefaultLanguageId">Default language id applied to new documents.</param>
+/// <param name="DefaultClientBankAccountNewId">Default client bank account id applied to new documents.</param>
+/// <param name="DefaultCurrencyId">Default currency id applied to new documents.</param>
+/// <param name="DefaultMwstType">Default VAT type applied to new documents.</param>
+/// <param name="DefaultMwstIsNet">When true, prices on new documents are entered net of VAT.</param>
+/// <param name="DefaultNbDecimalsAmount">Default number of decimal places for amounts.</param>
+/// <param name="DefaultNbDecimalsPrice">Default number of decimal places for unit prices.</param>
+/// <param name="DefaultShowPositionTaxes">When true, per-position taxes are shown on new documents.</param>
+/// <param name="DefaultTitle">Default document title (e.g. <c>Angebot</c>).</param>
+/// <param name="DefaultShowEsrOnSamePage">When true, the ESR payment slip is printed on the same page as the document.</param>
+/// <param name="DefaultPaymentTypeId">Default payment type id applied to new documents.</param>
+/// <param name="KbTermsOfPaymentTemplateId">Optional default terms-of-payment template id (nullable).</param>
+/// <param name="DefaultShowTotal">When true, the document total is shown on new documents.</param>
+public sealed record DocumentSetting(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("text")] string Text,
+    [property: JsonPropertyName("kb_item_class")] string KbItemClass,
+    [property: JsonPropertyName("enumeration_format")] string EnumerationFormat,
+    [property: JsonPropertyName("use_automatic_enumeration")] bool UseAutomaticEnumeration,
+    [property: JsonPropertyName("use_yearly_enumeration")] bool UseYearlyEnumeration,
+    [property: JsonPropertyName("next_nr")] int NextNr,
+    [property: JsonPropertyName("nr_min_length")] int NrMinLength,
+    [property: JsonPropertyName("default_time_period_in_days")] int DefaultTimePeriodInDays,
+    [property: JsonPropertyName("default_logopaper_id")] int DefaultLogopaperId,
+    [property: JsonPropertyName("default_language_id")] int DefaultLanguageId,
+    [property: JsonPropertyName("default_client_bank_account_new_id")] int DefaultClientBankAccountNewId,
+    [property: JsonPropertyName("default_currency_id")] int DefaultCurrencyId,
+    [property: JsonPropertyName("default_mwst_type")] int DefaultMwstType,
+    [property: JsonPropertyName("default_mwst_is_net")] bool DefaultMwstIsNet,
+    [property: JsonPropertyName("default_nb_decimals_amount")] int DefaultNbDecimalsAmount,
+    [property: JsonPropertyName("default_nb_decimals_price")] int DefaultNbDecimalsPrice,
+    [property: JsonPropertyName("default_show_position_taxes")] bool DefaultShowPositionTaxes,
+    [property: JsonPropertyName("default_title")] string DefaultTitle,
+    [property: JsonPropertyName("default_show_esr_on_same_page")] bool DefaultShowEsrOnSamePage,
+    [property: JsonPropertyName("default_payment_type_id")] int DefaultPaymentTypeId,
+    [property: JsonPropertyName("kb_terms_of_payment_template_id")] int? KbTermsOfPaymentTemplateId,
+    [property: JsonPropertyName("default_show_total")] bool DefaultShowTotal
+);

--- a/src/BexioApiNet.Abstractions/Models/Files/DocumentTemplates/DocumentTemplate.cs
+++ b/src/BexioApiNet.Abstractions/Models/Files/DocumentTemplates/DocumentTemplate.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Files.DocumentTemplates.Enums;
+
+namespace BexioApiNet.Abstractions.Models.Files.DocumentTemplates;
+
+/// <summary>
+/// Document template returned by the Bexio v3.0 <c>/document_templates</c> endpoint.
+/// Referenced by sales documents via the <c>template_slug</c> field.
+/// <see href="https://docs.bexio.com/#tag/Document-templates/operation/v3ListDocumentTemplate">v3 List Document Templates</see>
+/// </summary>
+/// <param name="TemplateSlug">Document template identifier (a.k.a. slug).</param>
+/// <param name="Name">Document template display name.</param>
+/// <param name="IsDefault">Whether this template is the default for at least one document type.</param>
+/// <param name="DefaultForDocumentTypes">Document types for which this template is the default.</param>
+public sealed record DocumentTemplate(
+    [property: JsonPropertyName("template_slug")] string TemplateSlug,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("is_default")] bool IsDefault,
+    [property: JsonPropertyName("default_for_document_types")] IReadOnlyList<DocumentTemplateDocumentType> DefaultForDocumentTypes
+);

--- a/src/BexioApiNet.Abstractions/Models/Files/DocumentTemplates/Enums/DocumentTemplateDocumentType.cs
+++ b/src/BexioApiNet.Abstractions/Models/Files/DocumentTemplates/Enums/DocumentTemplateDocumentType.cs
@@ -1,0 +1,57 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.Files.DocumentTemplates.Enums;
+
+/// <summary>
+/// Document types a <see cref="DocumentTemplate" /> may be marked as default for. The
+/// serialized form matches the Bexio <c>default_for_document_types</c> enum values exactly.
+/// <see href="https://docs.bexio.com/#tag/Document-templates/operation/v3ListDocumentTemplate">v3 List Document Templates</see>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum DocumentTemplateDocumentType
+{
+    /// <summary>Quote (offer) document type.</summary>
+    type_offer,
+
+    /// <summary>Order document type.</summary>
+    type_order,
+
+    /// <summary>Invoice document type.</summary>
+    type_invoice,
+
+    /// <summary>Delivery document type.</summary>
+    type_delivery,
+
+    /// <summary>Credit voucher document type.</summary>
+    type_credit_voucher,
+
+    /// <summary>Account statement document type.</summary>
+    type_account_statement,
+
+    /// <summary>Article order document type.</summary>
+    type_article_order
+}

--- a/src/BexioApiNet.Abstractions/Models/Files/Files/File.cs
+++ b/src/BexioApiNet.Abstractions/Models/Files/Files/File.cs
@@ -1,0 +1,72 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Files.Files;
+
+/// <summary>
+///     File entity returned by the Bexio v3.0 <c>/files</c> endpoints (list, show, upload, patch).
+///     <see href="https://docs.bexio.com/#tag/Files">Files</see>
+/// </summary>
+/// <param name="Id">The id of the file.</param>
+/// <param name="Uuid">The uuid of the file.</param>
+/// <param name="Name">The name of the file.</param>
+/// <param name="SizeInBytes">The size of the file in bytes.</param>
+/// <param name="Extension">The extension of the file.</param>
+/// <param name="MimeType">The mime type of the file.</param>
+/// <param name="UploaderEmail">Returns the email of the sender if the file was added by email.</param>
+/// <param name="UserId">The id of the user which originally uploaded the file (references a user object).</param>
+/// <param name="IsArchived">Whether the file is archived.</param>
+/// <param name="SourceId">
+///     ID of the source (web, mobile, etc.) this file has been uploaded from. Deprecated by Bexio —
+///     prefer <see cref="SourceType" />.
+/// </param>
+/// <param name="SourceType">Type of the source (<c>web</c>, <c>email</c>, <c>mobile</c>) this file has been uploaded from.</param>
+/// <param name="IsReferenced">Whether the file is referenced to a document or not.</param>
+/// <param name="CreatedAt">File upload date.</param>
+public sealed record File(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("uuid")] Guid Uuid,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("size_in_bytes")]
+    long SizeInBytes,
+    [property: JsonPropertyName("extension")]
+    string Extension,
+    [property: JsonPropertyName("mime_type")]
+    string MimeType,
+    [property: JsonPropertyName("uploader_email")]
+    string? UploaderEmail,
+    [property: JsonPropertyName("user_id")]
+    int UserId,
+    [property: JsonPropertyName("is_archived")]
+    bool IsArchived,
+    [property: JsonPropertyName("source_id")]
+    int? SourceId,
+    [property: JsonPropertyName("source_type")]
+    string? SourceType,
+    [property: JsonPropertyName("is_referenced")]
+    bool IsReferenced,
+    [property: JsonPropertyName("created_at")]
+    DateTime CreatedAt
+);

--- a/src/BexioApiNet.Abstractions/Models/Files/Files/FileUsage.cs
+++ b/src/BexioApiNet.Abstractions/Models/Files/Files/FileUsage.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Files.Files;
+
+/// <summary>
+///     File usage entity returned by the Bexio v3.0 <c>GET /3.0/files/{file_id}/usage</c> endpoint.
+///     Describes which document a file is attached to.
+///     <see href="https://docs.bexio.com/#tag/Files/operation/v3ShowFile">Show File usage</see>
+/// </summary>
+/// <param name="Id">The id of the file.</param>
+/// <param name="RefClass">The reference to the class this file is attached to (e.g. <c>KbInvoice</c>).</param>
+/// <param name="Title">The title set on the reference class.</param>
+/// <param name="DocumentNr">The internal document number set on the reference class.</param>
+public sealed record FileUsage(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("ref_class")]
+    string RefClass,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("document_nr")]
+    string DocumentNr
+);

--- a/src/BexioApiNet.Abstractions/Models/Files/Files/Views/FilePatch.cs
+++ b/src/BexioApiNet.Abstractions/Models/Files/Files/Views/FilePatch.cs
@@ -1,0 +1,47 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.Files.Files.Views;
+
+/// <summary>
+///     Patch view for <c>PATCH /3.0/files/{file_id}</c>. All properties are optional — only the
+///     fields supplied are sent to the server. <see langword="null" /> values are omitted from the
+///     serialized payload so unset fields are not mutated.
+///     <see href="https://docs.bexio.com/#tag/Files/operation/v3UpdateFile">Update File</see>
+/// </summary>
+/// <param name="Name">The new name of the file (max. 255 characters).</param>
+/// <param name="IsArchived">Define archived state of the file.</param>
+/// <param name="SourceType">Type of the source (<c>web</c>, <c>email</c>, <c>mobile</c>) this file has been uploaded from.</param>
+public sealed record FilePatch(
+    [property: JsonPropertyName("name")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? Name = null,
+    [property: JsonPropertyName("is_archived")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    bool? IsArchived = null,
+    [property: JsonPropertyName("source_type")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? SourceType = null
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Comments/Comment.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Comments/Comment.cs
@@ -1,0 +1,70 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Comments;
+
+/// <summary>
+/// Comment attached to a Bexio document (offer, order, or invoice). The discriminator
+/// (<c>kb_document_type</c>) is part of the URL only — it is not present in the response body.
+/// <see href="https://docs.bexio.com/#tag/Comments">Comments</see>
+/// </summary>
+public sealed record Comment
+{
+    /// <summary>Unique comment identifier (assigned by Bexio).</summary>
+    [JsonPropertyName("id")]
+    public int? Id { get; init; }
+
+    /// <summary>Free-form comment text.</summary>
+    [JsonPropertyName("text")]
+    public required string Text { get; init; }
+
+    /// <summary>Identifier of the user who authored the comment. References a user object.</summary>
+    [JsonPropertyName("user_id")]
+    public required int? UserId { get; init; }
+
+    /// <summary>Email address of the user who authored the comment, if known.</summary>
+    [JsonPropertyName("user_email")]
+    public string? UserEmail { get; init; }
+
+    /// <summary>Display name of the user who authored the comment.</summary>
+    [JsonPropertyName("user_name")]
+    public required string? UserName { get; init; }
+
+    /// <summary>Server-assigned creation timestamp formatted as <c>yyyy-MM-dd HH:mm:ss</c>.</summary>
+    [JsonPropertyName("date")]
+    public string? Date { get; init; }
+
+    /// <summary>Whether the comment is publicly visible (<c>true</c>) or internal-only (<c>false</c>).</summary>
+    [JsonPropertyName("is_public")]
+    public bool? IsPublic { get; init; }
+
+    /// <summary>Base64-encoded profile image of the comment author, when available.</summary>
+    [JsonPropertyName("image")]
+    public string? Image { get; init; }
+
+    /// <summary>URL to the profile image of the comment author, when available.</summary>
+    [JsonPropertyName("image_path")]
+    public string? ImagePath { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Comments/Views/CommentCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Comments/Views/CommentCreate.cs
@@ -1,0 +1,53 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Comments.Views;
+
+/// <summary>
+/// Create view for a comment on a Bexio document.
+/// <see href="https://docs.bexio.com/#tag/Comments/operation/v2CreateComment">Create Comment</see>
+/// </summary>
+public sealed record CommentCreate
+{
+    /// <summary>Free-form comment text.</summary>
+    [JsonPropertyName("text")]
+    public required string Text { get; init; }
+
+    /// <summary>Identifier of the user who authored the comment.</summary>
+    [JsonPropertyName("user_id")]
+    public required int? UserId { get; init; }
+
+    /// <summary>Display name of the user who authored the comment.</summary>
+    [JsonPropertyName("user_name")]
+    public required string? UserName { get; init; }
+
+    /// <summary>Email address of the user who authored the comment, if known.</summary>
+    [JsonPropertyName("user_email")]
+    public string? UserEmail { get; init; }
+
+    /// <summary>Whether the comment is publicly visible (<c>true</c>) or internal-only (<c>false</c>).</summary>
+    [JsonPropertyName("is_public")]
+    public bool? IsPublic { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/MasterData/CommunicationTypes/CommunicationType.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/CommunicationTypes/CommunicationType.cs
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.CommunicationTypes;
+
+/// <summary>
+/// A Bexio communication type lookup entry. Bexio exposes the resource under the
+/// legacy path segment <c>communication_kind</c> while the documented concept is
+/// "communication type".
+/// <see href="https://docs.bexio.com/#tag/Communication-Types"/>
+/// </summary>
+/// <param name="Id">Unique communication type identifier.</param>
+/// <param name="Name">Display name of the communication type (e.g. <c>Mobile Phone</c>).</param>
+public sealed record CommunicationType(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/CompanyProfiles/CompanyProfile.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/CompanyProfiles/CompanyProfile.cs
@@ -1,0 +1,229 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.MasterData.CompanyProfiles.Enums;
+
+namespace BexioApiNet.Abstractions.Models.MasterData.CompanyProfiles;
+
+/// <summary>
+/// Company profile object returned by <c>/2.0/company_profile</c>. Each Bexio account
+/// currently owns a single profile but the list endpoint still returns it as an array.
+/// <see href="https://docs.bexio.com/#tag/Company-Profile"/>
+/// </summary>
+public sealed record CompanyProfile
+{
+    /// <summary>
+    /// Unique company profile identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    /// <summary>
+    /// Display name of the company.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Street address.
+    /// </summary>
+    [JsonPropertyName("address")]
+    public string? Address { get; init; }
+
+    /// <summary>
+    /// Additional address line (e.g. mail box). Despite the field name, the Bexio API states
+    /// this is not the street number but an additional address line.
+    /// </summary>
+    [JsonPropertyName("address_nr")]
+    public string? AddressNr { get; init; }
+
+    /// <summary>
+    /// Postal code.
+    /// </summary>
+    [JsonPropertyName("postcode")]
+    public string? Postcode { get; init; }
+
+    /// <summary>
+    /// City / town name.
+    /// </summary>
+    [JsonPropertyName("city")]
+    public string? City { get; init; }
+
+    /// <summary>
+    /// Reference to a <see href="https://docs.bexio.com/#tag/Countries/operation/v2ListCountries">country object</see> by id.
+    /// </summary>
+    [JsonPropertyName("country_id")]
+    public int? CountryId { get; init; }
+
+    /// <summary>
+    /// Legal form of the company.
+    /// </summary>
+    [JsonPropertyName("legal_form")]
+    public CompanyLegalForm? LegalForm { get; init; }
+
+    /// <summary>
+    /// Display name of the country (denormalised by Bexio).
+    /// </summary>
+    [JsonPropertyName("country_name")]
+    public string? CountryName { get; init; }
+
+    /// <summary>
+    /// Contact e-mail address.
+    /// </summary>
+    [JsonPropertyName("mail")]
+    public string? Mail { get; init; }
+
+    /// <summary>
+    /// Primary fixed-line phone number.
+    /// </summary>
+    [JsonPropertyName("phone_fixed")]
+    public string? PhoneFixed { get; init; }
+
+    /// <summary>
+    /// Primary mobile phone number.
+    /// </summary>
+    [JsonPropertyName("phone_mobile")]
+    public string? PhoneMobile { get; init; }
+
+    /// <summary>
+    /// Fax number.
+    /// </summary>
+    [JsonPropertyName("fax")]
+    public string? Fax { get; init; }
+
+    /// <summary>
+    /// Public website URL.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    /// <summary>
+    /// Skype contact name.
+    /// </summary>
+    [JsonPropertyName("skype_name")]
+    public string? SkypeName { get; init; }
+
+    /// <summary>
+    /// Facebook contact name.
+    /// </summary>
+    [JsonPropertyName("facebook_name")]
+    public string? FacebookName { get; init; }
+
+    /// <summary>
+    /// Twitter contact name.
+    /// </summary>
+    [JsonPropertyName("twitter_name")]
+    public string? TwitterName { get; init; }
+
+    /// <summary>
+    /// Free-form company description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// UID / UST-ID company number.
+    /// </summary>
+    [JsonPropertyName("ust_id_nr")]
+    public string? UstIdNr { get; init; }
+
+    /// <summary>
+    /// VAT (MWST) number.
+    /// </summary>
+    [JsonPropertyName("mwst_nr")]
+    public string? MwstNr { get; init; }
+
+    /// <summary>
+    /// Commercial / trade register number.
+    /// </summary>
+    [JsonPropertyName("trade_register_nr")]
+    public string? TradeRegisterNr { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the company uses its own logo.
+    /// </summary>
+    [JsonPropertyName("has_own_logo")]
+    public bool? HasOwnLogo { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the profile is shown publicly on bexio's platform.
+    /// </summary>
+    [JsonPropertyName("is_public_profile")]
+    public bool? IsPublicProfile { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the logo is public.
+    /// </summary>
+    [JsonPropertyName("is_logo_public")]
+    public bool? IsLogoPublic { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the postal address is public.
+    /// </summary>
+    [JsonPropertyName("is_address_public")]
+    public bool? IsAddressPublic { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the fixed-line phone is public.
+    /// </summary>
+    [JsonPropertyName("is_phone_public")]
+    public bool? IsPhonePublic { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the mobile phone is public.
+    /// </summary>
+    [JsonPropertyName("is_mobile_public")]
+    public bool? IsMobilePublic { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the fax number is public.
+    /// </summary>
+    [JsonPropertyName("is_fax_public")]
+    public bool? IsFaxPublic { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the e-mail address is public.
+    /// </summary>
+    [JsonPropertyName("is_mail_public")]
+    public bool? IsMailPublic { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the website URL is public.
+    /// </summary>
+    [JsonPropertyName("is_url_public")]
+    public bool? IsUrlPublic { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> if the Skype name is public.
+    /// </summary>
+    [JsonPropertyName("is_skype_public")]
+    public bool? IsSkypePublic { get; init; }
+
+    /// <summary>
+    /// Base64-encoded logo image bytes.
+    /// </summary>
+    [JsonPropertyName("logo_base64")]
+    public string? LogoBase64 { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/MasterData/CompanyProfiles/Enums/CompanyLegalForm.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/CompanyProfiles/Enums/CompanyLegalForm.cs
@@ -1,0 +1,64 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// ReSharper disable InconsistentNaming
+namespace BexioApiNet.Abstractions.Models.MasterData.CompanyProfiles.Enums;
+
+/// <summary>
+/// Legal form of a company profile. <see href="https://docs.bexio.com/#tag/Company-Profile"/>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum CompanyLegalForm
+{
+    /// <summary>
+    /// Sole proprietorship.
+    /// </summary>
+    sole_proprietorship,
+
+    /// <summary>
+    /// Joint partnership.
+    /// </summary>
+    joint_partnership,
+
+    /// <summary>
+    /// Foundation.
+    /// </summary>
+    foundation,
+
+    /// <summary>
+    /// Corporation.
+    /// </summary>
+    corporation,
+
+    /// <summary>
+    /// Limited liability company.
+    /// </summary>
+    limited_liability_company,
+
+    /// <summary>
+    /// Association.
+    /// </summary>
+    association
+}

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Countries/Country.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Countries/Country.cs
@@ -1,0 +1,40 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Countries;
+
+/// <summary>
+///     Country object. <see href="https://docs.bexio.com/#tag/Countries/operation/v2ListCountries" />
+/// </summary>
+/// <param name="Id">Unique identifier of the country.</param>
+/// <param name="Name">Display name of the country (e.g. "Kiribati").</param>
+/// <param name="NameShort">Short name / code of the country (e.g. "KI").</param>
+/// <param name="Iso3166Alpha2">ISO 3166-1 alpha-2 country code (e.g. "KI").</param>
+public sealed record Country(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("name_short")] string NameShort,
+    [property: JsonPropertyName("iso3166_alpha2")] string Iso3166Alpha2
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Countries/Views/CountryCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Countries/Views/CountryCreate.cs
@@ -1,0 +1,38 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Countries.Views;
+
+/// <summary>
+///     Create view for a country. <see href="https://docs.bexio.com/#tag/Countries/operation/v2CreateCountry" />
+/// </summary>
+/// <param name="Name">Display name of the country (e.g. "Kiribati").</param>
+/// <param name="NameShort">Short name / code of the country (e.g. "KI").</param>
+/// <param name="Iso3166Alpha2">ISO 3166-1 alpha-2 country code (e.g. "KI").</param>
+public sealed record CountryCreate(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("name_short")] string NameShort,
+    [property: JsonPropertyName("iso3166_alpha2")] string Iso3166Alpha2
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Countries/Views/CountryUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Countries/Views/CountryUpdate.cs
@@ -1,0 +1,38 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Countries.Views;
+
+/// <summary>
+///     Update view for a country. <see href="https://docs.bexio.com/#tag/Countries/operation/v2EditCountry" />
+/// </summary>
+/// <param name="Name">Updated display name of the country.</param>
+/// <param name="NameShort">Updated short name / code of the country.</param>
+/// <param name="Iso3166Alpha2">Updated ISO 3166-1 alpha-2 country code.</param>
+public sealed record CountryUpdate(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("name_short")] string NameShort,
+    [property: JsonPropertyName("iso3166_alpha2")] string Iso3166Alpha2
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/FictionalUsers/FictionalUser.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/FictionalUsers/FictionalUser.cs
@@ -1,0 +1,53 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.FictionalUsers;
+
+/// <summary>
+///     Bexio fictional user returned by the v3.0 <c>/fictional_users</c> endpoints
+///     (GET list, GET by id, POST create, PATCH update).
+///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management">Fictional User Management</see>
+/// </summary>
+/// <param name="Id">Unique fictional user identifier.</param>
+/// <param name="SalutationType">Salutation type. One of <c>male</c> or <c>female</c>.</param>
+/// <param name="Firstname">First name of the fictional user. Maximum 80 characters.</param>
+/// <param name="Lastname">Last name of the fictional user. Maximum 80 characters.</param>
+/// <param name="Email">
+///     Email address of the fictional user. Email addresses must be unique across both regular
+///     and fictional users.
+/// </param>
+/// <param name="TitleId">Optional reference to a title.</param>
+public sealed record FictionalUser(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("salutation_type")]
+    string SalutationType,
+    [property: JsonPropertyName("firstname")]
+    string Firstname,
+    [property: JsonPropertyName("lastname")]
+    string Lastname,
+    [property: JsonPropertyName("email")] string Email,
+    [property: JsonPropertyName("title_id")]
+    int? TitleId
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/FictionalUsers/Views/FictionalUserCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/FictionalUsers/Views/FictionalUserCreate.cs
@@ -1,0 +1,53 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.FictionalUsers.Views;
+
+/// <summary>
+///     Create view for <c>POST /3.0/fictional_users</c>. All four labelled fields are required
+///     by Bexio; <c>title_id</c> is optional and omitted from the payload when <see langword="null" />.
+///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management/operation/v3CreateFictionalUser">
+///         Create Fictional User
+///     </see>
+/// </summary>
+/// <param name="SalutationType">Salutation type. One of <c>male</c> or <c>female</c>.</param>
+/// <param name="Firstname">First name of the fictional user. Maximum 80 characters.</param>
+/// <param name="Lastname">Last name of the fictional user. Maximum 80 characters.</param>
+/// <param name="Email">
+///     Email address of the fictional user. Must be unique across both regular and fictional users.
+/// </param>
+/// <param name="TitleId">Optional reference to a title.</param>
+public sealed record FictionalUserCreate(
+    [property: JsonPropertyName("salutation_type")]
+    string SalutationType,
+    [property: JsonPropertyName("firstname")]
+    string Firstname,
+    [property: JsonPropertyName("lastname")]
+    string Lastname,
+    [property: JsonPropertyName("email")] string Email,
+    [property: JsonPropertyName("title_id")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? TitleId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/FictionalUsers/Views/FictionalUserPatch.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/FictionalUsers/Views/FictionalUserPatch.cs
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.FictionalUsers.Views;
+
+/// <summary>
+///     Patch view for <c>PATCH /3.0/fictional_users/{fictional_user_id}</c>. All fields are
+///     nullable — only the properties supplied by the caller are serialized and sent to Bexio,
+///     so unspecified fields retain their current server-side value.
+///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management/operation/v3EditFictionalUser">
+///         Edit Fictional User
+///     </see>
+/// </summary>
+/// <param name="SalutationType">Salutation type. One of <c>male</c> or <c>female</c>.</param>
+/// <param name="Firstname">First name of the fictional user. Maximum 80 characters.</param>
+/// <param name="Lastname">Last name of the fictional user. Maximum 80 characters.</param>
+/// <param name="Email">
+///     Email address of the fictional user. Must be unique across both regular and fictional users.
+/// </param>
+/// <param name="TitleId">Reference to a title.</param>
+public sealed record FictionalUserPatch(
+    [property: JsonPropertyName("salutation_type")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? SalutationType = null,
+    [property: JsonPropertyName("firstname")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? Firstname = null,
+    [property: JsonPropertyName("lastname")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? Lastname = null,
+    [property: JsonPropertyName("email")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? Email = null,
+    [property: JsonPropertyName("title_id")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    int? TitleId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Languages/Language.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Languages/Language.cs
@@ -1,0 +1,74 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Languages;
+
+/// <summary>
+/// A Bexio language lookup entry. <see href="https://docs.bexio.com/#tag/Languages"/>
+/// </summary>
+public sealed record Language
+{
+    /// <summary>
+    /// Unique language identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    /// <summary>
+    /// Display name of the language (e.g. <c>German</c>).
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Decimal point character used when formatting numbers in this language (e.g. <c>.</c>).
+    /// </summary>
+    [JsonPropertyName("decimal_point")]
+    public string? DecimalPoint { get; init; }
+
+    /// <summary>
+    /// Thousands separator used when formatting numbers in this language (e.g. <c>'</c>).
+    /// </summary>
+    [JsonPropertyName("thousands_separator")]
+    public string? ThousandsSeparator { get; init; }
+
+    /// <summary>
+    /// Numeric id of the date format: <c>1</c> → <c>DD.MM.YYYY</c>, <c>2</c> → <c>MM/DD/YYYY</c>.
+    /// </summary>
+    [JsonPropertyName("date_format_id")]
+    public int? DateFormatId { get; init; }
+
+    /// <summary>
+    /// PHP-style date format pattern (e.g. <c>d.m.Y</c>).
+    /// </summary>
+    [JsonPropertyName("date_format")]
+    public string? DateFormat { get; init; }
+
+    /// <summary>
+    /// ISO 639-1 two-letter language code (e.g. <c>de</c>).
+    /// </summary>
+    [JsonPropertyName("iso_639_1")]
+    public required string Iso6391 { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Notes/Note.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Notes/Note.cs
@@ -1,0 +1,64 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Notes;
+
+/// <summary>
+///     Note object as returned by the Bexio notes endpoint.
+///     <see href="https://docs.bexio.com/#tag/Notes/operation/v2ListNotes" />
+/// </summary>
+/// <param name="Id">Unique note identifier (read-only, assigned by Bexio).</param>
+/// <param name="UserId">Reference to the user that owns the note.</param>
+/// <param name="EventStart">Timestamp of the note's event in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format.</param>
+/// <param name="Subject">Short subject / title of the note.</param>
+/// <param name="Info">Free-text body of the note.</param>
+/// <param name="ContactId">Optional reference to a linked contact object.</param>
+/// <param name="ProjectId">
+///     Optional reference to a linked project object (read-only — Bexio mirrors
+///     <see cref="PrProjectId" /> here on reads).
+/// </param>
+/// <param name="PrProjectId">Optional reference to a project object used when creating or updating a note (write-only).</param>
+/// <param name="EntryId">Optional reference to the linked document entry.</param>
+/// <param name="ModuleId">Optional reference to the module that owns <see cref="EntryId" />.</param>
+public sealed record Note(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("user_id")]
+    int UserId,
+    [property: JsonPropertyName("event_start")]
+    DateTime EventStart,
+    [property: JsonPropertyName("subject")]
+    string Subject,
+    [property: JsonPropertyName("info")] string Info,
+    [property: JsonPropertyName("contact_id")]
+    int? ContactId,
+    [property: JsonPropertyName("project_id")]
+    int? ProjectId,
+    [property: JsonPropertyName("pr_project_id")]
+    int? PrProjectId,
+    [property: JsonPropertyName("entry_id")]
+    int? EntryId,
+    [property: JsonPropertyName("module_id")]
+    int? ModuleId
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Notes/Views/NoteCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Notes/Views/NoteCreate.cs
@@ -1,0 +1,61 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Notes.Views;
+
+/// <summary>
+///     Create view for a note — body of <c>POST /2.0/note</c>. The read-only <c>id</c> and
+///     <c>project_id</c> fields are intentionally omitted; use <see cref="PrProjectId" /> to
+///     link the new note to a project (Bexio mirrors the value onto <c>project_id</c> on reads).
+///     <see href="https://docs.bexio.com/#tag/Notes/operation/v2CreateNote" />
+/// </summary>
+/// <param name="UserId">Reference to the user that owns the note.</param>
+/// <param name="EventStart">Timestamp of the note's event in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format.</param>
+/// <param name="Subject">Short subject / title of the note.</param>
+/// <param name="Info">
+///     Free-text body of the note. Optional; defaults to <see langword="null" /> and is only serialized
+///     when supplied.
+/// </param>
+/// <param name="ContactId">Optional reference to a linked contact object.</param>
+/// <param name="PrProjectId">Optional reference to a project object (write-only; surfaced as <c>project_id</c> on reads).</param>
+/// <param name="EntryId">Optional reference to the linked document entry.</param>
+/// <param name="ModuleId">Optional reference to the module that owns <see cref="EntryId" />.</param>
+public sealed record NoteCreate(
+    [property: JsonPropertyName("user_id")]
+    int UserId,
+    [property: JsonPropertyName("event_start")]
+    DateTime EventStart,
+    [property: JsonPropertyName("subject")]
+    string Subject,
+    [property: JsonPropertyName("info")] string? Info = null,
+    [property: JsonPropertyName("contact_id")]
+    int? ContactId = null,
+    [property: JsonPropertyName("pr_project_id")]
+    int? PrProjectId = null,
+    [property: JsonPropertyName("entry_id")]
+    int? EntryId = null,
+    [property: JsonPropertyName("module_id")]
+    int? ModuleId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Notes/Views/NoteUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Notes/Views/NoteUpdate.cs
@@ -1,0 +1,63 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Notes.Views;
+
+/// <summary>
+///     Update view for a note — body of the edit request against <c>/2.0/note/{note_id}</c>.
+///     Bexio performs a full-replacement edit, so every writable field should be provided to
+///     avoid losing the previous value. The note id travels in the path and is therefore not
+///     part of the body; the read-only <c>project_id</c> mirror is likewise omitted (use
+///     <see cref="PrProjectId" /> instead).
+///     <see href="https://docs.bexio.com/#tag/Notes/operation/v2EditNote" />
+/// </summary>
+/// <param name="UserId">Reference to the user that owns the note.</param>
+/// <param name="EventStart">Timestamp of the note's event in Bexio's <c>yyyy-MM-dd HH:mm:ss</c> format.</param>
+/// <param name="Subject">Short subject / title of the note.</param>
+/// <param name="Info">
+///     Free-text body of the note. Optional; defaults to <see langword="null" /> and is only serialized
+///     when supplied.
+/// </param>
+/// <param name="ContactId">Optional reference to a linked contact object.</param>
+/// <param name="PrProjectId">Optional reference to a project object (write-only; surfaced as <c>project_id</c> on reads).</param>
+/// <param name="EntryId">Optional reference to the linked document entry.</param>
+/// <param name="ModuleId">Optional reference to the module that owns <see cref="EntryId" />.</param>
+public sealed record NoteUpdate(
+    [property: JsonPropertyName("user_id")]
+    int UserId,
+    [property: JsonPropertyName("event_start")]
+    DateTime EventStart,
+    [property: JsonPropertyName("subject")]
+    string Subject,
+    [property: JsonPropertyName("info")] string? Info = null,
+    [property: JsonPropertyName("contact_id")]
+    int? ContactId = null,
+    [property: JsonPropertyName("pr_project_id")]
+    int? PrProjectId = null,
+    [property: JsonPropertyName("entry_id")]
+    int? EntryId = null,
+    [property: JsonPropertyName("module_id")]
+    int? ModuleId = null
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Permissions/Permission.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Permissions/Permission.cs
@@ -1,0 +1,50 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Permissions;
+
+/// <summary>
+/// Access information of the currently signed-in user, returned by Bexio's
+/// <c>/3.0/permissions</c> singleton endpoint.
+/// <see href="https://docs.bexio.com/#tag/Permissions/operation/Permissions">Get permissions</see>
+/// </summary>
+public sealed record Permission
+{
+    /// <summary>
+    /// Activated modules / functionalities for the signed-in user. The Bexio docs describe this
+    /// as a list of feature flags (e.g. <c>functionality1</c>).
+    /// </summary>
+    [JsonPropertyName("components")]
+    public IReadOnlyList<string>? Components { get; init; }
+
+    /// <summary>
+    /// Per-resource permission descriptors. Keys are Bexio resource names (e.g. <c>contact</c>,
+    /// <c>kb_invoice</c>, <c>article</c>). The shape of each value follows <see cref="PermissionAccess"/>.
+    /// The set of keys varies per user and per activated module; an unknown key should not be
+    /// treated as an error.
+    /// </summary>
+    [JsonPropertyName("permissions")]
+    public IReadOnlyDictionary<string, PermissionAccess>? Permissions { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Permissions/PermissionAccess.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Permissions/PermissionAccess.cs
@@ -1,0 +1,54 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Permissions;
+
+/// <summary>
+/// Access descriptor for a single Bexio permission resource. Each property corresponds to an
+/// attribute returned by the Bexio <c>/3.0/permissions</c> endpoint. Not every resource returns
+/// every attribute — only <see cref="Activation"/> is present for every resource.
+/// <see href="https://docs.bexio.com/#tag/Permissions"/>
+/// </summary>
+public sealed record PermissionAccess
+{
+    /// <summary>
+    /// Activation state of the resource (e.g. <c>enabled</c>, <c>disabled</c>). When this is
+    /// <c>disabled</c>, the other attributes have no effect.
+    /// </summary>
+    [JsonPropertyName("activation")]
+    public string? Activation { get; init; }
+
+    /// <summary>
+    /// Edit access level (e.g. <c>all</c>, <c>own</c>, <c>none</c>).
+    /// </summary>
+    [JsonPropertyName("edit")]
+    public string? Edit { get; init; }
+
+    /// <summary>
+    /// View / show access level (e.g. <c>all</c>, <c>own</c>).
+    /// </summary>
+    [JsonPropertyName("show")]
+    public string? Show { get; init; }
+}

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Salutations/Salutation.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Salutations/Salutation.cs
@@ -1,0 +1,36 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Salutations;
+
+/// <summary>
+///     Salutation object. <see href="https://docs.bexio.com/#tag/Salutations/operation/v2ListSalutations" />
+/// </summary>
+/// <param name="Id">Unique identifier of the salutation.</param>
+/// <param name="Name">Display name of the salutation (e.g. <c>Herr</c>, <c>Frau</c>).</param>
+public sealed record Salutation(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Salutations/Views/SalutationCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Salutations/Views/SalutationCreate.cs
@@ -1,0 +1,34 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Salutations.Views;
+
+/// <summary>
+///     Create view for a salutation. <see href="https://docs.bexio.com/#tag/Salutations/operation/v2CreateSalutation" />
+/// </summary>
+/// <param name="Name">Display name of the salutation (e.g. <c>Herr</c>, <c>Frau</c>).</param>
+public sealed record SalutationCreate(
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Salutations/Views/SalutationUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Salutations/Views/SalutationUpdate.cs
@@ -1,0 +1,34 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Salutations.Views;
+
+/// <summary>
+///     Update view for a salutation. <see href="https://docs.bexio.com/#tag/Salutations/operation/v2EditSalutation" />
+/// </summary>
+/// <param name="Name">Updated display name of the salutation.</param>
+public sealed record SalutationUpdate(
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Titles/Title.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Titles/Title.cs
@@ -1,0 +1,37 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Titles;
+
+/// <summary>
+///     Title object (honorific such as "Dr." or "Prof.").
+///     <see href="https://docs.bexio.com/#tag/Titles/operation/v2ListTitles" />
+/// </summary>
+/// <param name="Id">Unique identifier of the title.</param>
+/// <param name="Name">Display name of the title (e.g. "Dr.").</param>
+public sealed record Title(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Titles/Views/TitleCreate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Titles/Views/TitleCreate.cs
@@ -1,0 +1,34 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Titles.Views;
+
+/// <summary>
+///     Create view for a title. <see href="https://docs.bexio.com/#tag/Titles/operation/v2CreateTitle" />
+/// </summary>
+/// <param name="Name">Display name of the title (e.g. "Dr.").</param>
+public sealed record TitleCreate(
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Titles/Views/TitleUpdate.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Titles/Views/TitleUpdate.cs
@@ -1,0 +1,34 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Titles.Views;
+
+/// <summary>
+///     Update view for a title. <see href="https://docs.bexio.com/#tag/Titles/operation/v2EditTitle" />
+/// </summary>
+/// <param name="Name">Updated display name of the title.</param>
+public sealed record TitleUpdate(
+    [property: JsonPropertyName("name")] string Name
+);

--- a/src/BexioApiNet.Abstractions/Models/MasterData/Users/User.cs
+++ b/src/BexioApiNet.Abstractions/Models/MasterData/Users/User.cs
@@ -1,0 +1,57 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Abstractions.Models.MasterData.Users;
+
+/// <summary>
+///     Bexio user account returned by the v3.0 <c>/users</c> endpoints
+///     (GET list, GET <c>/users/me</c>, GET by id).
+///     <see href="https://docs.bexio.com/#tag/User-Management">User Management</see>
+/// </summary>
+/// <param name="Id">Unique user identifier.</param>
+/// <param name="SalutationType">Salutation type. One of <c>male</c> or <c>female</c>.</param>
+/// <param name="Firstname">First name of the user. Read-only. Maximum 80 characters.</param>
+/// <param name="Lastname">Last name of the user. Read-only. Maximum 80 characters.</param>
+/// <param name="Email">Email address of the user. Email addresses must be unique across users.</param>
+/// <param name="IsSuperadmin">
+///     Whether the user is a superadmin. Only included when the caller has the necessary admin rights.
+/// </param>
+/// <param name="IsAccountant">
+///     Whether the user is an accountant. Only included when the caller has the necessary admin rights.
+/// </param>
+public sealed record User(
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("salutation_type")]
+    string? SalutationType,
+    [property: JsonPropertyName("firstname")]
+    string? Firstname,
+    [property: JsonPropertyName("lastname")]
+    string? Lastname,
+    [property: JsonPropertyName("email")] string Email,
+    [property: JsonPropertyName("is_superadmin")]
+    bool? IsSuperadmin,
+    [property: JsonPropertyName("is_accountant")]
+    bool? IsAccountant
+);

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -31,6 +31,7 @@ using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Interfaces.Connectors.Files;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
@@ -45,6 +46,7 @@ using BexioApiNet.Services.Connectors.Banking;
 using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
+using BexioApiNet.Services.Connectors.Files;
 using BexioApiNet.Services.Connectors.Items;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
@@ -164,6 +166,7 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<IFileService, FileService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -46,6 +47,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -164,6 +166,10 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<ILanguageService, LanguageService>();
+        services.AddScoped<ICommunicationTypeService, CommunicationTypeService>();
+        services.AddScoped<ICompanyProfileService, CompanyProfileService>();
+        services.AddScoped<IPermissionService, PermissionService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -46,6 +47,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -164,6 +166,7 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<ISalutationService, SalutationService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -46,6 +47,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -164,6 +166,8 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<IUserService, UserService>();
+        services.AddScoped<IFictionalUserService, FictionalUserService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -46,6 +47,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -164,6 +166,7 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<INoteService, NoteService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -31,6 +31,7 @@ using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Interfaces.Connectors.Files;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
@@ -45,6 +46,7 @@ using BexioApiNet.Services.Connectors.Banking;
 using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
+using BexioApiNet.Services.Connectors.Files;
 using BexioApiNet.Services.Connectors.Items;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
@@ -164,6 +166,8 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<IDocumentSettingService, DocumentSettingService>();
+        services.AddScoped<IDocumentTemplateService, DocumentTemplateService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -46,6 +47,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -164,6 +166,7 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<ICountryService, CountryService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -46,6 +47,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -164,6 +166,7 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<ICommentService, CommentService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
+++ b/src/BexioApiNet.AspNetCore/BexioServiceCollection.cs
@@ -32,6 +32,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -46,6 +47,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -164,6 +166,7 @@ public static class BexioServiceCollection
         services.AddScoped<IEmployeeService, EmployeeService>();
         services.AddScoped<IAbsenceService, AbsenceService>();
         services.AddScoped<IPaystubService, PaystubService>();
+        services.AddScoped<ITitleService, TitleService>();
         services.AddScoped<IBexioApiClient, BexioApiClient>();
 
         return services;

--- a/src/BexioApiNet/Interfaces/Connectors/Files/IDocumentSettingService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Files/IDocumentSettingService.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.DocumentSettings;
+
+namespace BexioApiNet.Interfaces.Connectors.Files;
+
+/// <summary>
+/// Read-only service for the Bexio document settings (a.k.a. <c>kb_item_setting</c>) lookup endpoint.
+/// <see href="https://docs.bexio.com/#tag/Document-Settings">Document Settings</see>
+/// </summary>
+public interface IDocumentSettingService
+{
+    /// <summary>
+    /// List all document settings.
+    /// <see href="https://docs.bexio.com/#tag/Document-Settings/operation/v2ListDocumentSettings">v2 List Document Settings</see>
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The list of document settings.</returns>
+    public Task<ApiResult<List<DocumentSetting>>> Get([Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Files/IDocumentTemplateService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Files/IDocumentTemplateService.cs
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.DocumentTemplates;
+
+namespace BexioApiNet.Interfaces.Connectors.Files;
+
+/// <summary>
+/// Read-only service for the Bexio document templates lookup endpoint.
+/// <see href="https://docs.bexio.com/#tag/Document-templates">Document templates</see>
+/// </summary>
+public interface IDocumentTemplateService
+{
+    /// <summary>
+    /// List all document templates.
+    /// <see href="https://docs.bexio.com/#tag/Document-templates/operation/v3ListDocumentTemplate">v3 List Document Templates</see>
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The list of document templates.</returns>
+    public Task<ApiResult<List<DocumentTemplate>>> Get([Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/Files/IFileService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/Files/IFileService.cs
@@ -1,0 +1,137 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.Files.Views;
+using BexioApiNet.Models;
+using BexioFile = BexioApiNet.Abstractions.Models.Files.Files.File;
+using FileUsage = BexioApiNet.Abstractions.Models.Files.Files.FileUsage;
+
+namespace BexioApiNet.Interfaces.Connectors.Files;
+
+/// <summary>
+///     Service for the Bexio files endpoints. <see href="https://docs.bexio.com/#tag/Files">Files</see>
+/// </summary>
+public interface IFileService
+{
+    /// <summary>
+    ///     List files uploaded for the current company.
+    ///     <see href="https://docs.bexio.com/#tag/Files/operation/v3ReadFiles">List Files</see>
+    /// </summary>
+    /// <param name="queryParameterFile">Optional query parameters (offset/order_by/archived_state).</param>
+    /// <param name="autoPage">
+    ///     When <see langword="true" />, transparently pages through all remaining results via
+    ///     <c>X-Total-Count</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> with the full page (or all pages) of files.</returns>
+    public Task<ApiResult<List<BexioFile>?>> Get([Optional] QueryParameterFile? queryParameterFile,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single file by id. <see href="https://docs.bexio.com/#tag/Files/operation/v3ReadFile">Show File</see>
+    /// </summary>
+    /// <param name="id">The file id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The file metadata as returned by Bexio.</returns>
+    public Task<ApiResult<BexioFile>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Download the raw binary content of a file.
+    ///     <see href="https://docs.bexio.com/#tag/Files/operation/v3DownloadFile">Download File</see>
+    /// </summary>
+    /// <param name="id">The file id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> whose <c>Data</c> contains the file bytes on success.</returns>
+    public Task<ApiResult<byte[]>> Download(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Download a preview rendering of a file.
+    ///     <see href="https://docs.bexio.com/#tag/Files/operation/v3PreviewFile">Preview File</see>
+    /// </summary>
+    /// <param name="id">The file id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> whose <c>Data</c> contains the preview bytes on success.</returns>
+    public Task<ApiResult<byte[]>> Preview(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Show usage information for a file (which document it is attached to).
+    ///     <see href="https://docs.bexio.com/#tag/Files/operation/v3ShowFile">Show File Usage</see>
+    /// </summary>
+    /// <param name="id">The file id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The file's usage information.</returns>
+    public Task<ApiResult<FileUsage>> Usage(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Upload one or more files as a multipart/form-data payload.
+    ///     <see href="https://docs.bexio.com/#tag/Files/operation/v3CreateFile">Create File</see>
+    /// </summary>
+    /// <param name="files">The files to upload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created file metadata as returned by Bexio.</returns>
+    public Task<ApiResult<IReadOnlyList<BexioFile>>> Upload(List<FileInfo> files,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Upload one or more files as a multipart/form-data payload using in-memory streams.
+    ///     <see href="https://docs.bexio.com/#tag/Files/operation/v3CreateFile">Create File</see>
+    /// </summary>
+    /// <param name="files">The files to upload, each paired with its filename.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created file metadata as returned by Bexio.</returns>
+    public Task<ApiResult<IReadOnlyList<BexioFile>>> Upload(List<Tuple<MemoryStream, string>> files,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Search files by criteria. <see href="https://docs.bexio.com/#tag/Files/operation/v3SearchFile">Search Files</see>
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria submitted as the JSON array body.</param>
+    /// <param name="queryParameterFile">Optional query parameters (limit/offset/archived_state).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching files.</returns>
+    public Task<ApiResult<List<BexioFile>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterFile? queryParameterFile, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Update an existing file's metadata.
+    ///     <see href="https://docs.bexio.com/#tag/Files/operation/v3UpdateFile">Update File</see>
+    /// </summary>
+    /// <param name="id">The file id.</param>
+    /// <param name="payload">The file patch payload; only supplied fields are updated.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The updated file metadata as returned by Bexio.</returns>
+    public Task<ApiResult<BexioFile>> Patch(int id, FilePatch payload, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Delete a file. Sets the file state to deleted; cannot be undone.
+    ///     <see href="https://docs.bexio.com/#tag/Files/operation/v3DeleteFile">Delete File</see>
+    /// </summary>
+    /// <param name="id">The file id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> carrying Bexio's <c>{ "success": true }</c> payload.</returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/ICommentService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/ICommentService.cs
@@ -1,0 +1,73 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.MasterData;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Comments;
+using BexioApiNet.Abstractions.Models.MasterData.Comments.Views;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+/// Service for fetching and creating comments on Bexio documents (offers, orders, invoices).
+/// All routes follow the <c>/2.0/{kb_document_type}/{document_id}/comment</c> shape; the
+/// discriminator lives in the URL.
+/// <see href="https://docs.bexio.com/#tag/Comments">Comments</see>
+/// </summary>
+public interface ICommentService
+{
+    /// <summary>
+    /// Fetch a list of comments for the given document.
+    /// <see href="https://docs.bexio.com/#tag/Comments/operation/v2ListComments">List Comments</see>
+    /// </summary>
+    /// <param name="kbDocumentType">The document-type discriminator (offer, order, invoice).</param>
+    /// <param name="documentId">The id of the parent document.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Comment>?>> Get(KbDocumentType kbDocumentType, int documentId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single comment for the given document.
+    /// <see href="https://docs.bexio.com/#tag/Comments/operation/v2ShowComment">Show Comment</see>
+    /// </summary>
+    /// <param name="kbDocumentType">The document-type discriminator (offer, order, invoice).</param>
+    /// <param name="documentId">The id of the parent document.</param>
+    /// <param name="commentId">The id of the comment.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Comment>> GetById(KbDocumentType kbDocumentType, int documentId, int commentId, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create a new comment on the given document.
+    /// <see href="https://docs.bexio.com/#tag/Comments/operation/v2CreateComment">Create Comment</see>
+    /// </summary>
+    /// <param name="kbDocumentType">The document-type discriminator (offer, order, invoice).</param>
+    /// <param name="documentId">The id of the parent document.</param>
+    /// <param name="payload">Create view of the comment.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Comment>> Create(KbDocumentType kbDocumentType, int documentId, CommentCreate payload, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/ICommunicationTypeService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/ICommunicationTypeService.cs
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.CommunicationTypes;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+/// Read-only lookup service for Bexio communication types. Bexio exposes the resource under
+/// the legacy path segment <c>/2.0/communication_kind</c> while the documented concept is
+/// "communication type".
+/// <see href="https://docs.bexio.com/#tag/Communication-Types"/>
+/// </summary>
+public interface ICommunicationTypeService
+{
+    /// <summary>
+    /// Fetch a list of communication types. <see href="https://docs.bexio.com/#tag/Communication-Types/operation/v2ListCommunicationTypes">List Communication Types</see>
+    /// </summary>
+    /// <param name="queryParameterCommunicationType">Query parameters (pagination / ordering).</param>
+    /// <param name="autoPage">Fetch all possible results.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of communication types.</returns>
+    public Task<ApiResult<List<CommunicationType>?>> Get([Optional] QueryParameterCommunicationType? queryParameterCommunicationType, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search communication types. <see href="https://docs.bexio.com/#tag/Communication-Types/operation/v2SearchCommunicationTypes">Search Communication Types</see>
+    /// Supported search fields: <c>name</c>.
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria sent as JSON body.</param>
+    /// <param name="queryParameterCommunicationType">Optional pagination / ordering parameters appended to the URI.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of matched communication types.</returns>
+    public Task<ApiResult<List<CommunicationType>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterCommunicationType? queryParameterCommunicationType, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/ICompanyProfileService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/ICompanyProfileService.cs
@@ -1,0 +1,55 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.CompanyProfiles;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+/// Read-only lookup service for the Bexio company profile, exposed under
+/// <c>/2.0/company_profile</c>. Each Bexio account currently owns exactly one
+/// profile but the list endpoint still returns it as an array.
+/// <see href="https://docs.bexio.com/#tag/Company-Profile"/>
+/// </summary>
+public interface ICompanyProfileService
+{
+    /// <summary>
+    /// Fetch the list of company profiles. <see href="https://docs.bexio.com/#tag/Company-Profile/operation/v2ListCompanyProfile">List Company Profile</see>
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of company profiles.</returns>
+    public Task<ApiResult<List<CompanyProfile>?>> Get([Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fetch a single company profile by its identifier.
+    /// <see href="https://docs.bexio.com/#tag/Company-Profile/operation/v2ShowCompanyProfile">Show Company Profile</see>
+    /// </summary>
+    /// <param name="id">ID of the company profile to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the company profile.</returns>
+    public Task<ApiResult<CompanyProfile>> GetById(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/ICountryService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/ICountryService.cs
@@ -1,0 +1,98 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Countries;
+using BexioApiNet.Abstractions.Models.MasterData.Countries.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+///     Service for managing countries. <see href="https://docs.bexio.com/#tag/Countries">Countries</see>
+/// </summary>
+public interface ICountryService
+{
+    /// <summary>
+    ///     Fetch a list of countries.
+    ///     <see href="https://docs.bexio.com/#tag/Countries/operation/v2ListCountries">List Countries</see>
+    /// </summary>
+    /// <param name="queryParameterCountry">Query parameter specific for country</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Country>?>> Get([Optional] QueryParameterCountry? queryParameterCountry,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single country by id.
+    ///     <see href="https://docs.bexio.com/#tag/Countries/operation/v2ShowCountry">Show Country</see>
+    /// </summary>
+    /// <param name="id">The country id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Country?>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create a country.
+    ///     <see href="https://docs.bexio.com/#tag/Countries/operation/v2CreateCountry">Create Country</see>
+    /// </summary>
+    /// <param name="country">Create view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Country>> Create(CountryCreate country, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Search countries.
+    ///     <see href="https://docs.bexio.com/#tag/Countries/operation/v2SearchCountries">Search Countries</see>
+    /// </summary>
+    /// <param name="searchCriteria">The search criteria list. Supported fields: <c>name</c>, <c>name_short</c>.</param>
+    /// <param name="queryParameterCountry">Optional pagination parameters</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Country>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterCountry? queryParameterCountry, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Update (edit) a country.
+    ///     <see href="https://docs.bexio.com/#tag/Countries/operation/v2EditCountry">Edit Country</see>
+    /// </summary>
+    /// <param name="id">The country id</param>
+    /// <param name="country">Update view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Country>> Update(int id, CountryUpdate country,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Delete a country.
+    ///     <see href="https://docs.bexio.com/#tag/Countries/operation/DeleteCountry">Delete Country</see>
+    /// </summary>
+    /// <param name="id">The country id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/IFictionalUserService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/IFictionalUserService.cs
@@ -1,0 +1,100 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.FictionalUsers;
+using BexioApiNet.Abstractions.Models.MasterData.FictionalUsers.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+///     Service for managing Bexio fictional user accounts.
+///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management">Fictional User Management</see>
+/// </summary>
+public interface IFictionalUserService
+{
+    /// <summary>
+    ///     Get a list of fictional users.
+    ///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management/operation/v3ListFictionalUsers">
+    ///         List Fictional Users
+    ///     </see>
+    /// </summary>
+    /// <param name="queryParameterFictionalUser">Optional pagination query parameters.</param>
+    /// <param name="autoPage">Fetch all remaining pages automatically when <c>true</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> wrapping the list of fictional users.</returns>
+    public Task<ApiResult<List<FictionalUser>>> Get([Optional] QueryParameterFictionalUser? queryParameterFictionalUser,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single fictional user by id.
+    ///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management/operation/v3ShowFictionalUser">
+    ///         Show Fictional User
+    ///     </see>
+    /// </summary>
+    /// <param name="id">The id of the fictional user.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> wrapping the fictional user.</returns>
+    public Task<ApiResult<FictionalUser>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create a new fictional user.
+    ///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management/operation/v3CreateFictionalUser">
+    ///         Create Fictional User
+    ///     </see>
+    /// </summary>
+    /// <param name="fictionalUser">Create view describing the new fictional user.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> wrapping the created fictional user.</returns>
+    public Task<ApiResult<FictionalUser>> Create(FictionalUserCreate fictionalUser,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Partially update an existing fictional user. Only the non-null fields on the patch view
+    ///     are serialized and sent to Bexio; unspecified fields retain their current server-side value.
+    ///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management/operation/v3EditFictionalUser">
+    ///         Edit Fictional User
+    ///     </see>
+    /// </summary>
+    /// <param name="id">The id of the fictional user to update.</param>
+    /// <param name="fictionalUser">Patch view describing the fields to update.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> wrapping the updated fictional user.</returns>
+    public Task<ApiResult<FictionalUser>> Patch(int id, FictionalUserPatch fictionalUser,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Permanently delete a fictional user by id. This cannot be undone.
+    ///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management/operation/v3DeleteFictionalUser">
+    ///         Delete Fictional User
+    ///     </see>
+    /// </summary>
+    /// <param name="id">The id of the fictional user to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> indicating the outcome of the delete.</returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/ILanguageService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/ILanguageService.cs
@@ -1,0 +1,57 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Languages;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+/// Read-only lookup service for Bexio languages, exposed under <c>/2.0/language</c>.
+/// <see href="https://docs.bexio.com/#tag/Languages">Languages</see>
+/// </summary>
+public interface ILanguageService
+{
+    /// <summary>
+    /// Fetch a list of languages. <see href="https://docs.bexio.com/#tag/Languages/operation/v2ListLanguages">List Languages</see>
+    /// </summary>
+    /// <param name="queryParameterLanguage">Query parameters (pagination / ordering).</param>
+    /// <param name="autoPage">Fetch all possible results.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of languages.</returns>
+    public Task<ApiResult<List<Language>?>> Get([Optional] QueryParameterLanguage? queryParameterLanguage, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Search languages. <see href="https://docs.bexio.com/#tag/Languages/operation/v2SearchLanguages">Search Languages</see>
+    /// Supported search fields: <c>name</c>, <c>iso_639_1</c>.
+    /// </summary>
+    /// <param name="searchCriteria">Search criteria sent as JSON body.</param>
+    /// <param name="queryParameterLanguage">Optional pagination / ordering parameters appended to the URI.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the list of matched languages.</returns>
+    public Task<ApiResult<List<Language>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterLanguage? queryParameterLanguage, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/INoteService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/INoteService.cs
@@ -1,0 +1,94 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Notes;
+using BexioApiNet.Abstractions.Models.MasterData.Notes.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+///     Service for managing notes. <see href="https://docs.bexio.com/#tag/Notes">Notes</see>
+/// </summary>
+public interface INoteService
+{
+    /// <summary>
+    ///     Fetch a list of notes. <see href="https://docs.bexio.com/#tag/Notes/operation/v2ListNotes">List Notes</see>
+    /// </summary>
+    /// <param name="queryParameterNote">Query parameter specific for note</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Note>?>> Get([Optional] QueryParameterNote? queryParameterNote, [Optional] bool autoPage,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single note by id. <see href="https://docs.bexio.com/#tag/Notes/operation/v2ShowNote">Show Note</see>
+    /// </summary>
+    /// <param name="id">The note id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Note?>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create a note. <see href="https://docs.bexio.com/#tag/Notes/operation/v2CreateNote">Create Note</see>
+    /// </summary>
+    /// <param name="note">Create view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Note>> Create(NoteCreate note, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Search notes. <see href="https://docs.bexio.com/#tag/Notes/operation/v2SearchNotes">Search Notes</see>
+    /// </summary>
+    /// <param name="searchCriteria">
+    ///     The search criteria list. Supported fields: <c>event_start</c>, <c>contact_id</c>,
+    ///     <c>user_id</c>, <c>subject</c>, <c>module_id</c>, <c>entry_id</c>.
+    /// </param>
+    /// <param name="queryParameterNote">Optional pagination parameters</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Note>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterNote? queryParameterNote, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Update (edit) a note. <see href="https://docs.bexio.com/#tag/Notes/operation/v2EditNote">Edit Note</see>
+    /// </summary>
+    /// <param name="id">The note id</param>
+    /// <param name="note">Update view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Note>> Update(int id, NoteUpdate note, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Delete a note. <see href="https://docs.bexio.com/#tag/Notes/operation/DeleteNote">Delete Note</see>
+    /// </summary>
+    /// <param name="id">The note id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/IPermissionService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/IPermissionService.cs
@@ -1,0 +1,46 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Permissions;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+/// Read-only lookup service for the access information of the currently signed-in user.
+/// The Bexio <c>/3.0/permissions</c> route is a singleton (no id parameter).
+/// <see href="https://docs.bexio.com/#tag/Permissions"/>
+/// </summary>
+public interface IPermissionService
+{
+    /// <summary>
+    /// Get components and user permissions of the signed-in user.
+    /// <see href="https://docs.bexio.com/#tag/Permissions/operation/Permissions">Get permissions</see>
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}"/> wrapping the caller's <see cref="Permission"/> set.</returns>
+    public Task<ApiResult<Permission>> Get([Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/ISalutationService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/ISalutationService.cs
@@ -1,0 +1,99 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Salutations;
+using BexioApiNet.Abstractions.Models.MasterData.Salutations.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+///     Service for managing salutations. <see href="https://docs.bexio.com/#tag/Salutations">Salutations</see>
+/// </summary>
+public interface ISalutationService
+{
+    /// <summary>
+    ///     Fetch a list of salutations.
+    ///     <see href="https://docs.bexio.com/#tag/Salutations/operation/v2ListSalutations">List Salutations</see>
+    /// </summary>
+    /// <param name="queryParameterSalutation">Query parameter specific for salutation</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Salutation>?>> Get([Optional] QueryParameterSalutation? queryParameterSalutation,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single salutation by id.
+    ///     <see href="https://docs.bexio.com/#tag/Salutations/operation/v2ShowSalutation">Show Salutation</see>
+    /// </summary>
+    /// <param name="id">The salutation id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Salutation?>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create a salutation.
+    ///     <see href="https://docs.bexio.com/#tag/Salutations/operation/v2CreateSalutation">Create Salutation</see>
+    /// </summary>
+    /// <param name="salutation">Create view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Salutation>> Create(SalutationCreate salutation,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Search salutations.
+    ///     <see href="https://docs.bexio.com/#tag/Salutations/operation/v2SearchSalutations">Search Salutations</see>
+    /// </summary>
+    /// <param name="searchCriteria">The search criteria list. Supported fields: <c>name</c>.</param>
+    /// <param name="queryParameterSalutation">Optional pagination parameters</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Salutation>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterSalutation? queryParameterSalutation, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Update (edit) a salutation.
+    ///     <see href="https://docs.bexio.com/#tag/Salutations/operation/v2EditSalutation">Edit Salutation</see>
+    /// </summary>
+    /// <param name="id">The salutation id</param>
+    /// <param name="salutation">Update view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Salutation>> Update(int id, SalutationUpdate salutation,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Delete a salutation.
+    ///     <see href="https://docs.bexio.com/#tag/Salutations/operation/v2DeleteSalutation">Delete Salutation</see>
+    /// </summary>
+    /// <param name="id">The salutation id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/ITitleService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/ITitleService.cs
@@ -1,0 +1,92 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Titles;
+using BexioApiNet.Abstractions.Models.MasterData.Titles.Views;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+///     Service for managing titles. <see href="https://docs.bexio.com/#tag/Titles">Titles</see>
+/// </summary>
+public interface ITitleService
+{
+    /// <summary>
+    ///     Fetch a list of titles. <see href="https://docs.bexio.com/#tag/Titles/operation/v2ListTitles">List Titles</see>
+    /// </summary>
+    /// <param name="queryParameterTitle">Query parameter specific for title</param>
+    /// <param name="autoPage">Fetch all possible results</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Title>?>> Get([Optional] QueryParameterTitle? queryParameterTitle,
+        [Optional] bool autoPage,
+        [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single title by id. <see href="https://docs.bexio.com/#tag/Titles/operation/v2ShowTitle">Show Title</see>
+    /// </summary>
+    /// <param name="id">The title id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Title?>> GetById(int id, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Create a title. <see href="https://docs.bexio.com/#tag/Titles/operation/v2CreateTitle">Create Title</see>
+    /// </summary>
+    /// <param name="title">Create view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Title>> Create(TitleCreate title, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Search titles. <see href="https://docs.bexio.com/#tag/Titles/operation/v2SearchTitles">Search Titles</see>
+    /// </summary>
+    /// <param name="searchCriteria">The search criteria list. Supported fields: <c>name</c>.</param>
+    /// <param name="queryParameterTitle">Optional pagination parameters</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<List<Title>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterTitle? queryParameterTitle, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Update (edit) a title. <see href="https://docs.bexio.com/#tag/Titles/operation/v2EditTitle">Edit Title</see>
+    /// </summary>
+    /// <param name="id">The title id</param>
+    /// <param name="title">Update view</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<Title>> Update(int id, TitleUpdate title, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Delete a title. <see href="https://docs.bexio.com/#tag/Titles/operation/v2DeleteTitle">Delete Title</see>
+    /// </summary>
+    /// <param name="id">The title id</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    public Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/Connectors/MasterData/IUserService.cs
+++ b/src/BexioApiNet/Interfaces/Connectors/MasterData/IUserService.cs
@@ -1,0 +1,66 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Users;
+using BexioApiNet.Models;
+
+namespace BexioApiNet.Interfaces.Connectors.MasterData;
+
+/// <summary>
+///     Service for reading Bexio user accounts.
+///     <see href="https://docs.bexio.com/#tag/User-Management">User Management</see>
+/// </summary>
+public interface IUserService
+{
+    /// <summary>
+    ///     Get a list of users.
+    ///     <see href="https://docs.bexio.com/#tag/User-Management/operation/v3ListUsers">List Users</see>
+    /// </summary>
+    /// <param name="queryParameterUser">Optional pagination query parameters.</param>
+    /// <param name="autoPage">Fetch all remaining pages automatically when <c>true</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> wrapping the list of users.</returns>
+    public Task<ApiResult<List<User>>> GetAll([Optional] QueryParameterUser? queryParameterUser,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch the authenticated user (singleton <c>/users/me</c> endpoint).
+    ///     <see href="https://docs.bexio.com/#tag/User-Management/operation/v3ShowLoggedInUser">Show Logged-in User</see>
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> wrapping the logged-in user.</returns>
+    public Task<ApiResult<User>> GetMe([Optional] CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Fetch a single user by id.
+    ///     <see href="https://docs.bexio.com/#tag/User-Management/operation/v3ShowUser">Show User</see>
+    /// </summary>
+    /// <param name="id">The id of the user.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiResult{T}" /> wrapping the user.</returns>
+    public Task<ApiResult<User>> GetById(int id, [Optional] CancellationToken cancellationToken);
+}

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -312,4 +313,10 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio titles connector (honorifics such as "Dr." or "Prof.").
+    ///     <see href="https://docs.bexio.com/#tag/Titles">Titles</see>
+    /// </summary>
+    public ITitleService Titles { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -319,6 +319,8 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio files connector. <see href="https://docs.bexio.com/#tag/Files">Files</see>
     /// </summary>
     public IFileService Files { get; set; }
+
+    /// <summary>
     ///     Bexio document settings connector (<c>kb_item_setting</c> lookup).
     ///     <see href="https://docs.bexio.com/#tag/Document-Settings">Document Settings</see>
     /// </summary>
@@ -329,16 +331,24 @@ public interface IBexioApiClient : IDisposable
     ///     <see href="https://docs.bexio.com/#tag/Document-templates">Document templates</see>
     /// </summary>
     public IDocumentTemplateService DocumentTemplates { get; set; }
+
+    /// <summary>
     ///     Bexio countries connector. <see href="https://docs.bexio.com/#tag/Countries">Countries</see>
     /// </summary>
     public ICountryService Countries { get; set; }
+
+    /// <summary>
     ///     Bexio salutations connector. <see href="https://docs.bexio.com/#tag/Salutations">Salutations</see>
     /// </summary>
     public ISalutationService Salutations { get; set; }
+
+    /// <summary>
     ///     Bexio titles connector (honorifics such as "Dr." or "Prof.").
     ///     <see href="https://docs.bexio.com/#tag/Titles">Titles</see>
     /// </summary>
     public ITitleService Titles { get; set; }
+
+    /// <summary>
     ///     Bexio languages connector (read-only lookup). <see href="https://docs.bexio.com/#tag/Languages">Languages</see>
     /// </summary>
     public ILanguageService Languages { get; set; }
@@ -359,6 +369,8 @@ public interface IBexioApiClient : IDisposable
     ///     <see href="https://docs.bexio.com/#tag/Permissions">Permissions</see>
     /// </summary>
     public IPermissionService Permissions { get; set; }
+
+    /// <summary>
     ///     Bexio users connector (read-only v3.0 user management).
     ///     <see href="https://docs.bexio.com/#tag/User-Management">User Management</see>
     /// </summary>
@@ -369,9 +381,13 @@ public interface IBexioApiClient : IDisposable
     ///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management">Fictional User Management</see>
     /// </summary>
     public IFictionalUserService FictionalUsers { get; set; }
+
+    /// <summary>
     ///     Bexio notes connector. <see href="https://docs.bexio.com/#tag/Notes">Notes</see>
     /// </summary>
     public INoteService Notes { get; set; }
+
+    /// <summary>
     ///     Bexio document comments connector. <see href="https://docs.bexio.com/#tag/Comments">Comments</see>
     /// </summary>
     public ICommentService Comments { get; set; }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -312,4 +313,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio salutations connector. <see href="https://docs.bexio.com/#tag/Salutations">Salutations</see>
+    /// </summary>
+    public ISalutationService Salutations { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -28,6 +28,7 @@ using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Interfaces.Connectors.Files;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
@@ -312,4 +313,16 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio document settings connector (<c>kb_item_setting</c> lookup).
+    ///     <see href="https://docs.bexio.com/#tag/Document-Settings">Document Settings</see>
+    /// </summary>
+    public IDocumentSettingService DocumentSettings { get; set; }
+
+    /// <summary>
+    ///     Bexio document templates connector.
+    ///     <see href="https://docs.bexio.com/#tag/Document-templates">Document templates</see>
+    /// </summary>
+    public IDocumentTemplateService DocumentTemplates { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -28,6 +28,7 @@ using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Interfaces.Connectors.Files;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
@@ -312,4 +313,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio files connector. <see href="https://docs.bexio.com/#tag/Files">Files</see>
+    /// </summary>
+    public IFileService Files { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -312,4 +313,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio countries connector. <see href="https://docs.bexio.com/#tag/Countries">Countries</see>
+    /// </summary>
+    public ICountryService Countries { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -312,4 +313,26 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio languages connector (read-only lookup). <see href="https://docs.bexio.com/#tag/Languages">Languages</see>
+    /// </summary>
+    public ILanguageService Languages { get; set; }
+
+    /// <summary>
+    ///     Bexio communication types connector (read-only lookup). Exposed under the <c>/2.0/communication_kind</c> route.
+    ///     <see href="https://docs.bexio.com/#tag/Communication-Types">Communication Types</see>
+    /// </summary>
+    public ICommunicationTypeService CommunicationTypes { get; set; }
+
+    /// <summary>
+    ///     Bexio company profile connector (read-only lookup). <see href="https://docs.bexio.com/#tag/Company-Profile">Company Profile</see>
+    /// </summary>
+    public ICompanyProfileService CompanyProfiles { get; set; }
+
+    /// <summary>
+    ///     Bexio permissions connector (read-only singleton for the signed-in user).
+    ///     <see href="https://docs.bexio.com/#tag/Permissions">Permissions</see>
+    /// </summary>
+    public IPermissionService Permissions { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -312,4 +313,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio notes connector. <see href="https://docs.bexio.com/#tag/Notes">Notes</see>
+    /// </summary>
+    public INoteService Notes { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -312,4 +313,9 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio document comments connector. <see href="https://docs.bexio.com/#tag/Comments">Comments</see>
+    /// </summary>
+    public ICommentService Comments { get; set; }
 }

--- a/src/BexioApiNet/Interfaces/IBexioApiClient.cs
+++ b/src/BexioApiNet/Interfaces/IBexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -312,4 +313,16 @@ public interface IBexioApiClient : IDisposable
     ///     Bexio payroll paystubs connector. <see href="https://docs.bexio.com/#tag/Paystubs">Paystubs</see>
     /// </summary>
     public IPaystubService PayrollPaystubs { get; set; }
+
+    /// <summary>
+    ///     Bexio users connector (read-only v3.0 user management).
+    ///     <see href="https://docs.bexio.com/#tag/User-Management">User Management</see>
+    /// </summary>
+    public IUserService Users { get; set; }
+
+    /// <summary>
+    ///     Bexio fictional users connector (v3.0 fictional user management).
+    ///     <see href="https://docs.bexio.com/#tag/Fictional-User-Management">Fictional User Management</see>
+    /// </summary>
+    public IFictionalUserService FictionalUsers { get; set; }
 }

--- a/src/BexioApiNet/Models/QueryParameterCommunicationType.cs
+++ b/src/BexioApiNet/Models/QueryParameterCommunicationType.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters on communication type endpoints
+/// (<c>GET /2.0/communication_kind</c> and <c>POST /2.0/communication_kind/search</c>).
+/// </summary>
+/// <param name="Limit">Limit the number of results (Bexio max is 2000).</param>
+/// <param name="Offset">Skip over the given number of elements before returning results.</param>
+public sealed record QueryParameterCommunicationType(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    /// Parameter dictionary rendered onto the request URI by the connection handler.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Models/QueryParameterCountry.cs
+++ b/src/BexioApiNet/Models/QueryParameterCountry.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Dictionary for optional query parameters on country endpoints
+///     (<c>GET /2.0/country</c> and <c>POST /2.0/country/search</c>).
+/// </summary>
+/// <param name="Limit">Limit the number of results (Bexio max is 2000).</param>
+/// <param name="Offset">Skip over the given number of elements before returning results.</param>
+public sealed record QueryParameterCountry(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    ///     Parameter dictionary rendered onto the request URI by the connection handler.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(new Dictionary<string, object>
+        {
+            { "limit", Limit },
+            { "offset", Offset }
+        });
+}

--- a/src/BexioApiNet/Models/QueryParameterFictionalUser.cs
+++ b/src/BexioApiNet/Models/QueryParameterFictionalUser.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Pagination query parameters for <c>GET /3.0/fictional_users</c>.
+/// </summary>
+/// <param name="Limit">Maximum number of fictional users to return. Bexio default is 500, maximum is 2000.</param>
+/// <param name="Offset">Number of fictional users to skip over before starting the result page.</param>
+public sealed record QueryParameterFictionalUser(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    ///     Wraps the pagination fields in the generic <see cref="Models.QueryParameter" />
+    ///     dictionary consumed by <c>BexioConnectionHandler</c>.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(new Dictionary<string, object>
+        {
+            { "limit", Limit },
+            { "offset", Offset }
+        });
+}

--- a/src/BexioApiNet/Models/QueryParameterFile.cs
+++ b/src/BexioApiNet/Models/QueryParameterFile.cs
@@ -1,0 +1,75 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Typed query parameter wrapper for the Bexio files endpoints
+///     (<c>GET /3.0/files</c> and <c>POST /3.0/files/search</c>).
+///     Each constructor argument is optional so callers can supply only the parameters they need;
+///     <see langword="null" /> values are skipped and not serialized onto the URL.
+/// </summary>
+/// <param name="Limit">
+///     Maximum number of results to return (accepted by <c>/search</c>, Bexio default <c>500</c>, maximum
+///     <c>2000</c>).
+/// </param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+/// <param name="OrderBy">
+///     Sort clause — one of <c>id</c>, <c>created_at</c>, <c>source_id</c>, <c>uuid</c>, <c>name</c>,
+///     <c>size_in_bytes</c>, optionally with <c>_asc</c>/<c>_desc</c> suffixes.
+/// </param>
+/// <param name="ArchivedState">Archived filter — one of <c>all</c>, <c>archived</c>, <c>not_archived</c>.</param>
+public sealed record QueryParameterFile(
+    int? Limit = null,
+    int? Offset = null,
+    string? OrderBy = null,
+    string? ArchivedState = null
+)
+{
+    /// <summary>
+    ///     The underlying <see cref="Models.QueryParameter" /> passed to <see cref="Interfaces.IBexioConnectionHandler" />.
+    ///     <see langword="null" /> when every input is <see langword="null" /> so the handler appends no query string.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset, OrderBy, ArchivedState);
+
+    private static QueryParameter? BuildQueryParameter(int? limit, int? offset, string? orderBy, string? archivedState)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l)
+            parameters["limit"] = l;
+
+        if (offset is { } o)
+            parameters["offset"] = o;
+
+        if (!string.IsNullOrWhiteSpace(orderBy))
+            parameters["order_by"] = orderBy;
+
+        if (!string.IsNullOrWhiteSpace(archivedState))
+            parameters["archived_state"] = archivedState;
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+}

--- a/src/BexioApiNet/Models/QueryParameterLanguage.cs
+++ b/src/BexioApiNet/Models/QueryParameterLanguage.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+/// Dictionary for optional query parameters on language endpoints
+/// (<c>GET /2.0/language</c> and <c>POST /2.0/language/search</c>).
+/// </summary>
+/// <param name="Limit">Limit the number of results (Bexio max is 2000).</param>
+/// <param name="Offset">Skip over the given number of elements before returning results.</param>
+public sealed record QueryParameterLanguage(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    /// Parameter dictionary rendered onto the request URI by the connection handler.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(Parameters: new()
+        {
+            {"limit", Limit},
+            {"offset", Offset}
+        });
+};

--- a/src/BexioApiNet/Models/QueryParameterNote.cs
+++ b/src/BexioApiNet/Models/QueryParameterNote.cs
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Typed query parameter wrapper for the Bexio notes endpoints
+///     (<c>GET /2.0/note</c> and <c>POST /2.0/note/search</c>).
+///     Each constructor argument is optional so callers can supply only the parameters they need;
+///     <see langword="null" /> values are skipped and not serialized onto the URL.
+/// </summary>
+/// <param name="Limit">Maximum number of results to return (Bexio default <c>500</c>, maximum <c>2000</c>).</param>
+/// <param name="Offset">Number of results to skip for pagination.</param>
+public sealed record QueryParameterNote(
+    int? Limit = null,
+    int? Offset = null
+)
+{
+    /// <summary>
+    ///     The underlying <see cref="Models.QueryParameter" /> passed to <see cref="Interfaces.IBexioConnectionHandler" />.
+    ///     <see langword="null" /> when every input is <see langword="null" /> so the handler appends no query string.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } = BuildQueryParameter(Limit, Offset);
+
+    private static QueryParameter? BuildQueryParameter(int? limit, int? offset)
+    {
+        var parameters = new Dictionary<string, object>();
+
+        if (limit is { } l)
+            parameters["limit"] = l;
+
+        if (offset is { } o)
+            parameters["offset"] = o;
+
+        return parameters.Count is 0 ? null : new QueryParameter(parameters);
+    }
+}

--- a/src/BexioApiNet/Models/QueryParameterSalutation.cs
+++ b/src/BexioApiNet/Models/QueryParameterSalutation.cs
@@ -1,0 +1,47 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Dictionary for optional query parameters for the salutations endpoint.
+/// </summary>
+/// <param name="Limit">Maximum number of results returned (Bexio default 500, max 2000).</param>
+/// <param name="Offset">Number of records to skip for pagination.</param>
+public sealed record QueryParameterSalutation(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    ///     The wrapped query parameter dictionary serialized onto the URL.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(new Dictionary<string, object>
+        {
+            { "limit", Limit },
+            { "offset", Offset }
+        });
+}

--- a/src/BexioApiNet/Models/QueryParameterTitle.cs
+++ b/src/BexioApiNet/Models/QueryParameterTitle.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Dictionary for optional query parameters for the titles endpoint.
+/// </summary>
+public sealed record QueryParameterTitle(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(new Dictionary<string, object>
+        {
+            { "limit", Limit },
+            { "offset", Offset }
+        });
+}

--- a/src/BexioApiNet/Models/QueryParameterUser.cs
+++ b/src/BexioApiNet/Models/QueryParameterUser.cs
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Models;
+
+/// <summary>
+///     Pagination query parameters for <c>GET /3.0/users</c>.
+/// </summary>
+/// <param name="Limit">Maximum number of users to return. Bexio default is 500, maximum is 2000.</param>
+/// <param name="Offset">Number of users to skip over before starting the result page.</param>
+public sealed record QueryParameterUser(
+    int Limit,
+    int Offset
+)
+{
+    /// <summary>
+    ///     Wraps the pagination fields in the generic <see cref="Models.QueryParameter" />
+    ///     dictionary consumed by <c>BexioConnectionHandler</c>.
+    /// </summary>
+    public QueryParameter? QueryParameter { get; } =
+        new(new Dictionary<string, object>
+        {
+            { "limit", Limit },
+            { "offset", Offset }
+        });
+}

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -201,6 +202,12 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public IUserService Users { get; set; }
+
+    /// <inheritdoc />
+    public IFictionalUserService FictionalUsers { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +263,9 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        IUserService users,
+        IFictionalUserService fictionalUsers)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +319,8 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        Users = users;
+        FictionalUsers = fictionalUsers;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Interfaces.Connectors.Files;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
@@ -201,6 +202,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public IFileService Files { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +260,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        IFileService files)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +315,7 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        Files = files;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -201,6 +202,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public INoteService Notes { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +260,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        INoteService notes)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +315,7 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        Notes = notes;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -201,6 +202,18 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public ILanguageService Languages { get; set; }
+
+    /// <inheritdoc />
+    public ICommunicationTypeService CommunicationTypes { get; set; }
+
+    /// <inheritdoc />
+    public ICompanyProfileService CompanyProfiles { get; set; }
+
+    /// <inheritdoc />
+    public IPermissionService Permissions { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +269,11 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        ILanguageService languages,
+        ICommunicationTypeService communicationTypes,
+        ICompanyProfileService companyProfiles,
+        IPermissionService permissions)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +327,10 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        Languages = languages;
+        CommunicationTypes = communicationTypes;
+        CompanyProfiles = companyProfiles;
+        Permissions = permissions;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Interfaces.Connectors.Files;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
@@ -201,6 +202,12 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public IDocumentSettingService DocumentSettings { get; set; }
+
+    /// <inheritdoc />
+    public IDocumentTemplateService DocumentTemplates { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +263,9 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        IDocumentSettingService documentSettings,
+        IDocumentTemplateService documentTemplates)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +319,8 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        DocumentSettings = documentSettings;
+        DocumentTemplates = documentTemplates;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -201,6 +202,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public ICountryService Countries { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +260,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        ICountryService countries)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +315,7 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        Countries = countries;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -201,6 +202,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public ICommentService Comments { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +260,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        ICommentService comments)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +315,7 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        Comments = comments;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -201,6 +202,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public ISalutationService Salutations { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +260,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        ISalutationService salutations)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +315,7 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        Salutations = salutations;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -205,13 +205,23 @@ public sealed class BexioApiClient : IBexioApiClient
 
     /// <inheritdoc />
     public IFileService Files { get; set; }
+
+    /// <inheritdoc />
     public IDocumentSettingService DocumentSettings { get; set; }
 
     /// <inheritdoc />
     public IDocumentTemplateService DocumentTemplates { get; set; }
+
+    /// <inheritdoc />
     public ICountryService Countries { get; set; }
+
+    /// <inheritdoc />
     public ISalutationService Salutations { get; set; }
+
+    /// <inheritdoc />
     public ITitleService Titles { get; set; }
+
+    /// <inheritdoc />
     public ILanguageService Languages { get; set; }
 
     /// <inheritdoc />
@@ -222,11 +232,17 @@ public sealed class BexioApiClient : IBexioApiClient
 
     /// <inheritdoc />
     public IPermissionService Permissions { get; set; }
+
+    /// <inheritdoc />
     public IUserService Users { get; set; }
 
     /// <inheritdoc />
     public IFictionalUserService FictionalUsers { get; set; }
+
+    /// <inheritdoc />
     public INoteService Notes { get; set; }
+
+    /// <inheritdoc />
     public ICommentService Comments { get; set; }
 
     /// <summary>
@@ -285,19 +301,19 @@ public sealed class BexioApiClient : IBexioApiClient
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
         IPaystubService payrollPaystubs,
-        IFileService files)
+        IFileService files,
         IDocumentSettingService documentSettings,
-        IDocumentTemplateService documentTemplates)
-        ICountryService countries)
-        ISalutationService salutations)
-        ITitleService titles)
+        IDocumentTemplateService documentTemplates,
+        ICountryService countries,
+        ISalutationService salutations,
+        ITitleService titles,
         ILanguageService languages,
         ICommunicationTypeService communicationTypes,
         ICompanyProfileService companyProfiles,
-        IPermissionService permissions)
+        IPermissionService permissions,
         IUserService users,
-        IFictionalUserService fictionalUsers)
-        INoteService notes)
+        IFictionalUserService fictionalUsers,
+        INoteService notes,
         ICommentService comments)
     {
         _bexioConnectionHandler = bexioConnectionHandler;

--- a/src/BexioApiNet/Services/BexioApiClient.cs
+++ b/src/BexioApiNet/Services/BexioApiClient.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -201,6 +202,9 @@ public sealed class BexioApiClient : IBexioApiClient
     /// <inheritdoc />
     public IPaystubService PayrollPaystubs { get; set; }
 
+    /// <inheritdoc />
+    public ITitleService Titles { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BexioApiClient"/> class.
     /// </summary>
@@ -256,7 +260,8 @@ public sealed class BexioApiClient : IBexioApiClient
         IExpenseService expenses,
         IEmployeeService payrollEmployees,
         IAbsenceService payrollAbsences,
-        IPaystubService payrollPaystubs)
+        IPaystubService payrollPaystubs,
+        ITitleService titles)
     {
         _bexioConnectionHandler = bexioConnectionHandler;
         BankingBankAccounts = bankingBankAccounts;
@@ -310,6 +315,7 @@ public sealed class BexioApiClient : IBexioApiClient
         PayrollEmployees = payrollEmployees;
         PayrollAbsences = payrollAbsences;
         PayrollPaystubs = payrollPaystubs;
+        Titles = titles;
     }
 
     /// <inheritdoc />

--- a/src/BexioApiNet/Services/Connectors/Files/DocumentSettingConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Files/DocumentSettingConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Files;
+
+/// <summary>
+/// Document setting endpoint configuration.
+/// </summary>
+public static class DocumentSettingConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path.
+    /// </summary>
+    public const string EndpointRoot = "kb_item_setting";
+}

--- a/src/BexioApiNet/Services/Connectors/Files/DocumentSettingService.cs
+++ b/src/BexioApiNet/Services/Connectors/Files/DocumentSettingService.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.DocumentSettings;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Files;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Files;
+
+/// <inheritdoc cref="IDocumentSettingService" />
+public sealed class DocumentSettingService : ConnectorService, IDocumentSettingService
+{
+    /// <summary>
+    /// The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = DocumentSettingConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path.
+    /// </summary>
+    private const string EndpointRoot = DocumentSettingConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public DocumentSettingService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<DocumentSetting>>> Get([Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<DocumentSetting>>($"{ApiVersion}/{EndpointRoot}", null, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Files/DocumentTemplateConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Files/DocumentTemplateConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Files;
+
+/// <summary>
+/// Document template endpoint configuration.
+/// </summary>
+public static class DocumentTemplateConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    /// The request path.
+    /// </summary>
+    public const string EndpointRoot = "document_templates";
+}

--- a/src/BexioApiNet/Services/Connectors/Files/DocumentTemplateService.cs
+++ b/src/BexioApiNet/Services/Connectors/Files/DocumentTemplateService.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.DocumentTemplates;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Files;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.Files;
+
+/// <inheritdoc cref="IDocumentTemplateService" />
+public sealed class DocumentTemplateService : ConnectorService, IDocumentTemplateService
+{
+    /// <summary>
+    /// The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = DocumentTemplateConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path.
+    /// </summary>
+    private const string EndpointRoot = DocumentTemplateConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public DocumentTemplateService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<DocumentTemplate>>> Get([Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<DocumentTemplate>>($"{ApiVersion}/{EndpointRoot}", null, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/Files/FileConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/Files/FileConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.Files;
+
+/// <summary>
+///     File endpoint configuration
+/// </summary>
+public static class FileConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    ///     The request path
+    /// </summary>
+    public const string EndpointRoot = "files";
+}

--- a/src/BexioApiNet/Services/Connectors/Files/FileService.cs
+++ b/src/BexioApiNet/Services/Connectors/Files/FileService.cs
@@ -1,0 +1,143 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.Files.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.Files;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+using BexioFile = BexioApiNet.Abstractions.Models.Files.Files.File;
+using FileUsage = BexioApiNet.Abstractions.Models.Files.Files.FileUsage;
+
+namespace BexioApiNet.Services.Connectors.Files;
+
+/// <inheritdoc cref="IFileService" />
+public sealed class FileService : ConnectorService, IFileService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = FileConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = FileConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public FileService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<BexioFile>?>> Get([Optional] QueryParameterFile? queryParameterFile,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<BexioFile>?>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterFile?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<BexioFile>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterFile?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<BexioFile>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<BexioFile>($"{ApiVersion}/{EndpointRoot}/{id}", null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<byte[]>> Download(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetBinaryAsync($"{ApiVersion}/{EndpointRoot}/{id}/download", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<byte[]>> Preview(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetBinaryAsync($"{ApiVersion}/{EndpointRoot}/{id}/preview", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<FileUsage>> Usage(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<FileUsage>($"{ApiVersion}/{EndpointRoot}/{id}/usage", null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<IReadOnlyList<BexioFile>>> Upload(List<FileInfo> files,
+        [Optional] CancellationToken cancellationToken)
+    {
+        var filesInStream = files.Select(file =>
+            new Tuple<MemoryStream, string>(new MemoryStream(File.ReadAllBytes(file.FullName)), file.Name)).ToList();
+        return await ConnectionHandler.PostMultiPartFileAsync<IReadOnlyList<BexioFile>>(filesInStream,
+            $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<IReadOnlyList<BexioFile>>> Upload(List<Tuple<MemoryStream, string>> files,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostMultiPartFileAsync<IReadOnlyList<BexioFile>>(files,
+            $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<BexioFile>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterFile? queryParameterFile, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<BexioFile>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search",
+            queryParameterFile?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<BexioFile>> Patch(int id, FilePatch payload,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PatchAsync<BexioFile, FilePatch>(payload, $"{ApiVersion}/{EndpointRoot}/{id}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/CommentConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/CommentConfiguration.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+/// Comment endpoint configuration. The route includes the document-type discriminator and
+/// document id as URL segments — these are not part of <see cref="EndpointLeaf"/> and are
+/// supplied by the service per call.
+/// </summary>
+public static class CommentConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The trailing path segment after the document id (i.e. the resource name).
+    /// </summary>
+    public const string EndpointLeaf = "comment";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/CommentService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/CommentService.cs
@@ -1,0 +1,72 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.MasterData;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Comments;
+using BexioApiNet.Abstractions.Models.MasterData.Comments.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="ICommentService" />
+public sealed class CommentService : ConnectorService, ICommentService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = CommentConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The trailing path segment after the document id
+    /// </summary>
+    private const string EndpointLeaf = CommentConfiguration.EndpointLeaf;
+
+    /// <inheritdoc />
+    public CommentService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Comment>?>> Get(KbDocumentType kbDocumentType, int documentId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<Comment>?>($"{ApiVersion}/{kbDocumentType.ToBexioString()}/{documentId}/{EndpointLeaf}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Comment>> GetById(KbDocumentType kbDocumentType, int documentId, int commentId, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Comment>($"{ApiVersion}/{kbDocumentType.ToBexioString()}/{documentId}/{EndpointLeaf}/{commentId}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Comment>> Create(KbDocumentType kbDocumentType, int documentId, CommentCreate payload, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Comment, CommentCreate>(payload, $"{ApiVersion}/{kbDocumentType.ToBexioString()}/{documentId}/{EndpointLeaf}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/CommunicationTypeConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/CommunicationTypeConfiguration.cs
@@ -1,0 +1,44 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+/// Communication type endpoint configuration. The Bexio API exposes the resource
+/// under the legacy path segment <c>communication_kind</c> while the documented
+/// concept is "communication type".
+/// </summary>
+public static class CommunicationTypeConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "communication_kind";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/CommunicationTypeService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/CommunicationTypeService.cs
@@ -1,0 +1,78 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.CommunicationTypes;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="ICommunicationTypeService" />
+public sealed class CommunicationTypeService : ConnectorService, ICommunicationTypeService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = CommunicationTypeConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = CommunicationTypeConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public CommunicationTypeService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<CommunicationType>?>> Get([Optional] QueryParameterCommunicationType? queryParameterCommunicationType, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<CommunicationType>?>($"{ApiVersion}/{EndpointRoot}", queryParameterCommunicationType?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<CommunicationType>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterCommunicationType?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<CommunicationType>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterCommunicationType? queryParameterCommunicationType, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<CommunicationType>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterCommunicationType?.QueryParameter, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/CompanyProfileConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/CompanyProfileConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+/// Company profile endpoint configuration.
+/// </summary>
+public static class CompanyProfileConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "company_profile";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/CompanyProfileService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/CompanyProfileService.cs
@@ -1,0 +1,64 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.CompanyProfiles;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="ICompanyProfileService" />
+public sealed class CompanyProfileService : ConnectorService, ICompanyProfileService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = CompanyProfileConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = CompanyProfileConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public CompanyProfileService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<CompanyProfile>?>> Get([Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<List<CompanyProfile>?>($"{ApiVersion}/{EndpointRoot}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<CompanyProfile>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<CompanyProfile>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/CountryConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/CountryConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+///     Country endpoint configuration.
+/// </summary>
+public static class CountryConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    ///     The request path.
+    /// </summary>
+    public const string EndpointRoot = "country";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/CountryService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/CountryService.cs
@@ -1,0 +1,111 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Countries;
+using BexioApiNet.Abstractions.Models.MasterData.Countries.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.MasterData.ICountryService" />
+public sealed class CountryService : ConnectorService, ICountryService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = CountryConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = CountryConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public CountryService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Country>?>> Get([Optional] QueryParameterCountry? queryParameterCountry,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Country>?>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterCountry?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Country>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterCountry?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Country?>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Country?>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Country>> Create(CountryCreate country, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Country, CountryCreate>(country, $"{ApiVersion}/{EndpointRoot}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Country>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterCountry? queryParameterCountry, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Country>(searchCriteria,
+            $"{ApiVersion}/{EndpointRoot}/search", queryParameterCountry?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Country>> Update(int id, CountryUpdate country,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Country, CountryUpdate>(country,
+            $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/FictionalUserConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/FictionalUserConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+///     Fictional user endpoint configuration. Bexio <c>3.0/fictional_users</c>.
+/// </summary>
+public static class FictionalUserConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    ///     The request path for fictional user resources.
+    /// </summary>
+    public const string EndpointRoot = "fictional_users";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/FictionalUserService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/FictionalUserService.cs
@@ -1,0 +1,106 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.FictionalUsers;
+using BexioApiNet.Abstractions.Models.MasterData.FictionalUsers.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="IFictionalUserService" />
+public sealed class FictionalUserService : ConnectorService, IFictionalUserService
+{
+    /// <summary>
+    ///     The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = FictionalUserConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path for fictional user resources.
+    /// </summary>
+    private const string EndpointRoot = FictionalUserConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public FictionalUserService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<FictionalUser>>> Get(
+        [Optional] QueryParameterFictionalUser? queryParameterFictionalUser,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<FictionalUser>>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterFictionalUser?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<FictionalUser>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterFictionalUser?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<FictionalUser>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<FictionalUser>($"{ApiVersion}/{EndpointRoot}/{id}", null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<FictionalUser>> Create(FictionalUserCreate fictionalUser,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<FictionalUser, FictionalUserCreate>(fictionalUser,
+            $"{ApiVersion}/{EndpointRoot}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<FictionalUser>> Patch(int id, FictionalUserPatch fictionalUser,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PatchAsync<FictionalUser, FictionalUserPatch>(fictionalUser,
+            $"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/LanguageConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/LanguageConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+/// Language endpoint configuration.
+/// </summary>
+public static class LanguageConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "language";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/LanguageService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/LanguageService.cs
@@ -1,0 +1,78 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Languages;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="ILanguageService" />
+public sealed class LanguageService : ConnectorService, ILanguageService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = LanguageConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = LanguageConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public LanguageService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Language>?>> Get([Optional] QueryParameterLanguage? queryParameterLanguage, [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Language>?>($"{ApiVersion}/{EndpointRoot}", queryParameterLanguage?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null || res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Language>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterLanguage?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Language>>> Search(List<SearchCriteria> searchCriteria, [Optional] QueryParameterLanguage? queryParameterLanguage, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Language>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search", queryParameterLanguage?.QueryParameter, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/NoteConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/NoteConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+///     Note endpoint configuration
+/// </summary>
+public static class NoteConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    ///     The request path
+    /// </summary>
+    public const string EndpointRoot = "note";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/NoteService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/NoteService.cs
@@ -1,0 +1,110 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Notes;
+using BexioApiNet.Abstractions.Models.MasterData.Notes.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="INoteService" />
+public sealed class NoteService : ConnectorService, INoteService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = NoteConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = NoteConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public NoteService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Note>?>> Get([Optional] QueryParameterNote? queryParameterNote,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Note>?>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterNote?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Note>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterNote?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Note?>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Note?>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Note>> Create(NoteCreate note, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Note, NoteCreate>(note, $"{ApiVersion}/{EndpointRoot}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Note>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterNote? queryParameterNote, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Note>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search",
+            queryParameterNote?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Note>> Update(int id, NoteUpdate note, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Note, NoteUpdate>(note, $"{ApiVersion}/{EndpointRoot}/{id}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/PermissionConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/PermissionConfiguration.cs
@@ -1,0 +1,43 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+/// Permissions endpoint configuration. The Bexio <c>/3.0/permissions</c> route is a singleton
+/// that returns the access information of the currently signed-in user (no id parameter).
+/// </summary>
+public static class PermissionConfiguration
+{
+    /// <summary>
+    /// Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    /// The request path
+    /// </summary>
+    public const string EndpointRoot = "permissions";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/PermissionService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/PermissionService.cs
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Permissions;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="IPermissionService" />
+public sealed class PermissionService : ConnectorService, IPermissionService
+{
+    /// <summary>
+    /// The api endpoint version
+    /// </summary>
+    private const string ApiVersion = PermissionConfiguration.ApiVersion;
+
+    /// <summary>
+    /// The api request path
+    /// </summary>
+    private const string EndpointRoot = PermissionConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public PermissionService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Permission>> Get([Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Permission>($"{ApiVersion}/{EndpointRoot}", null, cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/SalutationConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/SalutationConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+///     Salutation endpoint configuration.
+/// </summary>
+public static class SalutationConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    ///     The request path.
+    /// </summary>
+    public const string EndpointRoot = "salutation";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/SalutationService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/SalutationService.cs
@@ -1,0 +1,116 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Salutations;
+using BexioApiNet.Abstractions.Models.MasterData.Salutations.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="BexioApiNet.Interfaces.Connectors.MasterData.ISalutationService" />
+public sealed class SalutationService : ConnectorService, ISalutationService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = SalutationConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = SalutationConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public SalutationService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Salutation>?>> Get([Optional] QueryParameterSalutation? queryParameterSalutation,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Salutation>?>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterSalutation?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Salutation>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterSalutation?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Salutation?>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Salutation?>($"{ApiVersion}/{EndpointRoot}/{id}", null,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Salutation>> Create(SalutationCreate salutation,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Salutation, SalutationCreate>(salutation,
+            $"{ApiVersion}/{EndpointRoot}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Salutation>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterSalutation? queryParameterSalutation, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Salutation>(searchCriteria,
+            $"{ApiVersion}/{EndpointRoot}/search",
+            queryParameterSalutation?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Salutation>> Update(int id, SalutationUpdate salutation,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Salutation, SalutationUpdate>(salutation,
+            $"{ApiVersion}/{EndpointRoot}/{id}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/TitleConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/TitleConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+///     Title endpoint configuration
+/// </summary>
+public static class TitleConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint
+    /// </summary>
+    public const string ApiVersion = "2.0";
+
+    /// <summary>
+    ///     The request path
+    /// </summary>
+    public const string EndpointRoot = "title";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/TitleService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/TitleService.cs
@@ -1,0 +1,111 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Titles;
+using BexioApiNet.Abstractions.Models.MasterData.Titles.Views;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="ITitleService" />
+public sealed class TitleService : ConnectorService, ITitleService
+{
+    /// <summary>
+    ///     The api endpoint version
+    /// </summary>
+    private const string ApiVersion = TitleConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path
+    /// </summary>
+    private const string EndpointRoot = TitleConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public TitleService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Title>?>> Get([Optional] QueryParameterTitle? queryParameterTitle,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<Title>?>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterTitle?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<Title>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterTitle?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Title?>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<Title?>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Title>> Create(TitleCreate title, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostAsync<Title, TitleCreate>(title, $"{ApiVersion}/{EndpointRoot}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<Title>>> Search(List<SearchCriteria> searchCriteria,
+        [Optional] QueryParameterTitle? queryParameterTitle, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PostSearchAsync<Title>(searchCriteria, $"{ApiVersion}/{EndpointRoot}/search",
+            queryParameterTitle?.QueryParameter, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<Title>> Update(int id, TitleUpdate title,
+        [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.PutAsync<Title, TitleUpdate>(title, $"{ApiVersion}/{EndpointRoot}/{id}",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<object>> Delete(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.Delete($"{ApiVersion}/{EndpointRoot}/{id}", cancellationToken);
+    }
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/UserConfiguration.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/UserConfiguration.cs
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <summary>
+///     User endpoint configuration. Bexio <c>3.0/users</c>.
+/// </summary>
+public static class UserConfiguration
+{
+    /// <summary>
+    ///     Current api version of the endpoint.
+    /// </summary>
+    public const string ApiVersion = "3.0";
+
+    /// <summary>
+    ///     The request path for user resources.
+    /// </summary>
+    public const string EndpointRoot = "users";
+}

--- a/src/BexioApiNet/Services/Connectors/MasterData/UserService.cs
+++ b/src/BexioApiNet/Services/Connectors/MasterData/UserService.cs
@@ -1,0 +1,87 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Runtime.InteropServices;
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Users;
+using BexioApiNet.Interfaces;
+using BexioApiNet.Interfaces.Connectors.MasterData;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Base;
+
+namespace BexioApiNet.Services.Connectors.MasterData;
+
+/// <inheritdoc cref="IUserService" />
+public sealed class UserService : ConnectorService, IUserService
+{
+    /// <summary>
+    ///     The api endpoint version.
+    /// </summary>
+    private const string ApiVersion = UserConfiguration.ApiVersion;
+
+    /// <summary>
+    ///     The api request path for user resources.
+    /// </summary>
+    private const string EndpointRoot = UserConfiguration.EndpointRoot;
+
+    /// <inheritdoc />
+    public UserService(IBexioConnectionHandler bexioConnectionHandler) : base(bexioConnectionHandler)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<List<User>>> GetAll([Optional] QueryParameterUser? queryParameterUser,
+        [Optional] bool autoPage, [Optional] CancellationToken cancellationToken)
+    {
+        var res = await ConnectionHandler.GetAsync<List<User>>($"{ApiVersion}/{EndpointRoot}",
+            queryParameterUser?.QueryParameter, cancellationToken);
+
+        if (!autoPage || !res.IsSuccess || res.Data is null ||
+            res.ResponseHeaders?.GetValueOrDefault(ApiHeaderNames.TotalResults) is not { } totalResults)
+            return res;
+
+        res.Data.AddRange(await ConnectionHandler.FetchAll<User>(
+            res.Data.Count,
+            totalResults,
+            $"{ApiVersion}/{EndpointRoot}",
+            queryParameterUser?.QueryParameter,
+            cancellationToken));
+
+        return res;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<User>> GetMe([Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<User>($"{ApiVersion}/{EndpointRoot}/me", null, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ApiResult<User>> GetById(int id, [Optional] CancellationToken cancellationToken)
+    {
+        return await ConnectionHandler.GetAsync<User>($"{ApiVersion}/{EndpointRoot}/{id}", null, cancellationToken);
+    }
+}

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -133,7 +134,8 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new CountryService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -133,7 +134,9 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new UserService(connectionHandler),
+            new FictionalUserService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -133,7 +134,11 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new LanguageService(connectionHandler),
+            new CommunicationTypeService(connectionHandler),
+            new CompanyProfileService(connectionHandler),
+            new PermissionService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Services.Connectors.Banking;
 using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
+using BexioApiNet.Services.Connectors.Files;
 using BexioApiNet.Services.Connectors.Items;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
@@ -133,7 +134,8 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new FileService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -133,7 +134,8 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new TitleService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -133,7 +134,8 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new CommentService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -133,7 +134,8 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new SalutationService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -136,19 +136,19 @@ public abstract class BexioE2eTestBase
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
             new PaystubService(connectionHandler),
-            new FileService(connectionHandler));
+            new FileService(connectionHandler),
             new DocumentSettingService(connectionHandler),
-            new DocumentTemplateService(connectionHandler));
-            new CountryService(connectionHandler));
-            new SalutationService(connectionHandler));
-            new TitleService(connectionHandler));
+            new DocumentTemplateService(connectionHandler),
+            new CountryService(connectionHandler),
+            new SalutationService(connectionHandler),
+            new TitleService(connectionHandler),
             new LanguageService(connectionHandler),
             new CommunicationTypeService(connectionHandler),
             new CompanyProfileService(connectionHandler),
-            new PermissionService(connectionHandler));
+            new PermissionService(connectionHandler),
             new UserService(connectionHandler),
-            new FictionalUserService(connectionHandler));
-            new NoteService(connectionHandler));
+            new FictionalUserService(connectionHandler),
+            new NoteService(connectionHandler),
             new CommentService(connectionHandler));
     }
 

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -30,6 +30,7 @@ using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
 using BexioApiNet.Services.Connectors.Items;
+using BexioApiNet.Services.Connectors.MasterData;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
 using BexioApiNet.Services.Connectors.Purchases;
@@ -133,7 +134,8 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new NoteService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
+++ b/tests/BexioApiNet.E2eTests/BexioE2eTestBase.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Services.Connectors.Banking;
 using BexioApiNet.Services.Connectors.BusinessActivities;
 using BexioApiNet.Services.Connectors.Contacts;
 using BexioApiNet.Services.Connectors.Expenses;
+using BexioApiNet.Services.Connectors.Files;
 using BexioApiNet.Services.Connectors.Items;
 using BexioApiNet.Services.Connectors.Payroll;
 using BexioApiNet.Services.Connectors.Projects;
@@ -133,7 +134,9 @@ public abstract class BexioE2eTestBase
             new ExpenseService(connectionHandler),
             new EmployeeService(connectionHandler),
             new AbsenceService(connectionHandler),
-            new PaystubService(connectionHandler));
+            new PaystubService(connectionHandler),
+            new DocumentSettingService(connectionHandler),
+            new DocumentTemplateService(connectionHandler));
     }
 
     /// <summary>

--- a/tests/BexioApiNet.IntegrationTests/BexioApiNet.IntegrationTests.csproj
+++ b/tests/BexioApiNet.IntegrationTests/BexioApiNet.IntegrationTests.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="WireMock.Net" Version="2.2.0" />
+        <PackageReference Include="WireMock.Net" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/BexioApiNet.IntegrationTests/MasterData/CountryServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/MasterData/CountryServiceIntegrationTests.cs
@@ -1,0 +1,236 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Countries.Views;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.IntegrationTests.MasterData;
+
+/// <summary>
+/// Integration tests covering the CRUD entry points of <see cref="CountryService" /> against
+/// WireMock stubs. Verifies the path composed from <see cref="CountryConfiguration" />
+/// (<c>2.0/country</c>) reaches the handler correctly, that the expected HTTP verbs are used
+/// (including the PUT verb for edits), and that payloads are serialized with the expected
+/// snake_case field names.
+/// </summary>
+public sealed class CountryServiceIntegrationTests : IntegrationTestBase
+{
+    private const string CountryPath = "/2.0/country";
+
+    private const string CountryResponse = """
+                                           {
+                                               "id": 1,
+                                               "name": "Kiribati",
+                                               "name_short": "KI",
+                                               "iso3166_alpha2": "KI"
+                                           }
+                                           """;
+
+    /// <summary>
+    /// <c>CountryService.Get()</c> must issue a <c>GET</c> request against
+    /// <c>/2.0/country</c> and return a successful <c>ApiResult</c> when the server
+    /// returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task CountryService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(CountryPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new CountryService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(CountryPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>CountryService.GetById</c> must issue a <c>GET</c> request that includes the target
+    /// id in the URL path and surface the returned country on success.
+    /// </summary>
+    [Test]
+    public async Task CountryService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{CountryPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(CountryResponse));
+
+        var service = new CountryService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(result.Data.NameShort, Is.EqualTo("KI"));
+            Assert.That(result.Data.Iso3166Alpha2, Is.EqualTo("KI"));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>CountryService.Create</c> must send a <c>POST</c> request whose body is the
+    /// serialized <see cref="CountryCreate" /> payload, and must surface the returned country
+    /// on success.
+    /// </summary>
+    [Test]
+    public async Task CountryService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(CountryPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(CountryResponse));
+
+        var service = new CountryService(ConnectionHandler);
+
+        var payload = new CountryCreate("Kiribati", "KI", "KI");
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(CountryPath));
+            Assert.That(request.Body, Does.Contain("\"name\":\"Kiribati\""));
+            Assert.That(request.Body, Does.Contain("\"name_short\":\"KI\""));
+            Assert.That(request.Body, Does.Contain("\"iso3166_alpha2\":\"KI\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>CountryService.Search</c> must send a <c>POST</c> request against
+    /// <c>/2.0/country/search</c> with the <see cref="SearchCriteria" /> list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task CountryService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{CountryPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{CountryResponse}]"));
+
+        var service = new CountryService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Kiribati", Criteria = "like" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"name\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+
+    /// <summary>
+    /// <c>CountryService.Update</c> must send a <c>PUT</c> request against
+    /// <c>/2.0/country/{id}</c>.
+    /// </summary>
+    [Test]
+    public async Task CountryService_Update_SendsPutRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{CountryPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(CountryResponse));
+
+        var service = new CountryService(ConnectionHandler);
+
+        var payload = new CountryUpdate("Kiribati", "KIR", "KI");
+
+        var result = await service.Update(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("PUT"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    /// <c>CountryService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    /// target id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task CountryService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{CountryPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new CountryService(ConnectionHandler);
+
+        var result = await service.Delete(idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.IntegrationTests/MasterData/SalutationServiceIntegrationTests.cs
+++ b/tests/BexioApiNet.IntegrationTests/MasterData/SalutationServiceIntegrationTests.cs
@@ -1,0 +1,230 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Salutations.Views;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.IntegrationTests.MasterData;
+
+/// <summary>
+///     Integration tests covering the CRUD entry points of <see cref="SalutationService" /> against
+///     WireMock stubs. Verifies the path composed from <see cref="SalutationConfiguration" />
+///     (<c>2.0/salutation</c>) reaches the handler correctly, that the expected HTTP verbs are used
+///     (including the Bexio-specific <c>PUT</c> for edits), and that payloads are serialized with the
+///     expected snake_case field names.
+/// </summary>
+public sealed class SalutationServiceIntegrationTests : IntegrationTestBase
+{
+    private const string SalutationPath = "/2.0/salutation";
+
+    private const string SalutationResponse = """
+                                              {
+                                                  "id": 1,
+                                                  "name": "Herr"
+                                              }
+                                              """;
+
+    /// <summary>
+    ///     <c>SalutationService.Get()</c> must issue a <c>GET</c> request against
+    ///     <c>/2.0/salutation</c> and return a successful <c>ApiResult</c> when the server
+    ///     returns an empty array.
+    /// </summary>
+    [Test]
+    public async Task SalutationService_Get_SendsGetRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(SalutationPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+
+        var service = new SalutationService(ConnectionHandler);
+
+        var result = await service.Get(cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(SalutationPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>SalutationService.GetById</c> must issue a <c>GET</c> request that includes the target
+    ///     id in the URL path and surface the returned salutation on success.
+    /// </summary>
+    [Test]
+    public async Task SalutationService_GetById_SendsGetRequest()
+    {
+        const int id = 1;
+        var expectedPath = $"{SalutationPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(SalutationResponse));
+
+        var service = new SalutationService(ConnectionHandler);
+
+        var result = await service.GetById(id, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("GET"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>SalutationService.Create</c> must send a <c>POST</c> request whose body is the
+    ///     serialized <see cref="SalutationCreate" /> payload, and must surface the returned salutation
+    ///     on success.
+    /// </summary>
+    [Test]
+    public async Task SalutationService_Create_SendsPostRequest()
+    {
+        Server
+            .Given(Request.Create().WithPath(SalutationPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(201).WithBody(SalutationResponse));
+
+        var service = new SalutationService(ConnectionHandler);
+
+        var payload = new SalutationCreate("Herr");
+
+        var result = await service.Create(payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(1));
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(SalutationPath));
+            Assert.That(request.Body, Does.Contain("\"name\":\"Herr\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>SalutationService.Search</c> must send a <c>POST</c> request against
+    ///     <c>/2.0/salutation/search</c> with the <see cref="SearchCriteria" /> list as the JSON body.
+    /// </summary>
+    [Test]
+    public async Task SalutationService_Search_SendsPostRequest_ToSearchPath()
+    {
+        var expectedPath = $"{SalutationPath}/search";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($"[{SalutationResponse}]"));
+
+        var service = new SalutationService(ConnectionHandler);
+
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Herr", Criteria = "like" }
+        };
+
+        var result = await service.Search(criteria, cancellationToken: TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("POST"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+            Assert.That(request.Body, Does.Contain("\"field\":\"name\""));
+            Assert.That(request.Body, Does.Contain("\"criteria\":\"like\""));
+        });
+    }
+
+    /// <summary>
+    ///     <c>SalutationService.Update</c> must send a <c>PUT</c> request against
+    ///     <c>/2.0/salutation/{id}</c>.
+    /// </summary>
+    [Test]
+    public async Task SalutationService_Update_SendsPutRequest_WithIdInPath()
+    {
+        const int id = 1;
+        var expectedPath = $"{SalutationPath}/{id}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(SalutationResponse));
+
+        var service = new SalutationService(ConnectionHandler);
+
+        var payload = new SalutationUpdate("Frau");
+
+        var result = await service.Update(id, payload, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Data, Is.Not.Null);
+            Assert.That(result.Data!.Id, Is.EqualTo(id));
+            Assert.That(request.Method, Is.EqualTo("PUT"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+
+    /// <summary>
+    ///     <c>SalutationService.Delete</c> must issue a <c>DELETE</c> request that includes the
+    ///     target id in the URL path.
+    /// </summary>
+    [Test]
+    public async Task SalutationService_Delete_SendsDeleteRequest()
+    {
+        const int idToDelete = 1;
+        var expectedPath = $"{SalutationPath}/{idToDelete}";
+
+        Server
+            .Given(Request.Create().WithPath(expectedPath).UsingDelete())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{\"success\":true}"));
+
+        var service = new SalutationService(ConnectionHandler);
+
+        var result = await service.Delete(idToDelete, TestContext.CurrentContext.CancellationToken);
+
+        var request = Server.LogEntries.Last().RequestMessage!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(request.Method, Is.EqualTo("DELETE"));
+            Assert.That(request.AbsolutePath, Is.EqualTo(expectedPath));
+        });
+    }
+}

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -110,7 +111,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<ITitleService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +167,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.Titles, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -110,7 +111,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<INoteService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +167,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.Notes, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -28,6 +28,7 @@ using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Interfaces.Connectors.Files;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
@@ -110,7 +111,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<IFileService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +167,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.Files, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -110,7 +111,9 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<IUserService>(),
+            Substitute.For<IFictionalUserService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +168,8 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.Users, Is.Not.Null);
+            Assert.That(client.FictionalUsers, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -113,19 +113,19 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
             Substitute.For<IPaystubService>(),
-            Substitute.For<IFileService>());
+            Substitute.For<IFileService>(),
             Substitute.For<IDocumentSettingService>(),
-            Substitute.For<IDocumentTemplateService>());
-            Substitute.For<ICountryService>());
-            Substitute.For<ISalutationService>());
-            Substitute.For<ITitleService>());
+            Substitute.For<IDocumentTemplateService>(),
+            Substitute.For<ICountryService>(),
+            Substitute.For<ISalutationService>(),
+            Substitute.For<ITitleService>(),
             Substitute.For<ILanguageService>(),
             Substitute.For<ICommunicationTypeService>(),
             Substitute.For<ICompanyProfileService>(),
-            Substitute.For<IPermissionService>());
+            Substitute.For<IPermissionService>(),
             Substitute.For<IUserService>(),
-            Substitute.For<IFictionalUserService>());
-            Substitute.For<INoteService>());
+            Substitute.For<IFictionalUserService>(),
+            Substitute.For<INoteService>(),
             Substitute.For<ICommentService>());
 
         Assert.Multiple(() =>

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -110,7 +111,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<ICommentService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +167,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.Comments, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -28,6 +28,7 @@ using BexioApiNet.Interfaces.Connectors.Banking;
 using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
+using BexioApiNet.Interfaces.Connectors.Files;
 using BexioApiNet.Interfaces.Connectors.Items;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
@@ -110,7 +111,9 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<IDocumentSettingService>(),
+            Substitute.For<IDocumentTemplateService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +168,8 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.DocumentSettings, Is.Not.Null);
+            Assert.That(client.DocumentTemplates, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -110,7 +111,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<ISalutationService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +167,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.Salutations, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -110,7 +111,11 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<ILanguageService>(),
+            Substitute.For<ICommunicationTypeService>(),
+            Substitute.For<ICompanyProfileService>(),
+            Substitute.For<IPermissionService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +170,10 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.Languages, Is.Not.Null);
+            Assert.That(client.CommunicationTypes, Is.Not.Null);
+            Assert.That(client.CompanyProfiles, Is.Not.Null);
+            Assert.That(client.Permissions, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
+++ b/tests/BexioApiNet.UnitTests/BexioApiClientWireUpTests.cs
@@ -29,6 +29,7 @@ using BexioApiNet.Interfaces.Connectors.BusinessActivities;
 using BexioApiNet.Interfaces.Connectors.Contacts;
 using BexioApiNet.Interfaces.Connectors.Expenses;
 using BexioApiNet.Interfaces.Connectors.Items;
+using BexioApiNet.Interfaces.Connectors.MasterData;
 using BexioApiNet.Interfaces.Connectors.Payroll;
 using BexioApiNet.Interfaces.Connectors.Projects;
 using BexioApiNet.Interfaces.Connectors.Purchases;
@@ -110,7 +111,8 @@ public sealed class BexioApiClientWireUpTests
             Substitute.For<IExpenseService>(),
             Substitute.For<IEmployeeService>(),
             Substitute.For<IAbsenceService>(),
-            Substitute.For<IPaystubService>());
+            Substitute.For<IPaystubService>(),
+            Substitute.For<ICountryService>());
 
         Assert.Multiple(() =>
         {
@@ -165,6 +167,7 @@ public sealed class BexioApiClientWireUpTests
             Assert.That(client.PayrollEmployees, Is.Not.Null);
             Assert.That(client.PayrollAbsences, Is.Not.Null);
             Assert.That(client.PayrollPaystubs, Is.Not.Null);
+            Assert.That(client.Countries, Is.Not.Null);
         });
     }
 }

--- a/tests/BexioApiNet.UnitTests/Files/DocumentSettingServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Files/DocumentSettingServiceTests.cs
@@ -1,0 +1,100 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.DocumentSettings;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Files;
+
+namespace BexioApiNet.UnitTests.Files;
+
+/// <summary>
+/// Offline unit tests for <see cref="DocumentSettingService" />. The service exposes only
+/// a read-only <c>Get</c> lookup against the v2.0 <c>kb_item_setting</c> route; these tests
+/// verify it forwards to <see cref="IBexioConnectionHandler" /> with the canonical path and
+/// null query parameter.
+/// </summary>
+[TestFixture]
+public sealed class DocumentSettingServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "2.0/kb_item_setting";
+
+    /// <summary>
+    /// Creates a fresh <see cref="DocumentSettingService" /> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute for every test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new DocumentSettingService(ConnectionHandler);
+    }
+
+    private DocumentSettingService _sut = null!;
+
+    /// <summary>
+    /// Get performs a single <c>GetAsync</c> against <c>2.0/kb_item_setting</c>
+    /// with a null query parameter and forwards the response verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<DocumentSetting>>
+        {
+            IsSuccess = true,
+            Data = []
+        };
+        ConnectionHandler
+            .GetAsync<List<DocumentSetting>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Get();
+
+        result.ShouldBeSameAs(expected);
+        await ConnectionHandler.Received(1).GetAsync<List<DocumentSetting>>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller must be forwarded to the connection
+    /// handler on <c>Get</c> so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<DocumentSetting>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<DocumentSetting>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<DocumentSetting>>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Files/DocumentTemplateServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Files/DocumentTemplateServiceTests.cs
@@ -1,0 +1,100 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.DocumentTemplates;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Files;
+
+namespace BexioApiNet.UnitTests.Files;
+
+/// <summary>
+/// Offline unit tests for <see cref="DocumentTemplateService" />. The service exposes only
+/// a read-only <c>Get</c> lookup against the v3.0 <c>document_templates</c> route; these tests
+/// verify it forwards to <see cref="IBexioConnectionHandler" /> with the canonical path and
+/// null query parameter.
+/// </summary>
+[TestFixture]
+public sealed class DocumentTemplateServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "3.0/document_templates";
+
+    /// <summary>
+    /// Creates a fresh <see cref="DocumentTemplateService" /> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler" /> substitute for every test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new DocumentTemplateService(ConnectionHandler);
+    }
+
+    private DocumentTemplateService _sut = null!;
+
+    /// <summary>
+    /// Get performs a single <c>GetAsync</c> against <c>3.0/document_templates</c>
+    /// with a null query parameter and forwards the response verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<DocumentTemplate>>
+        {
+            IsSuccess = true,
+            Data = []
+        };
+        ConnectionHandler
+            .GetAsync<List<DocumentTemplate>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Get();
+
+        result.ShouldBeSameAs(expected);
+        await ConnectionHandler.Received(1).GetAsync<List<DocumentTemplate>>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller must be forwarded to the connection
+    /// handler on <c>Get</c> so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<DocumentTemplate>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<DocumentTemplate>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<DocumentTemplate>>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/Files/FileServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/Files/FileServiceTests.cs
@@ -1,0 +1,500 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.Files.Files.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.Files;
+using BexioFile = BexioApiNet.Abstractions.Models.Files.Files.File;
+using FileUsage = BexioApiNet.Abstractions.Models.Files.Files.FileUsage;
+
+namespace BexioApiNet.UnitTests.Files;
+
+/// <summary>
+///     Offline unit tests for <see cref="FileService" />. Each test verifies that the service
+///     forwards its call to <see cref="IBexioConnectionHandler" /> with the expected verb, path,
+///     and payload, and returns the handler's <see cref="ApiResult{T}" /> unchanged. No network,
+///     no live Bexio calls. Temporary files (Upload FileInfo overload only) are created under the
+///     OS temp folder and deleted in <c>[TearDown]</c>.
+/// </summary>
+[TestFixture]
+public sealed class FileServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="FileService" /> per test, bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute provided by the base fixture.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new FileService(ConnectionHandler);
+    }
+
+    /// <summary>
+    ///     Cleans up any temporary files created by upload tests that exercise the
+    ///     <see cref="FileInfo" /> overload.
+    /// </summary>
+    [TearDown]
+    public void CleanUpTempFiles()
+    {
+        foreach (var path in _tempFiles)
+            if (File.Exists(path))
+                File.Delete(path);
+
+        _tempFiles.Clear();
+    }
+
+    private const string ExpectedEndpoint = "3.0/files";
+
+    private FileService _sut = null!;
+    private readonly List<string> _tempFiles = [];
+
+    /// <summary>
+    ///     Get (no parameters) calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once
+    ///     with the expected <c>3.0/files</c> path and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsync()
+    {
+        var response = new ApiResult<List<BexioFile>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<BexioFile>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get();
+
+        await ConnectionHandler.Received(1).GetAsync<List<BexioFile>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get returns the <see cref="ApiResult{T}" /> produced by the connection handler unchanged
+    ///     when <c>autoPage</c> is not requested (no FetchAll round-trip).
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResultFromConnectionHandler()
+    {
+        var response = new ApiResult<List<BexioFile>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<BexioFile>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Get forwards the <see cref="QueryParameterFile.QueryParameter" /> payload to the handler
+    ///     when a typed query parameter object is supplied.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_ForwardsUnderlyingQueryParameter()
+    {
+        var queryParameter = new QueryParameterFile(Offset: 10, OrderBy: "name_asc", ArchivedState: "all");
+        var response = new ApiResult<List<BexioFile>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<BexioFile>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<BexioFile>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Get (<c>autoPage = true</c>) triggers <see cref="IBexioConnectionHandler.FetchAll{TResult}" />
+    ///     when the <c>X-Total-Count</c> header is present and the initial response only contained a
+    ///     page of the total result set.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_CallsFetchAll()
+    {
+        const int totalResults = 10;
+        var initialData = new List<BexioFile> { BuildFile(1), BuildFile(2) };
+        var initial = new ApiResult<List<BexioFile>?>
+        {
+            IsSuccess = true,
+            Data = initialData,
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                { ApiHeaderNames.TotalResults, totalResults }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<BexioFile>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(initial);
+        ConnectionHandler
+            .FetchAll<BexioFile>(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<BexioFile>(
+            initialData.Count,
+            totalResults,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetById builds the <c>3.0/files/{id}</c> path and forwards the call to
+    ///     <see cref="IBexioConnectionHandler.GetAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<BexioFile> { IsSuccess = true, Data = BuildFile(id) };
+        ConnectionHandler
+            .GetAsync<BexioFile>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.GetById(id);
+
+        await ConnectionHandler.Received(1).GetAsync<BexioFile>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Download builds the <c>3.0/files/{id}/download</c> path and forwards the call to
+    ///     <see cref="IBexioConnectionHandler.GetBinaryAsync" />.
+    /// </summary>
+    [Test]
+    public async Task Download_CallsGetBinaryAsyncWithExpectedPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<byte[]> { IsSuccess = true, Data = [1, 2, 3] };
+        ConnectionHandler
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Download(id);
+
+        await ConnectionHandler.Received(1).GetBinaryAsync(
+            $"{ExpectedEndpoint}/{id}/download",
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Download forwards the supplied <see cref="CancellationToken" /> to the connection
+    ///     handler so callers can cancel a download in-flight.
+    /// </summary>
+    [Test]
+    public async Task Download_ForwardsCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetBinaryAsync(Arg.Any<string>(), cts.Token)
+            .Returns(new ApiResult<byte[]> { IsSuccess = true });
+
+        await _sut.Download(1, cts.Token);
+
+        await ConnectionHandler.Received(1).GetBinaryAsync(Arg.Any<string>(), cts.Token);
+    }
+
+    /// <summary>
+    ///     Preview builds the <c>3.0/files/{id}/preview</c> path and forwards the call to
+    ///     <see cref="IBexioConnectionHandler.GetBinaryAsync" />.
+    /// </summary>
+    [Test]
+    public async Task Preview_CallsGetBinaryAsyncWithExpectedPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<byte[]> { IsSuccess = true, Data = [1, 2, 3] };
+        ConnectionHandler
+            .GetBinaryAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Preview(id);
+
+        await ConnectionHandler.Received(1).GetBinaryAsync(
+            $"{ExpectedEndpoint}/{id}/preview",
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Usage builds the <c>3.0/files/{id}/usage</c> path and forwards the call to
+    ///     <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> with a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task Usage_CallsGetAsyncWithExpectedPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<FileUsage>
+        {
+            IsSuccess = true,
+            Data = new FileUsage(id, "KbInvoice", "RE-00001", "RE-00001")
+        };
+        ConnectionHandler
+            .GetAsync<FileUsage>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Usage(id);
+
+        await ConnectionHandler.Received(1).GetAsync<FileUsage>(
+            $"{ExpectedEndpoint}/{id}/usage",
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Upload (<see cref="MemoryStream" /> overload) forwards the supplied tuple list and the
+    ///     <c>3.0/files</c> path to <see cref="IBexioConnectionHandler.PostMultiPartFileAsync{TResult}" />.
+    /// </summary>
+    [Test]
+    public async Task Upload_WithStreams_CallsPostMultiPartFileAsync()
+    {
+        var files = new List<Tuple<MemoryStream, string>>
+        {
+            Tuple.Create(new MemoryStream([1, 2, 3]), "test.pdf")
+        };
+        var response = new ApiResult<IReadOnlyList<BexioFile>>
+        {
+            IsSuccess = true,
+            Data = []
+        };
+        ConnectionHandler
+            .PostMultiPartFileAsync<IReadOnlyList<BexioFile>>(
+                Arg.Any<List<Tuple<MemoryStream, string>>>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Upload(files);
+
+        await ConnectionHandler.Received(1).PostMultiPartFileAsync<IReadOnlyList<BexioFile>>(
+            files,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Upload (<see cref="FileInfo" /> overload) reads the file bytes from disk, converts them to
+    ///     in-memory streams paired with the original filename, and forwards the result to
+    ///     <see cref="IBexioConnectionHandler.PostMultiPartFileAsync{TResult}" /> with the
+    ///     <c>3.0/files</c> path.
+    /// </summary>
+    [Test]
+    public async Task Upload_WithFileInfo_ReadsBytesAndCallsPostMultiPartFileAsync()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"fileservicetest-{Guid.NewGuid():N}.pdf");
+        byte[] expectedBytes = [9, 8, 7];
+        await File.WriteAllBytesAsync(path, expectedBytes);
+        _tempFiles.Add(path);
+
+        var files = new List<FileInfo> { new(path) };
+
+        List<Tuple<MemoryStream, string>>? capturedFiles = null;
+        ConnectionHandler
+            .PostMultiPartFileAsync<IReadOnlyList<BexioFile>>(
+                Arg.Do<List<Tuple<MemoryStream, string>>>(f => capturedFiles = f),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ApiResult<IReadOnlyList<BexioFile>> { IsSuccess = true, Data = [] });
+
+        await _sut.Upload(files);
+
+        await ConnectionHandler.Received(1).PostMultiPartFileAsync<IReadOnlyList<BexioFile>>(
+            Arg.Any<List<Tuple<MemoryStream, string>>>(),
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+        Assert.That(capturedFiles, Is.Not.Null);
+        Assert.That(capturedFiles, Has.Count.EqualTo(1));
+        Assert.That(capturedFiles![0].Item2, Is.EqualTo(Path.GetFileName(path)));
+        Assert.That(capturedFiles[0].Item1.ToArray(), Is.EqualTo(expectedBytes));
+    }
+
+    /// <summary>
+    ///     Search forwards the supplied <see cref="SearchCriteria" /> list to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> against the
+    ///     <c>3.0/files/search</c> path, with a null query parameter when none is supplied.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsyncWithExpectedPathAndBody()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "report", Criteria = "like" }
+        };
+        var response = new ApiResult<List<BexioFile>>
+        {
+            IsSuccess = true,
+            Data = [BuildFile(1)]
+        };
+        ConnectionHandler
+            .PostSearchAsync<BexioFile>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Search(criteria);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<BexioFile>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterFile" /> is passed to <c>Search</c> the inner
+    ///     <see cref="QueryParameter" /> is forwarded to the handler so pagination / archived-state
+    ///     parameters reach the URI.
+    /// </summary>
+    [Test]
+    public async Task Search_WithQueryParameter_PassesUnderlyingQueryParameterToHandler()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "invoice", Criteria = "=" }
+        };
+        var queryParameter = new QueryParameterFile(10, 0, ArchivedState: "not_archived");
+        ConnectionHandler
+            .PostSearchAsync<BexioFile>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<BexioFile>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<BexioFile>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Patch forwards the <see cref="FilePatch" /> payload and the <c>3.0/files/{id}</c> path
+    ///     to <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}" />.
+    /// </summary>
+    [Test]
+    public async Task Patch_CallsPatchAsyncWithIdInPath()
+    {
+        const int id = 99;
+        var payload = new FilePatch("renamed.png", true);
+        var response = new ApiResult<BexioFile>
+        {
+            IsSuccess = true,
+            Data = BuildFile(id)
+        };
+        ConnectionHandler
+            .PatchAsync<BexioFile, FilePatch>(
+                Arg.Any<FilePatch>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Patch(id, payload);
+
+        await ConnectionHandler.Received(1).PatchAsync<BexioFile, FilePatch>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    /// <summary>
+    ///     Delete forwards the call to <see cref="IBexioConnectionHandler.Delete" /> with the
+    ///     <c>3.0/files/{id}</c> path.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(id);
+
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+        Assert.That(result, Is.SameAs(response));
+    }
+
+    private static BexioFile BuildFile(int id)
+    {
+        return new BexioFile(
+            id,
+            Guid.NewGuid(),
+            $"file-{id}.pdf",
+            1024,
+            "pdf",
+            "application/pdf",
+            null,
+            1,
+            false,
+            null,
+            "web",
+            false,
+            DateTime.UtcNow);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/CommentServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/CommentServiceTests.cs
@@ -1,0 +1,186 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.MasterData;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Comments;
+using BexioApiNet.Abstractions.Models.MasterData.Comments.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+/// Offline unit tests for <see cref="CommentService"/>. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected route
+/// (composed from the polymorphic <c>kb_document_type</c> URL discriminator and the document id)
+/// and arguments. No network, no filesystem access.
+/// </summary>
+[TestFixture]
+public sealed class CommentServiceTests : ServiceTestBase
+{
+    private const int DocumentId = 4;
+    private const int CommentId = 7;
+
+    private CommentService _sut = null!;
+
+    /// <summary>Creates a fresh <see cref="CommentService"/> bound to the substitute per test.</summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new CommentService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// <see cref="KbDocumentTypeExtensions.ToBexioString"/> maps every defined enum value
+    /// to the snake_case Bexio path segment.
+    /// </summary>
+    [TestCase(KbDocumentType.Offer, "kb_offer")]
+    [TestCase(KbDocumentType.Order, "kb_order")]
+    [TestCase(KbDocumentType.Invoice, "kb_invoice")]
+    public void ToBexioString_MapsEnumValueToBexioSegment(KbDocumentType kbDocumentType, string expectedSegment)
+    {
+        kbDocumentType.ToBexioString().ShouldBe(expectedSegment);
+    }
+
+    /// <summary>
+    /// Get composes the route from the polymorphic discriminator and document id and forwards
+    /// the call to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with a null query parameter.
+    /// </summary>
+    [TestCase(KbDocumentType.Invoice, "kb_invoice")]
+    [TestCase(KbDocumentType.Offer, "kb_offer")]
+    public async Task Get_CallsGetAsync_WithExpectedPath(KbDocumentType kbDocumentType, string expectedSegment)
+    {
+        var response = new ApiResult<List<Comment>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Comment>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Get(kbDocumentType, DocumentId);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Comment>?>(
+            $"2.0/{expectedSegment}/{DocumentId}/comment",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Get returns the <see cref="ApiResult{T}"/> produced by the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Get_ReturnsApiResult()
+    {
+        var response = new ApiResult<List<Comment>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Comment>?>(
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Get(KbDocumentType.Invoice, DocumentId);
+
+        result.ShouldBeSameAs(response);
+    }
+
+    /// <summary>
+    /// GetById appends the comment id to the path for both discriminator values exercised here.
+    /// </summary>
+    [TestCase(KbDocumentType.Invoice, "kb_invoice")]
+    [TestCase(KbDocumentType.Order, "kb_order")]
+    public async Task GetById_CallsGetAsync_WithCommentIdInPath(KbDocumentType kbDocumentType, string expectedSegment)
+    {
+        var response = new ApiResult<Comment> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .GetAsync<Comment>(
+                Arg.Do<string>(p => capturedPath = p),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.GetById(kbDocumentType, DocumentId, CommentId);
+
+        capturedPath.ShouldBe($"2.0/{expectedSegment}/{DocumentId}/comment/{CommentId}");
+    }
+
+    /// <summary>
+    /// Create posts the payload to the list path for both discriminator values exercised here.
+    /// </summary>
+    [TestCase(KbDocumentType.Invoice, "kb_invoice")]
+    [TestCase(KbDocumentType.Offer, "kb_offer")]
+    public async Task Create_CallsPostAsync_WithExpectedPath(KbDocumentType kbDocumentType, string expectedSegment)
+    {
+        var payload = new CommentCreate
+        {
+            Text = "Sample comment",
+            UserId = 1,
+            UserName = "Peter Smith",
+            IsPublic = false
+        };
+        var response = new ApiResult<Comment> { IsSuccess = true };
+        CommentCreate? capturedPayload = null;
+        string? capturedPath = null;
+        ConnectionHandler
+            .PostAsync<Comment, CommentCreate>(
+                Arg.Do<CommentCreate>(p => capturedPayload = p),
+                Arg.Do<string>(p => capturedPath = p),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        await _sut.Create(kbDocumentType, DocumentId, payload);
+
+        capturedPath.ShouldBe($"2.0/{expectedSegment}/{DocumentId}/comment");
+        capturedPayload.ShouldBeSameAs(payload);
+    }
+
+    /// <summary>
+    /// Create returns the <see cref="ApiResult{T}"/> produced by the connection handler unchanged.
+    /// </summary>
+    [Test]
+    public async Task Create_ReturnsApiResult()
+    {
+        var payload = new CommentCreate
+        {
+            Text = "Sample comment",
+            UserId = 1,
+            UserName = "Peter Smith"
+        };
+        var response = new ApiResult<Comment> { IsSuccess = true };
+        ConnectionHandler
+            .PostAsync<Comment, CommentCreate>(
+                Arg.Any<CommentCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(KbDocumentType.Invoice, DocumentId, payload);
+
+        result.ShouldBeSameAs(response);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/CommunicationTypeServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/CommunicationTypeServiceTests.cs
@@ -1,0 +1,148 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.CommunicationTypes;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+/// Offline unit tests for <see cref="CommunicationTypeService"/>. Verifies the read-only lookup
+/// forwards to <see cref="IBexioConnectionHandler"/> against the Bexio <c>communication_kind</c>
+/// URL with the expected verb and arguments.
+/// </summary>
+[TestFixture]
+public sealed class CommunicationTypeServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "2.0/communication_kind";
+    private const string ExpectedSearchEndpoint = "2.0/communication_kind/search";
+
+    private CommunicationTypeService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="CommunicationTypeService"/> per test bound to the base-fixture substitute.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new CommunicationTypeService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// <c>Get</c> hits <c>2.0/communication_kind</c> via the connection handler with a
+    /// <see langword="null"/> query parameter when no caller parameters are supplied.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsync_WithExpectedPath()
+    {
+        var response = new ApiResult<List<CommunicationType>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<CommunicationType>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get();
+
+        result.ShouldBeSameAs(response);
+        await ConnectionHandler.Received(1).GetAsync<List<CommunicationType>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A supplied <see cref="QueryParameterCommunicationType"/> is forwarded verbatim to the handler.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterCommunicationType(Limit: 100, Offset: 0);
+        ConnectionHandler
+            .GetAsync<List<CommunicationType>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<CommunicationType>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<CommunicationType>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// <c>Search</c> posts the supplied <see cref="SearchCriteria"/> list to
+    /// <c>2.0/communication_kind/search</c> via <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}"/>.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync_WithExpectedPathAndBody()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Phone", Criteria = "like" }
+        };
+        var response = new ApiResult<List<CommunicationType>>
+        {
+            IsSuccess = true,
+            Data = [new CommunicationType(Id: 1, Name: "Mobile Phone")]
+        };
+        ConnectionHandler
+            .PostSearchAsync<CommunicationType>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Search(criteria);
+
+        result.ShouldBeSameAs(response);
+        await ConnectionHandler.Received(1).PostSearchAsync<CommunicationType>(
+            criteria,
+            ExpectedSearchEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A <see cref="QueryParameterCommunicationType"/> supplied to <c>Search</c> is forwarded to the handler.
+    /// </summary>
+    [Test]
+    public async Task Search_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Phone", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterCommunicationType(Limit: 10, Offset: 0);
+        ConnectionHandler
+            .PostSearchAsync<CommunicationType>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<CommunicationType>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<CommunicationType>(
+            criteria,
+            ExpectedSearchEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/CompanyProfileServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/CompanyProfileServiceTests.cs
@@ -1,0 +1,98 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.CompanyProfiles;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+/// Offline unit tests for <see cref="CompanyProfileService"/>. Verifies the read-only lookup
+/// forwards list/by-id calls to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> with the
+/// expected paths.
+/// </summary>
+[TestFixture]
+public sealed class CompanyProfileServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "2.0/company_profile";
+
+    private CompanyProfileService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="CompanyProfileService"/> per test bound to the base-fixture substitute.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new CompanyProfileService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// <c>Get</c> hits <c>2.0/company_profile</c> once with a <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsync_WithExpectedPath()
+    {
+        var response = new ApiResult<List<CompanyProfile>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<CompanyProfile>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get();
+
+        result.ShouldBeSameAs(response);
+        await ConnectionHandler.Received(1).GetAsync<List<CompanyProfile>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// <c>GetById(id)</c> composes <c>2.0/company_profile/{id}</c> and forwards to the handler.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsync_WithComposedIdPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<CompanyProfile>
+        {
+            IsSuccess = true,
+            Data = new CompanyProfile { Id = id, Name = "bexio AG" }
+        };
+        ConnectionHandler
+            .GetAsync<CompanyProfile>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.GetById(id);
+
+        result.ShouldBeSameAs(response);
+        await ConnectionHandler.Received(1).GetAsync<CompanyProfile>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/CountryServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/CountryServiceTests.cs
@@ -1,0 +1,357 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Countries;
+using BexioApiNet.Abstractions.Models.MasterData.Countries.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+/// Offline unit tests for <see cref="CountryService"/>. Each test verifies that the service
+/// forwards its calls to <see cref="IBexioConnectionHandler"/> with the expected verb and path,
+/// propagates the response unchanged, and honours the canonical <c>autoPage</c> + <c>X-Total-Count</c>
+/// pagination contract. No network access.
+/// </summary>
+[TestFixture]
+public sealed class CountryServiceTests : ServiceTestBase
+{
+    /// <summary>
+    /// Creates a fresh <see cref="CountryService"/> bound to the
+    /// <see cref="ServiceTestBase.ConnectionHandler"/> substitute for every test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new CountryService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/country";
+
+    private CountryService _sut = null!;
+
+    /// <summary>
+    /// Get (no parameters) performs a single <c>GetAsync</c> against <c>2.0/country</c>
+    /// with a null query parameter and never triggers <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<Country>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Country>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<Country>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        await ConnectionHandler.DidNotReceive().FetchAll<Country>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When a <see cref="QueryParameterCountry"/> is supplied, its inner
+    /// <see cref="QueryParameter"/> instance is forwarded to the connection
+    /// handler verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterCountry(Limit: 50, Offset: 100);
+        ConnectionHandler
+            .GetAsync<List<Country>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Country>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Country>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// When <c>autoPage</c> is on and the first response advertises a
+    /// <c>X-Total-Count</c> header, the service calls <c>FetchAll</c> with the
+    /// count of already-fetched items, the total, the same path, and the
+    /// same query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
+    {
+        var firstCountry = NewCountry(1);
+        var firstPage = new ApiResult<List<Country>?>
+        {
+            IsSuccess = true,
+            Data = [firstCountry],
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                [ApiHeaderNames.TotalResults] = 3
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Country>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(firstPage));
+        var remaining = new List<Country> { NewCountry(2), NewCountry(3) };
+        ConnectionHandler
+            .FetchAll<Country>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(remaining));
+
+        var result = await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Country>(
+            1,
+            3,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result.Data, Has.Count.EqualTo(3));
+        Assert.That(result.Data, Is.EquivalentTo(new[] { firstCountry, remaining[0], remaining[1] }));
+    }
+
+    /// <summary>
+    /// When <c>autoPage</c> is requested but the response carries no
+    /// <c>X-Total-Count</c> header, the service does not invoke <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
+    {
+        var response = new ApiResult<List<Country>?>
+        {
+            IsSuccess = true,
+            Data = [NewCountry(1)],
+            ResponseHeaders = new Dictionary<string, int?>()
+        };
+        ConnectionHandler
+            .GetAsync<List<Country>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get(autoPage: true);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.DidNotReceive().FetchAll<Country>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> once
+    /// with the path <c>2.0/country/{id}</c> and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<Country?>
+        {
+            IsSuccess = true,
+            Data = NewCountry(id)
+        };
+        ConnectionHandler
+            .GetAsync<Country?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<Country?>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Create forwards the create view to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}"/>
+    /// against the endpoint root (no id suffix).
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithEndpointRoot()
+    {
+        var payload = new CountryCreate("Kiribati", "KI", "KI");
+        var expected = new ApiResult<Country> { IsSuccess = true, Data = NewCountry(1) };
+        ConnectionHandler
+            .PostAsync<Country, CountryCreate>(
+                Arg.Any<CountryCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostAsync<Country, CountryCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Search forwards the criteria list and optional pagination parameters to
+    /// <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}"/> against
+    /// the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsyncWithSearchPath()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Switzerland", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterCountry(Limit: 10, Offset: 0);
+        var expected = new ApiResult<List<Country>>
+        {
+            IsSuccess = true,
+            Data = [NewCountry(1)]
+        };
+        ConnectionHandler
+            .PostSearchAsync<Country>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Search(criteria, queryParameter);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostSearchAsync<Country>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Search without a query parameter passes <see langword="null"/> pagination to
+    /// the connection handler and still targets the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_WithoutQueryParameter_PassesNullPagination()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name_short", Value = "CH", Criteria = "=" }
+        };
+        ConnectionHandler
+            .PostSearchAsync<Country>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Country>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Country>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Update forwards the update view to <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}"/>
+    /// against the per-id sub-path (Update uses PUT per the epic blueprint).
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsyncWithIdInPath()
+    {
+        const int id = 7;
+        var payload = new CountryUpdate("Kiribati", "KIR", "KI");
+        var expected = new ApiResult<Country> { IsSuccess = true, Data = NewCountry(id) };
+        ConnectionHandler
+            .PutAsync<Country, CountryUpdate>(
+                Arg.Any<CountryUpdate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Update(id, payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PutAsync<Country, CountryUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Delete forwards to <see cref="IBexioConnectionHandler.Delete"/> with the
+    /// per-id path exactly once.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Delete(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller must be forwarded to the
+    /// connection handler on <c>Get</c> so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<Country>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Country>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Country>?>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+
+    private static Country NewCountry(int id) =>
+        new(Id: id, Name: $"Country {id}", NameShort: $"C{id}", Iso3166Alpha2: "CH");
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/FictionalUserServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/FictionalUserServiceTests.cs
@@ -1,0 +1,259 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System.Text.Json;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.FictionalUsers;
+using BexioApiNet.Abstractions.Models.MasterData.FictionalUsers.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+///     Offline unit tests for <see cref="FictionalUserService" />. Each test asserts that the
+///     service forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected verb,
+///     path and payload, and returns the handler's <see cref="ApiResult{T}" /> unchanged. Verifies
+///     that <see cref="FictionalUserService.Patch" /> routes to <c>PATCH</c> (not <c>PUT</c>) and
+///     that <see cref="FictionalUserPatch" /> omits unset properties from serialization. No network,
+///     no filesystem.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public sealed class FictionalUserServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="FictionalUserService" /> bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new FictionalUserService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "3.0/fictional_users";
+
+    private FictionalUserService _sut = null!;
+
+    private static FictionalUser NewFictionalUser(int id = 1)
+    {
+        return new FictionalUser(id, "male", "Rudolph", "Smith", "rudolph.smith@bexio.com", null);
+    }
+
+    /// <summary>
+    ///     <c>Get</c> with no query parameter must hit <c>3.0/fictional_users</c> exactly once with
+    ///     a <see langword="null" /> query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
+    {
+        var expected = new ApiResult<List<FictionalUser>>
+        {
+            IsSuccess = true,
+            Data = [NewFictionalUser()]
+        };
+        ConnectionHandler
+            .GetAsync<List<FictionalUser>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<FictionalUser>>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterFictionalUser" /> is supplied, the wrapped dictionary is
+    ///     forwarded to the connection handler so pagination reaches the API.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToHandler()
+    {
+        var query = new QueryParameterFictionalUser(100, 50);
+        ConnectionHandler
+            .GetAsync<List<FictionalUser>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<FictionalUser>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(query);
+
+        await ConnectionHandler.Received(1).GetAsync<List<FictionalUser>>(
+            ExpectedEndpoint,
+            query.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>GetById</c> must build the request path with the fictional user id appended to the
+    ///     endpoint root.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<FictionalUser>
+        {
+            IsSuccess = true,
+            Data = NewFictionalUser(id)
+        };
+        ConnectionHandler
+            .GetAsync<FictionalUser>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<FictionalUser>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>Create</c> forwards the payload and the <c>3.0/fictional_users</c> endpoint path to
+    ///     <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />.
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithExpectedPath()
+    {
+        var payload = new FictionalUserCreate("male", "Rudolph", "Smith", "rudolph.smith@bexio.com");
+        var response = new ApiResult<FictionalUser>
+        {
+            IsSuccess = true,
+            Data = NewFictionalUser()
+        };
+        ConnectionHandler
+            .PostAsync<FictionalUser, FictionalUserCreate>(
+                Arg.Any<FictionalUserCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).PostAsync<FictionalUser, FictionalUserCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>Patch</c> forwards the patch payload and the <c>3.0/fictional_users/{id}</c> endpoint
+    ///     path to <see cref="IBexioConnectionHandler.PatchAsync{TResult,TPatch}" />. This asserts
+    ///     <c>PATCH</c> semantics (not <c>PUT</c>) per the Bexio fictional-users contract.
+    /// </summary>
+    [Test]
+    public async Task Patch_CallsPatchAsyncWithIdInPath()
+    {
+        const int id = 99;
+        var payload = new FictionalUserPatch(Firstname: "Updated");
+        var response = new ApiResult<FictionalUser>
+        {
+            IsSuccess = true,
+            Data = NewFictionalUser(id)
+        };
+        ConnectionHandler
+            .PatchAsync<FictionalUser, FictionalUserPatch>(
+                Arg.Any<FictionalUserPatch>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Patch(id, payload);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.Received(1).PatchAsync<FictionalUser, FictionalUserPatch>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>Delete</c> forwards the call to <see cref="IBexioConnectionHandler.Delete" /> exactly
+    ///     once, building the path with the fictional user id.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        const int id = 42;
+        var response = new ApiResult<object> { IsSuccess = true };
+        string? capturedPath = null;
+        ConnectionHandler
+            .Delete(
+                Arg.Do<string>(path => capturedPath = path),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var result = await _sut.Delete(id);
+
+        Assert.That(result, Is.SameAs(response));
+        Assert.That(capturedPath, Is.EqualTo($"{ExpectedEndpoint}/{id}"));
+        await ConnectionHandler.Received(1).Delete(
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Serializing a sparsely-populated <see cref="FictionalUserPatch" /> must omit every unset
+    ///     (null) property from the JSON payload so Bexio only updates the fields the caller
+    ///     supplied. A default-constructed patch produces the empty JSON object.
+    /// </summary>
+    [Test]
+    public void FictionalUserPatch_SerializationOmitsNullFields()
+    {
+        var patch = new FictionalUserPatch(Firstname: "Updated");
+
+        var json = JsonSerializer.Serialize(patch);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"firstname\":\"Updated\""));
+            Assert.That(json, Does.Not.Contain("salutation_type"));
+            Assert.That(json, Does.Not.Contain("lastname"));
+            Assert.That(json, Does.Not.Contain("email"));
+            Assert.That(json, Does.Not.Contain("title_id"));
+        });
+    }
+
+    /// <summary>
+    ///     A <see cref="FictionalUserPatch" /> with no arguments serializes to an empty object — every
+    ///     nullable property is omitted because
+    ///     <see cref="System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull" />
+    ///     suppresses null output.
+    /// </summary>
+    [Test]
+    public void FictionalUserPatch_EmptyPatch_SerializesToEmptyJsonObject()
+    {
+        var patch = new FictionalUserPatch();
+
+        var json = JsonSerializer.Serialize(patch);
+
+        Assert.That(json, Is.EqualTo("{}"));
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/LanguageServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/LanguageServiceTests.cs
@@ -1,0 +1,147 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Languages;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+/// Offline unit tests for <see cref="LanguageService"/>. Verifies the read-only lookup forwards its
+/// calls to <see cref="IBexioConnectionHandler"/> with the expected verb, path, and arguments.
+/// </summary>
+[TestFixture]
+public sealed class LanguageServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "2.0/language";
+    private const string ExpectedSearchEndpoint = "2.0/language/search";
+
+    private LanguageService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="LanguageService"/> per test bound to the base-fixture substitute.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new LanguageService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// <c>Get</c> hits <c>2.0/language</c> via <see cref="IBexioConnectionHandler.GetAsync{TResult}"/>
+    /// with a <see langword="null"/> query parameter when no caller parameters are supplied.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsync_WithExpectedPath()
+    {
+        var response = new ApiResult<List<Language>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Language>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get();
+
+        result.ShouldBeSameAs(response);
+        await ConnectionHandler.Received(1).GetAsync<List<Language>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A supplied <see cref="QueryParameterLanguage"/> is forwarded verbatim to the handler.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterLanguage(Limit: 50, Offset: 25);
+        ConnectionHandler
+            .GetAsync<List<Language>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Language>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Language>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// <c>Search</c> posts the supplied <see cref="SearchCriteria"/> list to
+    /// <c>2.0/language/search</c> via <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}"/>.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsync_WithExpectedPathAndBody()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "German", Criteria = "=" }
+        };
+        var response = new ApiResult<List<Language>>
+        {
+            IsSuccess = true,
+            Data = [new Language { Id = 1, Name = "German", Iso6391 = "de" }]
+        };
+        ConnectionHandler
+            .PostSearchAsync<Language>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Search(criteria);
+
+        result.ShouldBeSameAs(response);
+        await ConnectionHandler.Received(1).PostSearchAsync<Language>(
+            criteria,
+            ExpectedSearchEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A <see cref="QueryParameterLanguage"/> supplied to <c>Search</c> is forwarded to the handler.
+    /// </summary>
+    [Test]
+    public async Task Search_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "iso_639_1", Value = "de", Criteria = "=" }
+        };
+        var queryParameter = new QueryParameterLanguage(Limit: 10, Offset: 0);
+        ConnectionHandler
+            .PostSearchAsync<Language>(Arg.Any<List<SearchCriteria>>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Language>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria, queryParameter);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Language>(
+            criteria,
+            ExpectedSearchEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/NoteServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/NoteServiceTests.cs
@@ -1,0 +1,386 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Notes;
+using BexioApiNet.Abstractions.Models.MasterData.Notes.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+///     Offline unit tests for <see cref="NoteService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected verb and path,
+///     propagates the response unchanged, and honours the canonical <c>autoPage</c> + <c>X-Total-Count</c>
+///     pagination contract. No network access.
+/// </summary>
+[TestFixture]
+public sealed class NoteServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="NoteService" /> bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute for every test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new NoteService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/note";
+
+    private NoteService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) performs a single <c>GetAsync</c> against <c>2.0/note</c>
+    ///     with a null query parameter and never triggers <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<Note>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Note>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<Note>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        await ConnectionHandler.DidNotReceive().FetchAll<Note>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterNote" /> is supplied, its inner
+    ///     <see cref="QueryParameter" /> instance is forwarded to the connection
+    ///     handler verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterNote(50, 100);
+        ConnectionHandler
+            .GetAsync<List<Note>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Note>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Note>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When <c>autoPage</c> is on and the first response advertises a
+    ///     <c>X-Total-Count</c> header, the service calls <c>FetchAll</c> with the
+    ///     count of already-fetched items, the total, the same path, and the
+    ///     same query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
+    {
+        var firstNote = NewNote(1);
+        var firstPage = new ApiResult<List<Note>?>
+        {
+            IsSuccess = true,
+            Data = [firstNote],
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                [ApiHeaderNames.TotalResults] = 3
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Note>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(firstPage));
+        var remaining = new List<Note> { NewNote(2), NewNote(3) };
+        ConnectionHandler
+            .FetchAll<Note>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(remaining));
+
+        var result = await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Note>(
+            1,
+            3,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result.Data, Has.Count.EqualTo(3));
+        Assert.That(result.Data, Is.EquivalentTo(new[] { firstNote, remaining[0], remaining[1] }));
+    }
+
+    /// <summary>
+    ///     When <c>autoPage</c> is requested but the response carries no
+    ///     <c>X-Total-Count</c> header, the service does not invoke <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
+    {
+        var response = new ApiResult<List<Note>?>
+        {
+            IsSuccess = true,
+            Data = [NewNote(1)],
+            ResponseHeaders = new Dictionary<string, int?>()
+        };
+        ConnectionHandler
+            .GetAsync<List<Note>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get(autoPage: true);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.DidNotReceive().FetchAll<Note>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once
+    ///     with the path <c>2.0/note/{id}</c> and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<Note?>
+        {
+            IsSuccess = true,
+            Data = NewNote(id)
+        };
+        ConnectionHandler
+            .GetAsync<Note?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<Note?>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Create forwards the create view to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />
+    ///     against the endpoint root (no id suffix).
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithEndpointRoot()
+    {
+        var payload = NewNoteCreate();
+        var expected = new ApiResult<Note> { IsSuccess = true, Data = NewNote(1) };
+        ConnectionHandler
+            .PostAsync<Note, NoteCreate>(
+                Arg.Any<NoteCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostAsync<Note, NoteCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria list and optional pagination parameters to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> against
+    ///     the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsyncWithSearchPath()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "subject", Value = "API", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterNote(10, 0);
+        var expected = new ApiResult<List<Note>>
+        {
+            IsSuccess = true,
+            Data = [NewNote(1)]
+        };
+        ConnectionHandler
+            .PostSearchAsync<Note>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Search(criteria, queryParameter);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostSearchAsync<Note>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search without a query parameter passes <see langword="null" /> pagination to
+    ///     the connection handler and still targets the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_WithoutQueryParameter_PassesNullPagination()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "user_id", Value = "1", Criteria = "=" }
+        };
+        ConnectionHandler
+            .PostSearchAsync<Note>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Note>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Note>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update forwards the update view to <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}" />
+    ///     against the per-id sub-path (the Bexio Notes API uses PUT for full-replacement edits).
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsyncWithIdInPath()
+    {
+        const int id = 7;
+        var payload = NewNoteUpdate();
+        var expected = new ApiResult<Note> { IsSuccess = true, Data = NewNote(id) };
+        ConnectionHandler
+            .PutAsync<Note, NoteUpdate>(
+                Arg.Any<NoteUpdate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Update(id, payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PutAsync<Note, NoteUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Delete forwards to <see cref="IBexioConnectionHandler.Delete" /> with the
+    ///     per-id path exactly once.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Delete(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     The cancellation token supplied by the caller must be forwarded to the
+    ///     connection handler on <c>Get</c> so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<Note>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Note>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Note>?>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+
+    private static Note NewNote(int id)
+    {
+        return new Note(
+            id,
+            1,
+            new DateTime(2026, 1, 16, 14, 20, 0, DateTimeKind.Utc),
+            $"Note {id}",
+            "Body text",
+            null,
+            null,
+            null,
+            null,
+            null);
+    }
+
+    private static NoteCreate NewNoteCreate()
+    {
+        return new NoteCreate(
+            1,
+            new DateTime(2026, 1, 16, 14, 20, 0, DateTimeKind.Utc),
+            "API conception");
+    }
+
+    private static NoteUpdate NewNoteUpdate()
+    {
+        return new NoteUpdate(
+            1,
+            new DateTime(2026, 1, 16, 14, 20, 0, DateTimeKind.Utc),
+            "API conception (edited)");
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/PermissionServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/PermissionServiceTests.cs
@@ -1,0 +1,104 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Permissions;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+/// Offline unit tests for <see cref="PermissionService"/>. Verifies the singleton lookup forwards
+/// to <see cref="IBexioConnectionHandler.GetAsync{TResult}"/> against the <c>3.0/permissions</c>
+/// route.
+/// </summary>
+[TestFixture]
+public sealed class PermissionServiceTests : ServiceTestBase
+{
+    private const string ExpectedEndpoint = "3.0/permissions";
+
+    private PermissionService _sut = null!;
+
+    /// <summary>
+    /// Creates a fresh <see cref="PermissionService"/> per test bound to the base-fixture substitute.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new PermissionService(ConnectionHandler);
+    }
+
+    /// <summary>
+    /// <c>Get</c> hits <c>3.0/permissions</c> (no id) via the connection handler with a
+    /// <see langword="null"/> query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_CallsGetAsync_WithExpectedSingletonPath()
+    {
+        var response = new ApiResult<Permission>
+        {
+            IsSuccess = true,
+            Data = new Permission
+            {
+                Components = ["functionality1"],
+                Permissions = new Dictionary<string, PermissionAccess>
+                {
+                    { "contact", new PermissionAccess { Activation = "enabled", Edit = "own", Show = "all" } }
+                }
+            }
+        };
+        ConnectionHandler
+            .GetAsync<Permission>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get();
+
+        result.ShouldBeSameAs(response);
+        await ConnectionHandler.Received(1).GetAsync<Permission>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The cancellation token supplied by the caller is forwarded to the connection handler.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<Permission>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<Permission> { IsSuccess = true, Data = new Permission() }));
+
+        await _sut.Get(cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<Permission>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/SalutationServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/SalutationServiceTests.cs
@@ -1,0 +1,360 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Salutations;
+using BexioApiNet.Abstractions.Models.MasterData.Salutations.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+///     Offline unit tests for <see cref="SalutationService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected verb and path,
+///     propagates the response unchanged, and honours the canonical <c>autoPage</c> + <c>X-Total-Count</c>
+///     pagination contract. No network access.
+/// </summary>
+[TestFixture]
+public sealed class SalutationServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="SalutationService" /> bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute for every test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new SalutationService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/salutation";
+
+    private SalutationService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) performs a single <c>GetAsync</c> against <c>2.0/salutation</c>
+    ///     with a null query parameter and never triggers <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<Salutation>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Salutation>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<Salutation>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        await ConnectionHandler.DidNotReceive().FetchAll<Salutation>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterSalutation" /> is supplied, its inner
+    ///     <see cref="QueryParameter" /> instance is forwarded to the connection
+    ///     handler verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterSalutation(50, 100);
+        ConnectionHandler
+            .GetAsync<List<Salutation>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Salutation>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Salutation>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When <c>autoPage</c> is on and the first response advertises a
+    ///     <c>X-Total-Count</c> header, the service calls <c>FetchAll</c> with the
+    ///     count of already-fetched items, the total, the same path, and the
+    ///     same query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
+    {
+        var firstSalutation = NewSalutation(1);
+        var firstPage = new ApiResult<List<Salutation>?>
+        {
+            IsSuccess = true,
+            Data = [firstSalutation],
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                [ApiHeaderNames.TotalResults] = 3
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Salutation>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(firstPage));
+        var remaining = new List<Salutation> { NewSalutation(2), NewSalutation(3) };
+        ConnectionHandler
+            .FetchAll<Salutation>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(remaining));
+
+        var result = await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Salutation>(
+            1,
+            3,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result.Data, Has.Count.EqualTo(3));
+        Assert.That(result.Data, Is.EquivalentTo(new[] { firstSalutation, remaining[0], remaining[1] }));
+    }
+
+    /// <summary>
+    ///     When <c>autoPage</c> is requested but the response carries no
+    ///     <c>X-Total-Count</c> header, the service does not invoke <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
+    {
+        var response = new ApiResult<List<Salutation>?>
+        {
+            IsSuccess = true,
+            Data = [NewSalutation(1)],
+            ResponseHeaders = new Dictionary<string, int?>()
+        };
+        ConnectionHandler
+            .GetAsync<List<Salutation>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get(autoPage: true);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.DidNotReceive().FetchAll<Salutation>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once
+    ///     with the path <c>2.0/salutation/{id}</c> and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<Salutation?>
+        {
+            IsSuccess = true,
+            Data = NewSalutation(id)
+        };
+        ConnectionHandler
+            .GetAsync<Salutation?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<Salutation?>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Create forwards the create view to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />
+    ///     against the endpoint root (no id suffix).
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithEndpointRoot()
+    {
+        var payload = new SalutationCreate("Herr");
+        var expected = new ApiResult<Salutation> { IsSuccess = true, Data = NewSalutation(1) };
+        ConnectionHandler
+            .PostAsync<Salutation, SalutationCreate>(
+                Arg.Any<SalutationCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostAsync<Salutation, SalutationCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria list and optional pagination parameters to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> against
+    ///     the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsyncWithSearchPath()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Herr", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterSalutation(10, 0);
+        var expected = new ApiResult<List<Salutation>>
+        {
+            IsSuccess = true,
+            Data = [NewSalutation(1)]
+        };
+        ConnectionHandler
+            .PostSearchAsync<Salutation>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Search(criteria, queryParameter);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostSearchAsync<Salutation>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search without a query parameter passes <see langword="null" /> pagination to
+    ///     the connection handler and still targets the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_WithoutQueryParameter_PassesNullPagination()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Herr", Criteria = "=" }
+        };
+        ConnectionHandler
+            .PostSearchAsync<Salutation>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Salutation>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Salutation>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update forwards the update view to <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}" />
+    ///     against the per-id sub-path.
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsyncWithIdInPath()
+    {
+        const int id = 7;
+        var payload = new SalutationUpdate("Frau");
+        var expected = new ApiResult<Salutation> { IsSuccess = true, Data = NewSalutation(id) };
+        ConnectionHandler
+            .PutAsync<Salutation, SalutationUpdate>(
+                Arg.Any<SalutationUpdate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Update(id, payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PutAsync<Salutation, SalutationUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Delete forwards to <see cref="IBexioConnectionHandler.Delete" /> with the
+    ///     per-id path exactly once.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Delete(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     The cancellation token supplied by the caller must be forwarded to the
+    ///     connection handler on <c>Get</c> so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<Salutation>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Salutation>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Salutation>?>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+
+    private static Salutation NewSalutation(int id)
+    {
+        return new Salutation(id, $"Salutation {id}");
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/TitleServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/TitleServiceTests.cs
@@ -1,0 +1,360 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Enums.Api;
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Titles;
+using BexioApiNet.Abstractions.Models.MasterData.Titles.Views;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+///     Offline unit tests for <see cref="TitleService" />. Each test verifies that the service
+///     forwards its calls to <see cref="IBexioConnectionHandler" /> with the expected verb and path,
+///     propagates the response unchanged, and honours the canonical <c>autoPage</c> + <c>X-Total-Count</c>
+///     pagination contract. No network access.
+/// </summary>
+[TestFixture]
+public sealed class TitleServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="TitleService" /> bound to the
+    ///     <see cref="ServiceTestBase.ConnectionHandler" /> substitute for every test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new TitleService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "2.0/title";
+
+    private TitleService _sut = null!;
+
+    /// <summary>
+    ///     Get (no parameters) performs a single <c>GetAsync</c> against <c>2.0/title</c>
+    ///     with a null query parameter and never triggers <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithNoParams_CallsGetAsyncOnceWithExpectedPathAndNullQuery()
+    {
+        var expected = new ApiResult<List<Title>?> { IsSuccess = true, Data = [] };
+        ConnectionHandler
+            .GetAsync<List<Title>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Get();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<Title>?>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        await ConnectionHandler.DidNotReceive().FetchAll<Title>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterTitle" /> is supplied, its inner
+    ///     <see cref="QueryParameter" /> instance is forwarded to the connection
+    ///     handler verbatim.
+    /// </summary>
+    [Test]
+    public async Task Get_WithQueryParameter_PassesQueryParameterToConnectionHandler()
+    {
+        var queryParameter = new QueryParameterTitle(50, 100);
+        ConnectionHandler
+            .GetAsync<List<Title>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Title>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(queryParameter);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Title>?>(
+            ExpectedEndpoint,
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When <c>autoPage</c> is on and the first response advertises a
+    ///     <c>X-Total-Count</c> header, the service calls <c>FetchAll</c> with the
+    ///     count of already-fetched items, the total, the same path, and the
+    ///     same query parameter.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderPresent_CallsFetchAll()
+    {
+        var firstTitle = NewTitle(1);
+        var firstPage = new ApiResult<List<Title>?>
+        {
+            IsSuccess = true,
+            Data = [firstTitle],
+            ResponseHeaders = new Dictionary<string, int?>
+            {
+                [ApiHeaderNames.TotalResults] = 3
+            }
+        };
+        ConnectionHandler
+            .GetAsync<List<Title>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(firstPage));
+        var remaining = new List<Title> { NewTitle(2), NewTitle(3) };
+        ConnectionHandler
+            .FetchAll<Title>(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(remaining));
+
+        var result = await _sut.Get(autoPage: true);
+
+        await ConnectionHandler.Received(1).FetchAll<Title>(
+            1,
+            3,
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+        Assert.That(result.Data, Has.Count.EqualTo(3));
+        Assert.That(result.Data, Is.EquivalentTo(new[] { firstTitle, remaining[0], remaining[1] }));
+    }
+
+    /// <summary>
+    ///     When <c>autoPage</c> is requested but the response carries no
+    ///     <c>X-Total-Count</c> header, the service does not invoke <c>FetchAll</c>.
+    /// </summary>
+    [Test]
+    public async Task Get_WithAutoPage_WhenTotalResultsHeaderMissing_DoesNotCallFetchAll()
+    {
+        var response = new ApiResult<List<Title>?>
+        {
+            IsSuccess = true,
+            Data = [NewTitle(1)],
+            ResponseHeaders = new Dictionary<string, int?>()
+        };
+        ConnectionHandler
+            .GetAsync<List<Title>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(response));
+
+        var result = await _sut.Get(autoPage: true);
+
+        Assert.That(result, Is.SameAs(response));
+        await ConnectionHandler.DidNotReceive().FetchAll<Title>(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryParameter?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     GetById calls <see cref="IBexioConnectionHandler.GetAsync{TResult}" /> once
+    ///     with the path <c>2.0/title/{id}</c> and a null query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<Title?>
+        {
+            IsSuccess = true,
+            Data = NewTitle(id)
+        };
+        ConnectionHandler
+            .GetAsync<Title?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<Title?>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Create forwards the create view to <see cref="IBexioConnectionHandler.PostAsync{TResult,TCreate}" />
+    ///     against the endpoint root (no id suffix).
+    /// </summary>
+    [Test]
+    public async Task Create_CallsPostAsyncWithEndpointRoot()
+    {
+        var payload = new TitleCreate("Dr.");
+        var expected = new ApiResult<Title> { IsSuccess = true, Data = NewTitle(1) };
+        ConnectionHandler
+            .PostAsync<Title, TitleCreate>(
+                Arg.Any<TitleCreate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Create(payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostAsync<Title, TitleCreate>(
+            payload,
+            ExpectedEndpoint,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search forwards the criteria list and optional pagination parameters to
+    ///     <see cref="IBexioConnectionHandler.PostSearchAsync{TResult}" /> against
+    ///     the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_CallsPostSearchAsyncWithSearchPath()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Dr.", Criteria = "like" }
+        };
+        var queryParameter = new QueryParameterTitle(10, 0);
+        var expected = new ApiResult<List<Title>>
+        {
+            IsSuccess = true,
+            Data = [NewTitle(1)]
+        };
+        ConnectionHandler
+            .PostSearchAsync<Title>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Search(criteria, queryParameter);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PostSearchAsync<Title>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            queryParameter.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Search without a query parameter passes <see langword="null" /> pagination to
+    ///     the connection handler and still targets the <c>/search</c> sub-path.
+    /// </summary>
+    [Test]
+    public async Task Search_WithoutQueryParameter_PassesNullPagination()
+    {
+        var criteria = new List<SearchCriteria>
+        {
+            new() { Field = "name", Value = "Dr.", Criteria = "=" }
+        };
+        ConnectionHandler
+            .PostSearchAsync<Title>(
+                Arg.Any<List<SearchCriteria>>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryParameter?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Title>> { IsSuccess = true, Data = [] }));
+
+        await _sut.Search(criteria);
+
+        await ConnectionHandler.Received(1).PostSearchAsync<Title>(
+            criteria,
+            $"{ExpectedEndpoint}/search",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Update forwards the update view to <see cref="IBexioConnectionHandler.PutAsync{TResult,TUpdate}" />
+    ///     against the per-id sub-path (the Bexio Titles API uses PUT for full-replacement edits).
+    /// </summary>
+    [Test]
+    public async Task Update_CallsPutAsyncWithIdInPath()
+    {
+        const int id = 7;
+        var payload = new TitleUpdate("Prof.");
+        var expected = new ApiResult<Title> { IsSuccess = true, Data = NewTitle(id) };
+        ConnectionHandler
+            .PutAsync<Title, TitleUpdate>(
+                Arg.Any<TitleUpdate>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Update(id, payload);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).PutAsync<Title, TitleUpdate>(
+            payload,
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     Delete forwards to <see cref="IBexioConnectionHandler.Delete" /> with the
+    ///     per-id path exactly once.
+    /// </summary>
+    [Test]
+    public async Task Delete_CallsConnectionHandlerDeleteWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<object> { IsSuccess = true };
+        ConnectionHandler
+            .Delete(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.Delete(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).Delete(
+            $"{ExpectedEndpoint}/{id}",
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     The cancellation token supplied by the caller must be forwarded to the
+    ///     connection handler on <c>Get</c> so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task Get_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<Title>?>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<Title>?> { IsSuccess = true, Data = [] }));
+
+        await _sut.Get(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<Title>?>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+
+    private static Title NewTitle(int id)
+    {
+        return new Title(id, $"Title {id}");
+    }
+}

--- a/tests/BexioApiNet.UnitTests/MasterData/UserServiceTests.cs
+++ b/tests/BexioApiNet.UnitTests/MasterData/UserServiceTests.cs
@@ -1,0 +1,196 @@
+/*
+MIT License
+
+Copyright (c) 2022 Philip Näf <philip.naef@amanda-technology.ch>
+Copyright (c) 2022 Manuel Gysin <manuel.gysin@amanda-technology.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using BexioApiNet.Abstractions.Models.Api;
+using BexioApiNet.Abstractions.Models.MasterData.Users;
+using BexioApiNet.Models;
+using BexioApiNet.Services.Connectors.MasterData;
+
+namespace BexioApiNet.UnitTests.MasterData;
+
+/// <summary>
+///     Offline unit tests for <see cref="UserService" />. Each test asserts that the service forwards
+///     its calls to <see cref="IBexioConnectionHandler" /> with the expected verb, path and query
+///     parameter, and returns the handler's <see cref="ApiResult{T}" /> unchanged. Verifies that the
+///     singleton <c>GetMe</c> call hits <c>3.0/users/me</c> (no id segment). No network, no filesystem.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public sealed class UserServiceTests : ServiceTestBase
+{
+    /// <summary>
+    ///     Creates a fresh <see cref="UserService" /> bound to the <see cref="ServiceTestBase.ConnectionHandler" />
+    ///     substitute before each test.
+    /// </summary>
+    [SetUp]
+    public void CreateSut()
+    {
+        _sut = new UserService(ConnectionHandler);
+    }
+
+    private const string ExpectedEndpoint = "3.0/users";
+
+    private UserService _sut = null!;
+
+    private static User NewUser(int id = 1)
+    {
+        return new User(id, "male", "Rudolph", "Smith", "rudolph.smith@example.com", false, false);
+    }
+
+    /// <summary>
+    ///     <c>GetAll</c> with no query parameter must hit <c>3.0/users</c> exactly once with a
+    ///     <see langword="null" /> query parameter and return the connection handler's
+    ///     <see cref="ApiResult{T}" /> as-is.
+    /// </summary>
+    [Test]
+    public async Task GetAll_WithNoParams_CallsGetAsyncOnceWithExpectedPath()
+    {
+        var expected = new ApiResult<List<User>>
+        {
+            IsSuccess = true,
+            Data = [NewUser()]
+        };
+        ConnectionHandler
+            .GetAsync<List<User>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetAll();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<List<User>>(
+            ExpectedEndpoint,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     When a <see cref="QueryParameterUser" /> is supplied, the wrapped dictionary is forwarded to
+    ///     the connection handler so pagination reaches the API.
+    /// </summary>
+    [Test]
+    public async Task GetAll_WithQueryParameter_PassesQueryParameterToHandler()
+    {
+        var query = new QueryParameterUser(100, 50);
+        ConnectionHandler
+            .GetAsync<List<User>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<User>> { IsSuccess = true, Data = [] }));
+
+        await _sut.GetAll(query);
+
+        await ConnectionHandler.Received(1).GetAsync<List<User>>(
+            ExpectedEndpoint,
+            query.QueryParameter,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     The cancellation token supplied by the caller must be forwarded to the connection handler
+    ///     so cooperative cancellation flows end-to-end.
+    /// </summary>
+    [Test]
+    public async Task GetAll_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<List<User>>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<List<User>> { IsSuccess = true, Data = [] }));
+
+        await _sut.GetAll(cancellationToken: cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<List<User>>(
+            ExpectedEndpoint,
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    ///     <c>GetMe</c> must hit the singleton <c>3.0/users/me</c> route (no id segment) exactly once
+    ///     with a <see langword="null" /> query parameter.
+    /// </summary>
+    [Test]
+    public async Task GetMe_CallsGetAsyncWithMePath()
+    {
+        var expected = new ApiResult<User>
+        {
+            IsSuccess = true,
+            Data = NewUser()
+        };
+        ConnectionHandler
+            .GetAsync<User>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetMe();
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<User>(
+            $"{ExpectedEndpoint}/me",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    ///     <c>GetMe</c> forwards the supplied cancellation token to the connection handler.
+    /// </summary>
+    [Test]
+    public async Task GetMe_ForwardsCancellationTokenToConnectionHandler()
+    {
+        using var cts = new CancellationTokenSource();
+        ConnectionHandler
+            .GetAsync<User>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ApiResult<User> { IsSuccess = true }));
+
+        await _sut.GetMe(cts.Token);
+
+        await ConnectionHandler.Received(1).GetAsync<User>(
+            $"{ExpectedEndpoint}/me",
+            null,
+            cts.Token);
+    }
+
+    /// <summary>
+    ///     <c>GetById</c> must build the request path with the user id appended to the endpoint root.
+    /// </summary>
+    [Test]
+    public async Task GetById_CallsGetAsyncWithIdInPath()
+    {
+        const int id = 42;
+        var expected = new ApiResult<User>
+        {
+            IsSuccess = true,
+            Data = NewUser(id)
+        };
+        ConnectionHandler
+            .GetAsync<User>(Arg.Any<string>(), Arg.Any<QueryParameter?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await _sut.GetById(id);
+
+        Assert.That(result, Is.SameAs(expected));
+        await ConnectionHandler.Received(1).GetAsync<User>(
+            $"{ExpectedEndpoint}/{id}",
+            null,
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

Implements Wave 6 of the 100% API Coverage Roadmap (#22), adding 53 new endpoints across 14 services in two categories: Files & Documents and Master Data.

All 9 sub-issues were implemented in parallel by individual Docker agents, each individually verified (APPROVED), then merged into this integration branch. A final integration verification confirmed the full solution builds clean and all unit tests pass.

## Sub-Issues Completed

| # | Service(s) | Endpoints | API Version | Status |
|---|-----------|-----------|-------------|--------|
| #93 | FileService | 9 (Get, GetById, Download, Preview, Usage, Upload, Search, Patch, Delete) | v3.0 | ✅ Closed |
| #94 | DocumentSettingService, DocumentTemplateService | 2 (Get each) | v2.0 / v3.0 | ✅ Closed |
| #95 | CountryService | 6 (full CRUD + Search) | v2.0 | ✅ Closed |
| #96 | SalutationService | 6 (full CRUD + Search) | v2.0 | ✅ Closed |
| #97 | TitleService | 6 (full CRUD + Search) | v2.0 | ✅ Closed |
| #98 | LanguageService, CommunicationTypeService, CompanyProfileService, PermissionService | 8 (read-only lookups) | v2.0 / v3.0 | ✅ Closed |
| #99 | UserService, FictionalUserService | 8 (v3.0 user management) | v3.0 | ✅ Closed |
| #100 | NoteService | 6 (full CRUD + Search) | v2.0 | ✅ Closed |
| #101 | CommentService | 3 (polymorphic kb_document_type) | v2.0 | ✅ Closed |

**Total: 53 endpoints, 14 services**

## Key Implementation Notes

- **Binary downloads** — `FileService.Download` and `FileService.Preview` return `byte[]` via `ApiResult<byte[]>`
- **File upload** — `FileService.Upload` uses multipart/form-data
- **Polymorphic comments** — `CommentService` uses `{kb_document_type}/{document_id}` route pattern with a typed `KbDocumentType` enum
- **Read-only services** — Languages, CommunicationTypes, CompanyProfile, Permissions are GET-only with no mutation methods
- **WireMock.Net bump** — `2.2.0 → 2.4.0` (clears pre-existing NU1902 advisories in IntegrationTests)

## Verification

- Each sub-issue individually verified: **VERDICT: APPROVED** (9/9)
- Integration verification on merged branch: **VERDICT: APPROVED**
- `dotnet build /warnaserror`: ✅ clean (NU1902 pre-existing advisories on IntegrationTests are exempt)
- `dotnet test --filter TestCategory=Unit`: ✅ all green

## Test plan

- [ ] Review coordination files (`IBexioApiClient`, `BexioApiClient`, `BexioServiceCollection`) for all 14 new service registrations
- [ ] Spot-check a few unit test files (e.g. `FileServiceTests.cs`, `CountryServiceTests.cs`) for coverage quality
- [ ] Verify binary download and file upload patterns in `FileService`
- [ ] Confirm `CommentService` polymorphic route construction

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)